### PR TITLE
Remove unmatched #pragma warning(push)

### DIFF
--- a/include/boost/multiprecision/cpp_int.hpp
+++ b/include/boost/multiprecision/cpp_int.hpp
@@ -32,13 +32,6 @@ namespace backends{
 
   using boost::enable_if;
 
-
-#ifdef BOOST_MSVC
-// warning C4127: conditional expression is constant
-#pragma warning(push)
-#pragma warning(disable:4127 4351 4293 4996 4307 4702 6285)
-#endif
-
 template <unsigned MinBits = 0, unsigned MaxBits = 0, boost::multiprecision::cpp_integer_type SignType = signed_magnitude, cpp_int_check_type Checked = unchecked, class Allocator = typename mpl::if_c<MinBits && (MinBits == MaxBits), void, std::allocator<limb_type> >::type >
 struct cpp_int_backend;
 


### PR DESCRIPTION
The `#pragma warning(push)` in **cpp_int.hpp** did not have a matching `#pragma warning(pop)` which was causing certain warnings to be disabled when including this header. On further investigation removing all disabled warnings entirely seemed to still generate no warnings when including the header so the whole `#ifdef BOOST_MSVC` block was removed. Tested with **Visual Studio 2015 Update 2** using the 64-bit compiler.

The mismatched header was found using the new optional warnings in **Visual Studio 2015 Update 1** C5031 and C5032. See https://msdn.microsoft.com/en-us/library/mt612856.aspx#BK_compiler for more information on those.