### PR TITLE
correct URL for libtommath

### DIFF
--- a/doc/html/boost_multiprecision/perf/overhead.html
+++ b/doc/html/boost_multiprecision/perf/overhead.html
@@ -180,7 +180,7 @@
       </p>
 <p>
         The test code was compiled with Microsoft Visual Studio 2010 with all optimisations
-        turned on (/Ox), and used MPIR-2.3.0 and <a href="http://libtom.org/?page=features&amp;newsitems=5&amp;whatfile=ltm" target="_top">libtommath</a>-0.42.0.
+        turned on (/Ox), and used MPIR-2.3.0 and <a href="http://libtom.net" target="_top">libtommath</a>-0.42.0.
         The tests were run on 32-bit Windows Vista machine.
       </p>
 </div>

--- a/doc/html/boost_multiprecision/tut/ints.html
+++ b/doc/html/boost_multiprecision/tut/ints.html
@@ -112,7 +112,7 @@
 <td>
                 <p>
                   Slower than <a href="http://gmplib.org" target="_top">GMP</a>, though
-                  typically not as slow as <a href="http://libtom.org/?page=features&amp;newsitems=5&amp;whatfile=ltm" target="_top">libtommath</a>
+                  typically not as slow as <a href="http://libtom.net" target="_top">libtommath</a>
                 </p>
               </td>
 </tr>
@@ -167,7 +167,7 @@
               </td>
 <td>
                 <p>
-                  <a href="http://libtom.org/?page=features&amp;newsitems=5&amp;whatfile=ltm" target="_top">libtommath</a>
+                  <a href="http://libtom.net" target="_top">libtommath</a>
                 </p>
               </td>
 <td>

--- a/doc/html/boost_multiprecision/tut/ints/tom_int.html
+++ b/doc/html/boost_multiprecision/tut/ints/tom_int.html
@@ -40,7 +40,7 @@
 <p>
           The <code class="computeroutput"><span class="identifier">tommath_int</span></code> back-end
           is used via the typedef <code class="computeroutput"><span class="identifier">boost</span><span class="special">::</span><span class="identifier">multiprecision</span><span class="special">::</span><span class="identifier">tom_int</span></code>.
-          It acts as a thin wrapper around the <a href="http://libtom.org/?page=features&amp;newsitems=5&amp;whatfile=ltm" target="_top">libtommath</a>
+          It acts as a thin wrapper around the <a href="http://libtom.net" target="_top">libtommath</a>
           <code class="computeroutput"><span class="identifier">tom_int</span></code> to provide an integer
           type that is a drop-in replacement for the native C++ integer types, but
           with unlimited precision.
@@ -50,7 +50,7 @@
         </p>
 <div class="itemizedlist"><ul class="itemizedlist" style="list-style-type: disc; ">
 <li class="listitem">
-              Default constructed objects have the value zero (this is <a href="http://libtom.org/?page=features&amp;newsitems=5&amp;whatfile=ltm" target="_top">libtommath</a>'s
+              Default constructed objects have the value zero (this is <a href="http://libtom.net" target="_top">libtommath</a>'s
               default behavior).
             </li>
 <li class="listitem">

--- a/doc/html/boost_multiprecision/tut/rational.html
+++ b/doc/html/boost_multiprecision/tut/rational.html
@@ -161,7 +161,7 @@
               </td>
 <td>
                 <p>
-                  <a href="http://libtom.org/?page=features&amp;newsitems=5&amp;whatfile=ltm" target="_top">libtommath</a>
+                  <a href="http://libtom.net" target="_top">libtommath</a>
                 </p>
               </td>
 <td>

--- a/doc/html/boost_multiprecision/tut/rational/tommath_rational.html
+++ b/doc/html/boost_multiprecision/tut/rational/tommath_rational.html
@@ -75,8 +75,8 @@
               number.
             </li>
 <li class="listitem">
-              No changes are made to <a href="http://libtom.org/?page=features&amp;newsitems=5&amp;whatfile=ltm" target="_top">libtommath</a>'s
-              global state, so this type can safely coexist with other <a href="http://libtom.org/?page=features&amp;newsitems=5&amp;whatfile=ltm" target="_top">libtommath</a>
+              No changes are made to <a href="http://libtom.net" target="_top">libtommath</a>'s
+              global state, so this type can safely coexist with other <a href="http://libtom.net" target="_top">libtommath</a>
               code.
             </li>
 <li class="listitem">

--- a/doc/multiprecision.qbk
+++ b/doc/multiprecision.qbk
@@ -47,7 +47,7 @@
 [template mpfr_class[] [@http://math.berkeley.edu/~wilken/code/gmpfrxx/ mpfr_class]]
 [template mpreal[] [@http://www.holoborodko.com/pavel/mpfr/ mpreal]]
 [template mpir[] [@http://mpir.org/ MPIR]]
-[template tommath[] [@http://libtom.org/?page=features&newsitems=5&whatfile=ltm libtommath]]
+[template tommath[] [@http://libtom.net libtommath]]
 [template quadmath[] [@http://gcc.gnu.org/onlinedocs/libquadmath/ libquadmath]]
 
 [template super[x]'''<superscript>'''[x]'''</superscript>''']


### PR DESCRIPTION
libtom.org is not associated with libtommath anymore, see https://github.com/libtom/libtomcrypt/issues/138