### PR TITLE
Fix compile error

### DIFF
--- a/include/boost/multiprecision/detail/bitscan.hpp
+++ b/include/boost/multiprecision/detail/bitscan.hpp
@@ -9,6 +9,7 @@
 #define BOOST_MP_DETAIL_BITSCAN_HPP
 
 #include <boost/detail/endian.hpp>
+#include <boost/cstdint.hpp>
 
 #if (defined(BOOST_MSVC) || (defined(__clang__) && defined(__c2__)) || (defined(BOOST_INTEL) && defined(_MSC_VER))) && (defined(_M_IX86) || defined(_M_X64))
 #include <intrin.h>


### PR DESCRIPTION
../multiprecision/include/boost/multiprecision/detail/bitscan.hpp:151:28: fatal error: no type named 'uint64_t' in namespace 'boost';