### PR TITLE
Remove use of deprecated macros; use replacements

### DIFF
--- a/example/float128_snips.cpp
+++ b/example/float128_snips.cpp
@@ -30,7 +30,7 @@ int main()
    // We can declare constants using GCC or Intel's native types, and the Q suffix,
    // these can be declared constexpr if required:
    /*<-*/
-#ifndef BOOST_NO_CONSTEXPR
+#ifndef BOOST_NO_CXX11_CONSTEXPR
    /*->*/
    constexpr float128 pi = 3.1415926535897932384626433832795028841971693993751058Q;
    /*<-*/

--- a/test/test_nothrow_cpp_bin_float.cpp
+++ b/test/test_nothrow_cpp_bin_float.cpp
@@ -11,7 +11,7 @@
 #include <boost/type_traits/has_nothrow_copy.hpp>
 #include <boost/static_assert.hpp>
 
-#ifndef BOOST_NO_NOEXCEPT
+#ifndef BOOST_NO_CXX11_NOEXCEPT
 
 #if !defined(BOOST_NO_CXX11_NOEXCEPT) && !defined(BOOST_NO_SFINAE_EXPR) || defined(BOOST_IS_NOTHROW_MOVE_CONSTRUCT)
 //

--- a/test/test_nothrow_cpp_dec_float.cpp
+++ b/test/test_nothrow_cpp_dec_float.cpp
@@ -11,7 +11,7 @@
 #include <boost/type_traits/has_nothrow_copy.hpp>
 #include <boost/static_assert.hpp>
 
-#ifndef BOOST_NO_NOEXCEPT
+#ifndef BOOST_NO_CXX11_NOEXCEPT
 
 #if !defined(BOOST_NO_CXX11_NOEXCEPT) && !defined(BOOST_NO_SFINAE_EXPR) || defined(BOOST_IS_NOTHROW_MOVE_CONSTRUCT)
 //

--- a/test/test_nothrow_cpp_int.cpp
+++ b/test/test_nothrow_cpp_int.cpp
@@ -11,7 +11,7 @@
 #include <boost/type_traits/has_nothrow_copy.hpp>
 #include <boost/static_assert.hpp>
 
-#ifndef BOOST_NO_NOEXCEPT
+#ifndef BOOST_NO_CXX11_NOEXCEPT
 
 #if !defined(BOOST_NO_CXX11_NOEXCEPT) && !defined(BOOST_NO_SFINAE_EXPR) || defined(BOOST_IS_NOTHROW_MOVE_CONSTRUCT)
 //

--- a/test/test_nothrow_cpp_rational.cpp
+++ b/test/test_nothrow_cpp_rational.cpp
@@ -21,7 +21,7 @@ typedef boost::multiprecision::number<boost::multiprecision::rational_adaptor<bo
 typedef boost::multiprecision::number<boost::multiprecision::rational_adaptor<boost::multiprecision::checked_int512_t::backend_type> > checked_rat512_t;
 typedef boost::multiprecision::number<boost::multiprecision::rational_adaptor<boost::multiprecision::checked_uint512_t::backend_type> > checked_urat512_t;
 
-#ifndef BOOST_NO_NOEXCEPT
+#ifndef BOOST_NO_CXX11_NOEXCEPT
 
 #if !defined(BOOST_NO_CXX11_NOEXCEPT) && !defined(BOOST_NO_SFINAE_EXPR) || defined(BOOST_IS_NOTHROW_MOVE_CONSTRUCT)
 //

--- a/test/test_nothrow_float128.cpp
+++ b/test/test_nothrow_float128.cpp
@@ -11,7 +11,7 @@
 #include <boost/type_traits/has_nothrow_copy.hpp>
 #include <boost/static_assert.hpp>
 
-#ifndef BOOST_NO_NOEXCEPT
+#ifndef BOOST_NO_CXX11_NOEXCEPT
 
 #if !defined(BOOST_NO_CXX11_NOEXCEPT) && !defined(BOOST_NO_SFINAE_EXPR) || defined(BOOST_IS_NOTHROW_MOVE_CONSTRUCT)
 //

--- a/test/test_nothrow_gmp.cpp
+++ b/test/test_nothrow_gmp.cpp
@@ -11,7 +11,7 @@
 #include <boost/type_traits/has_nothrow_copy.hpp>
 #include <boost/static_assert.hpp>
 
-#ifndef BOOST_NO_NOEXCEPT
+#ifndef BOOST_NO_CXX11_NOEXCEPT
 
 #if !defined(BOOST_NO_CXX11_NOEXCEPT) && !defined(BOOST_NO_SFINAE_EXPR) || defined(BOOST_IS_NOTHROW_MOVE_CONSTRUCT)
 //

--- a/test/test_nothrow_mpfr.cpp
+++ b/test/test_nothrow_mpfr.cpp
@@ -11,7 +11,7 @@
 #include <boost/type_traits/has_nothrow_copy.hpp>
 #include <boost/static_assert.hpp>
 
-#ifndef BOOST_NO_NOEXCEPT
+#ifndef BOOST_NO_CXX11_NOEXCEPT
 
 #if !defined(BOOST_NO_CXX11_NOEXCEPT) && !defined(BOOST_NO_SFINAE_EXPR) || defined(BOOST_IS_NOTHROW_MOVE_CONSTRUCT)
 //


### PR DESCRIPTION
Replace deprecated macro `BOOST_NO_CONSTEXPR` with `BOOST_NO_CXX11_CONSTEXPR` and `BOOST_NO_NOEXCEPT` with `BOOST_NO_CXX11_NOEXCEPT`.

These were deprecated in the 1.50 and 1.51 releases, and I'd like to remove them in the 1.60 release.

No functionality change.