### PR TITLE
Remove warning on shifting negative value.

### DIFF
--- a/test/test_arithmetic.hpp
+++ b/test/test_arithmetic.hpp
@@ -363,6 +363,17 @@ void test_signed_integer_ops(const boost::mpl::true_&)
       BOOST_CHECK_THROW(a >>= 2, std::range_error);
 #endif
    }
+   else
+   {
+      a = -1;
+      BOOST_CHECK_EQUAL(a << 10, -1024);
+      a = -23;
+      BOOST_CHECK_EQUAL(a << 10, -23552);
+      a = -23456;
+      BOOST_CHECK_EQUAL(a >> 10, -23);
+      a = -3;
+      BOOST_CHECK_EQUAL(a >> 10, -1);
+   }
 #endif
 }
 template <class Real>

--- a/test/test_arithmetic.hpp
+++ b/test/test_arithmetic.hpp
@@ -363,17 +363,6 @@ void test_signed_integer_ops(const boost::mpl::true_&)
       BOOST_CHECK_THROW(a >>= 2, std::range_error);
 #endif
    }
-   else
-   {
-      a = -1;
-      BOOST_CHECK_EQUAL(a << 10, (boost::intmax_t(-1) << 10));
-      a = -23;
-      BOOST_CHECK_EQUAL(a << 10, (boost::intmax_t(-23) << 10));
-      a = -23456;
-      BOOST_CHECK_EQUAL(a >> 10, (boost::intmax_t(-23456) >> 10));
-      a = -3;
-      BOOST_CHECK_EQUAL(a >> 10, (boost::intmax_t(-3) >> 10));
-   }
 #endif
 }
 template <class Real>


### PR DESCRIPTION
Using `b2 --toolset=clang --compiler=g++`, I received a pile of warnings of the form:

```
In file included from test_arithmetic_cpp_bin_float_3.cpp:8:
../../../libs/multiprecision/test/test_arithmetic.hpp:371:56: warning: shifting a negative signed value is undefined [-Wshift-negative-value]
      BOOST_CHECK_EQUAL(a << 10, (boost::intmax_t(-23) << 10));
```

This removes the test of shifted negative values, which might not be the correct action.
