### PR TITLE
Suppress MSVC warning

### DIFF
--- a/include/boost/multiprecision/number.hpp
+++ b/include/boost/multiprecision/number.hpp
@@ -1735,7 +1735,7 @@ inline std::string read_string_while(std::istream& is, std::string const& permit
          else if(permitted_chars.find_first_of(std::istream::traits_type::to_char_type(c)) == std::string::npos)
          {
             // Invalid numeric character, stop reading:
-            is.rdbuf()->sputbackc(c);
+            is.rdbuf()->sputbackc(static_cast<char>(c));
             break;
          }
          else


### PR DESCRIPTION
warning C4244: 'argument': conversion from 'int' to 'char', possible loss of data

This causes the Boost.Units regression tests to fail on MSVC because of warnings-as-errors:
http://www.boost.org/development/tests/develop/developer/output/teeks99-08f-win2012R2-64on64-boost-bin-v2-libs-units-test-test_information_units-test-msvc-14-0-dbg-adrs-mdl-64-archt-x86-async-excpt-on-thrd-mlt.html