### PR TITLE
Fix for MSVC SmallerTypeCheck runtime error

### DIFF
--- a/include/boost/multiprecision/cpp_int/multiply.hpp
+++ b/include/boost/multiprecision/cpp_int/multiply.hpp
@@ -36,7 +36,7 @@ inline typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBit
    while(p != pe)
    {
       carry += static_cast<double_limb_type>(*pa) * static_cast<double_limb_type>(val);
-      *p = static_cast<limb_type>(carry);
+      *p = carry & ~static_cast<limb_type>(0);
       carry >>= cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::limb_bits;
       ++p, ++pa;
    }


### PR DESCRIPTION
The assignment of carry to p in eval_multiply generates a runtime error in non-optimized MSVC builds which have SmallerTypeCheck enabled. As carry is twice the size of p and the top bits are non-zero the check errors saying that some bits are being ignored. This is Microsoft's recommended fix of masking the unwanted bits when assigning to the smaller type.