### PR TITLE
[inspection report] Remove tabs and protect std::min from macro expansion

### DIFF
--- a/include/boost/multiprecision/cpp_int/bitwise.hpp
+++ b/include/boost/multiprecision/cpp_int/bitwise.hpp
@@ -326,7 +326,7 @@ inline void left_shift_byte(Int& result, double_limb_type s)
    if(rs != ors)
       pr[rs - 1] = 0u;
    std::size_t bytes = static_cast<std::size_t>(s / CHAR_BIT);
-   std::size_t len = std::min(ors * sizeof(limb_type), rs * sizeof(limb_type) - bytes);
+   std::size_t len = (std::min)(ors * sizeof(limb_type), rs * sizeof(limb_type) - bytes);
    if(bytes >= rs * sizeof(limb_type))
       result = static_cast<limb_type>(0u);
    else

--- a/include/boost/multiprecision/cpp_int/import_export.hpp
+++ b/include/boost/multiprecision/cpp_int/import_export.hpp
@@ -134,7 +134,7 @@ namespace boost {
             cpp_int_backend<MinBits, MaxBits, SignType, Checked, Allocator>& result = val.backend();
             result.resize(static_cast<unsigned>(limb_len), static_cast<unsigned>(limb_len));  // checked types may throw here if they're not large enough to hold the data!
             result.limbs()[result.size() - 1] = 0u;
-            std::memcpy(result.limbs(), i, std::min(byte_len, result.size() * sizeof(limb_type)));
+            std::memcpy(result.limbs(), i, (std::min)(byte_len, result.size() * sizeof(limb_type)));
             result.normalize(); // In case data has leading zeros.
             return val;
          }
@@ -150,7 +150,7 @@ namespace boost {
                ++limb_len;
             result.limbs()[0] = 0u;
             result.resize(static_cast<unsigned>(limb_len), static_cast<unsigned>(limb_len));  // checked types may throw here if they're not large enough to hold the data!
-            std::memcpy(result.limbs(), i, std::min(byte_len, result.size() * sizeof(result.limbs()[0])));
+            std::memcpy(result.limbs(), i, (std::min)(byte_len, result.size() * sizeof(result.limbs()[0])));
             result.normalize(); // In case data has leading zeros.
             return val;
          }

--- a/include/boost/multiprecision/number.hpp
+++ b/include/boost/multiprecision/number.hpp
@@ -1732,7 +1732,7 @@ inline std::string read_string_while(std::istream& is, std::string const& permit
 
       for(;; c = is.rdbuf()->snextc())
          if(std::istream::traits_type::eq_int_type(std::istream::traits_type::eof(), c))
-         {	// end of file:
+         { // end of file:
             state |= std::ios_base::eofbit;
             break;
          }
@@ -1743,7 +1743,7 @@ inline std::string read_string_while(std::istream& is, std::string const& permit
             break;
          }
          else
-         {	
+         {
             result.append(1, std::istream::traits_type::to_char_type(c));
          }
    }


### PR DESCRIPTION
The previous PR consists of multiple commits with bad commit messages (which was done using GitHub Web-interface editing). Thus, squashed and improved the commit log.