### PR TITLE
Apply "Assignment Preserves Precision of Source".

### DIFF
--- a/include/boost/multiprecision/detail/default_ops.hpp
+++ b/include/boost/multiprecision/detail/default_ops.hpp
@@ -1985,7 +1985,9 @@ inline typename scalar_result_from_possible_complex<multiprecision::number<Backe
    real(const multiprecision::number<Backend, ExpressionTemplates>& a)
 {
    using default_ops::eval_real;
-   typename scalar_result_from_possible_complex<multiprecision::number<Backend, ExpressionTemplates> >::type result;
+   typedef typename scalar_result_from_possible_complex<multiprecision::number<Backend, ExpressionTemplates> >::type result_type;
+   boost::multiprecision::detail::scoped_default_precision<result_type> precision_guard(a);
+   result_type result;
    eval_real(result.backend(), a.backend());
    return result;
 }
@@ -1994,7 +1996,9 @@ inline typename scalar_result_from_possible_complex<multiprecision::number<Backe
    imag(const multiprecision::number<Backend, ExpressionTemplates>& a)
 {
    using default_ops::eval_imag;
-   typename scalar_result_from_possible_complex<multiprecision::number<Backend, ExpressionTemplates> >::type result;
+   typedef typename scalar_result_from_possible_complex<multiprecision::number<Backend, ExpressionTemplates> >::type result_type;
+   boost::multiprecision::detail::scoped_default_precision<result_type> precision_guard(a);
+   result_type result;
    eval_imag(result.backend(), a.backend());
    return result;
 }
@@ -2004,6 +2008,7 @@ inline typename scalar_result_from_possible_complex<typename multiprecision::det
    real(const multiprecision::detail::expression<tag, A1, A2, A3, A4>& arg)
 {
    typedef typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type value_type;
+   detail::scoped_default_precision<value_type> precision_guard(arg);
    return real(value_type(arg));
 }
 
@@ -2012,6 +2017,7 @@ inline typename scalar_result_from_possible_complex<typename multiprecision::det
    imag(const multiprecision::detail::expression<tag, A1, A2, A3, A4>& arg)
 {
    typedef typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type value_type;
+   detail::scoped_default_precision<value_type> precision_guard(arg);
    return imag(value_type(arg));
 }
 
@@ -2173,6 +2179,7 @@ namespace multiprecision{
    inline typename boost::enable_if_c<number_category<Backend>::value != number_kind_complex, multiprecision::number<Backend, ExpressionTemplates> >::type 
       asinh BOOST_PREVENT_MACRO_SUBSTITUTION(const multiprecision::number<Backend, ExpressionTemplates>& arg)
    {
+      detail::scoped_default_precision<multiprecision::number<Backend, ExpressionTemplates> > precision_guard(arg);
       return boost::math::asinh(arg, c99_error_policy());
    }
    template <class tag, class A1, class A2, class A3, class A4>
@@ -2180,12 +2187,14 @@ namespace multiprecision{
          asinh BOOST_PREVENT_MACRO_SUBSTITUTION(const multiprecision::detail::expression<tag, A1, A2, A3, A4>& arg)
    {
       typedef typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type value_type;
+      detail::scoped_default_precision<value_type > precision_guard(arg);
       return asinh(value_type(arg));
    }
    template <class Backend, multiprecision::expression_template_option ExpressionTemplates>
    inline typename boost::enable_if_c<number_category<Backend>::value != number_kind_complex, multiprecision::number<Backend, ExpressionTemplates> >::type
       acosh BOOST_PREVENT_MACRO_SUBSTITUTION(const multiprecision::number<Backend, ExpressionTemplates>& arg)
    {
+      detail::scoped_default_precision<multiprecision::number<Backend, ExpressionTemplates> > precision_guard(arg);
       return boost::math::acosh(arg, c99_error_policy());
    }
    template <class tag, class A1, class A2, class A3, class A4>
@@ -2193,12 +2202,14 @@ namespace multiprecision{
       acosh BOOST_PREVENT_MACRO_SUBSTITUTION(const multiprecision::detail::expression<tag, A1, A2, A3, A4>& arg)
    {
       typedef typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type value_type;
+      detail::scoped_default_precision<value_type > precision_guard(arg);
       return acosh(value_type(arg));
    }
    template <class Backend, multiprecision::expression_template_option ExpressionTemplates>
    inline typename boost::enable_if_c<number_category<Backend>::value != number_kind_complex, multiprecision::number<Backend, ExpressionTemplates> >::type
       atanh BOOST_PREVENT_MACRO_SUBSTITUTION(const multiprecision::number<Backend, ExpressionTemplates>& arg)
    {
+      detail::scoped_default_precision<multiprecision::number<Backend, ExpressionTemplates> > precision_guard(arg);
       return boost::math::atanh(arg, c99_error_policy());
    }
    template <class tag, class A1, class A2, class A3, class A4>
@@ -2206,55 +2217,65 @@ namespace multiprecision{
       atanh BOOST_PREVENT_MACRO_SUBSTITUTION(const multiprecision::detail::expression<tag, A1, A2, A3, A4>& arg)
    {
       typedef typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type value_type;
+      detail::scoped_default_precision<value_type > precision_guard(arg);
       return atanh(value_type(arg));
    }
    template <class Backend, multiprecision::expression_template_option ExpressionTemplates>
    inline multiprecision::number<Backend, ExpressionTemplates> cbrt BOOST_PREVENT_MACRO_SUBSTITUTION(const multiprecision::number<Backend, ExpressionTemplates>& arg)
    {
+      detail::scoped_default_precision<multiprecision::number<Backend, ExpressionTemplates> > precision_guard(arg);
       return boost::math::cbrt(arg, c99_error_policy());
    }
    template <class tag, class A1, class A2, class A3, class A4>
    inline typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type cbrt BOOST_PREVENT_MACRO_SUBSTITUTION(const multiprecision::detail::expression<tag, A1, A2, A3, A4>& arg)
    {
       typedef typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type value_type;
+      detail::scoped_default_precision<value_type> precision_guard(arg);
       return cbrt(value_type(arg));
    }
    template <class Backend, multiprecision::expression_template_option ExpressionTemplates>
    inline multiprecision::number<Backend, ExpressionTemplates> erf BOOST_PREVENT_MACRO_SUBSTITUTION(const multiprecision::number<Backend, ExpressionTemplates>& arg)
    {
+      detail::scoped_default_precision<multiprecision::number<Backend, ExpressionTemplates> > precision_guard(arg);
       return boost::math::erf(arg, c99_error_policy());
    }
    template <class tag, class A1, class A2, class A3, class A4>
    inline typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type erf BOOST_PREVENT_MACRO_SUBSTITUTION(const multiprecision::detail::expression<tag, A1, A2, A3, A4>& arg)
    {
       typedef typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type value_type;
+      detail::scoped_default_precision<value_type> precision_guard(arg);
       return erf(value_type(arg));
    }
    template <class Backend, multiprecision::expression_template_option ExpressionTemplates>
    inline multiprecision::number<Backend, ExpressionTemplates> erfc BOOST_PREVENT_MACRO_SUBSTITUTION(const multiprecision::number<Backend, ExpressionTemplates>& arg)
    {
+      detail::scoped_default_precision<multiprecision::number<Backend, ExpressionTemplates> > precision_guard(arg);
       return boost::math::erfc(arg, c99_error_policy());
    }
    template <class tag, class A1, class A2, class A3, class A4>
    inline typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type erfc BOOST_PREVENT_MACRO_SUBSTITUTION(const multiprecision::detail::expression<tag, A1, A2, A3, A4>& arg)
    {
       typedef typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type value_type;
+      detail::scoped_default_precision<value_type> precision_guard(arg);
       return erfc(value_type(arg));
    }
    template <class Backend, multiprecision::expression_template_option ExpressionTemplates>
    inline multiprecision::number<Backend, ExpressionTemplates> expm1 BOOST_PREVENT_MACRO_SUBSTITUTION(const multiprecision::number<Backend, ExpressionTemplates>& arg)
    {
+      detail::scoped_default_precision<multiprecision::number<Backend, ExpressionTemplates> > precision_guard(arg);
       return boost::math::expm1(arg, c99_error_policy());
    }
    template <class tag, class A1, class A2, class A3, class A4>
    inline typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type expm1 BOOST_PREVENT_MACRO_SUBSTITUTION(const multiprecision::detail::expression<tag, A1, A2, A3, A4>& arg)
    {
       typedef typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type value_type;
+      detail::scoped_default_precision<value_type> precision_guard(arg);
       return expm1(value_type(arg));
    }
    template <class Backend, multiprecision::expression_template_option ExpressionTemplates>
    inline multiprecision::number<Backend, ExpressionTemplates> lgamma BOOST_PREVENT_MACRO_SUBSTITUTION(const multiprecision::number<Backend, ExpressionTemplates>& arg)
    {
+      detail::scoped_default_precision<multiprecision::number<Backend, ExpressionTemplates> > precision_guard(arg);
       multiprecision::number<Backend, ExpressionTemplates> result;
       result = boost::math::lgamma(arg, c99_error_policy());
       if((boost::multiprecision::isnan)(result) && !(boost::multiprecision::isnan)(arg))
@@ -2268,11 +2289,13 @@ namespace multiprecision{
    inline typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type lgamma BOOST_PREVENT_MACRO_SUBSTITUTION(const multiprecision::detail::expression<tag, A1, A2, A3, A4>& arg)
    {
       typedef typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type value_type;
+      detail::scoped_default_precision<value_type> precision_guard(arg);
       return lgamma(value_type(arg));
    }
    template <class Backend, multiprecision::expression_template_option ExpressionTemplates>
    inline multiprecision::number<Backend, ExpressionTemplates> tgamma BOOST_PREVENT_MACRO_SUBSTITUTION(const multiprecision::number<Backend, ExpressionTemplates>& arg)
    {
+      detail::scoped_default_precision<multiprecision::number<Backend, ExpressionTemplates> > precision_guard(arg);
       if((arg == 0) && std::numeric_limits<multiprecision::number<Backend, ExpressionTemplates> >::has_infinity)
       {
          errno = ERANGE;
@@ -2284,6 +2307,7 @@ namespace multiprecision{
    inline typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type tgamma BOOST_PREVENT_MACRO_SUBSTITUTION(const multiprecision::detail::expression<tag, A1, A2, A3, A4>& arg)
    {
       typedef typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type value_type;
+      detail::scoped_default_precision<value_type> precision_guard(arg);
       return tgamma(value_type(arg));
    }
 
@@ -2312,55 +2336,65 @@ namespace multiprecision{
    template <class Backend, multiprecision::expression_template_option ExpressionTemplates>
    inline multiprecision::number<Backend, ExpressionTemplates> log1p BOOST_PREVENT_MACRO_SUBSTITUTION(const multiprecision::number<Backend, ExpressionTemplates>& arg)
    {
+      detail::scoped_default_precision<multiprecision::number<Backend, ExpressionTemplates> > precision_guard(arg);
       return boost::math::log1p(arg, c99_error_policy());
    }
    template <class tag, class A1, class A2, class A3, class A4>
    inline typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type log1p BOOST_PREVENT_MACRO_SUBSTITUTION(const multiprecision::detail::expression<tag, A1, A2, A3, A4>& arg)
    {
       typedef typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type value_type;
+      detail::scoped_default_precision<value_type> precision_guard(arg);
       return log1p(value_type(arg));
    }
 
    template <class Backend, multiprecision::expression_template_option ExpressionTemplates>
    inline multiprecision::number<Backend, ExpressionTemplates> nextafter BOOST_PREVENT_MACRO_SUBSTITUTION(const multiprecision::number<Backend, ExpressionTemplates>& a, const multiprecision::number<Backend, ExpressionTemplates>& b)
    {
+      detail::scoped_default_precision<multiprecision::number<Backend, ExpressionTemplates> > precision_guard(a, b);
       return boost::math::nextafter(a, b, c99_error_policy());
    }
    template <class Backend, multiprecision::expression_template_option ExpressionTemplates, class tag, class A1, class A2, class A3, class A4>
    inline multiprecision::number<Backend, ExpressionTemplates> nextafter BOOST_PREVENT_MACRO_SUBSTITUTION(const multiprecision::number<Backend, ExpressionTemplates>& a, const multiprecision::detail::expression<tag, A1, A2, A3, A4>& b)
    {
+      detail::scoped_default_precision<multiprecision::number<Backend, ExpressionTemplates> > precision_guard(a, b);
       return nextafter BOOST_PREVENT_MACRO_SUBSTITUTION(a, multiprecision::number<Backend, ExpressionTemplates>(b));
    }
    template <class tag, class A1, class A2, class A3, class A4, class Backend, multiprecision::expression_template_option ExpressionTemplates>
    inline multiprecision::number<Backend, ExpressionTemplates> nextafter BOOST_PREVENT_MACRO_SUBSTITUTION(const multiprecision::detail::expression<tag, A1, A2, A3, A4>& a, const multiprecision::number<Backend, ExpressionTemplates>& b)
    {
+      detail::scoped_default_precision<multiprecision::number<Backend, ExpressionTemplates> > precision_guard(a, b);
       return nextafter BOOST_PREVENT_MACRO_SUBSTITUTION(multiprecision::number<Backend, ExpressionTemplates>(a), b);
    }
    template <class tag, class A1, class A2, class A3, class A4, class tagb, class A1b, class A2b, class A3b, class A4b>
    inline typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type nextafter BOOST_PREVENT_MACRO_SUBSTITUTION(const multiprecision::detail::expression<tag, A1, A2, A3, A4>& a, const multiprecision::detail::expression<tagb, A1b, A2b, A3b, A4b>& b)
    {
       typedef typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type value_type;
+      detail::scoped_default_precision<value_type> precision_guard(a, b);
       return nextafter BOOST_PREVENT_MACRO_SUBSTITUTION(value_type(a), value_type(b));
    }
    template <class Backend, multiprecision::expression_template_option ExpressionTemplates>
    inline multiprecision::number<Backend, ExpressionTemplates> nexttoward BOOST_PREVENT_MACRO_SUBSTITUTION(const multiprecision::number<Backend, ExpressionTemplates>& a, const multiprecision::number<Backend, ExpressionTemplates>& b)
    {
+      detail::scoped_default_precision<multiprecision::number<Backend, ExpressionTemplates> > precision_guard(a, b);
       return boost::math::nextafter(a, b, c99_error_policy());
    }
    template <class Backend, multiprecision::expression_template_option ExpressionTemplates, class tag, class A1, class A2, class A3, class A4>
    inline multiprecision::number<Backend, ExpressionTemplates> nexttoward BOOST_PREVENT_MACRO_SUBSTITUTION(const multiprecision::number<Backend, ExpressionTemplates>& a, const multiprecision::detail::expression<tag, A1, A2, A3, A4>& b)
    {
+      detail::scoped_default_precision<multiprecision::number<Backend, ExpressionTemplates> > precision_guard(a, b);
       return nexttoward BOOST_PREVENT_MACRO_SUBSTITUTION(a, multiprecision::number<Backend, ExpressionTemplates>(b));
    }
    template <class tag, class A1, class A2, class A3, class A4, class Backend, multiprecision::expression_template_option ExpressionTemplates>
    inline multiprecision::number<Backend, ExpressionTemplates> nexttoward BOOST_PREVENT_MACRO_SUBSTITUTION(const multiprecision::detail::expression<tag, A1, A2, A3, A4>& a, const multiprecision::number<Backend, ExpressionTemplates>& b)
    {
+      detail::scoped_default_precision<multiprecision::number<Backend, ExpressionTemplates> > precision_guard(a, b);
       return nexttoward BOOST_PREVENT_MACRO_SUBSTITUTION(multiprecision::number<Backend, ExpressionTemplates>(a), b);
    }
    template <class tag, class A1, class A2, class A3, class A4, class tagb, class A1b, class A2b, class A3b, class A4b>
    inline typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type nexttoward BOOST_PREVENT_MACRO_SUBSTITUTION(const multiprecision::detail::expression<tag, A1, A2, A3, A4>& a, const multiprecision::detail::expression<tagb, A1b, A2b, A3b, A4b>& b)
    {
       typedef typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type value_type;
+      detail::scoped_default_precision<value_type> precision_guard(a, b);
       return nexttoward BOOST_PREVENT_MACRO_SUBSTITUTION(value_type(a), value_type(b));
    }
 
@@ -2435,6 +2469,7 @@ template <class Backend, expression_template_option ExpressionTemplates, class P
 inline number<Backend, ExpressionTemplates> trunc(const number<Backend, ExpressionTemplates>& v, const Policy&)
 {
    using default_ops::eval_trunc;
+   detail::scoped_default_precision<multiprecision::number<Backend, ExpressionTemplates> > precision_guard(v);
    number<Backend, ExpressionTemplates> result;
    eval_trunc(result.backend(), v.backend());
    return BOOST_MP_MOVE(result);
@@ -2444,7 +2479,7 @@ template <class tag, class A1, class A2, class A3, class A4, class Policy>
 inline int itrunc(const detail::expression<tag, A1, A2, A3, A4>& v, const Policy& pol)
 {
    typedef typename detail::expression<tag, A1, A2, A3, A4>::result_type number_type;
-   number_type r = trunc(v, pol);
+   number_type r(trunc(v, pol));
    if((r > (std::numeric_limits<int>::max)()) || r < (std::numeric_limits<int>::min)() || !(boost::math::isfinite)(v))
       return boost::math::policies::raise_rounding_error("boost::multiprecision::itrunc<%1%>(%1%)", 0, number_type(v), 0, pol);
    return r.template convert_to<int>();
@@ -2457,7 +2492,7 @@ inline int itrunc(const detail::expression<tag, A1, A2, A3, A4>& v)
 template <class Backend, expression_template_option ExpressionTemplates, class Policy>
 inline int itrunc(const number<Backend, ExpressionTemplates>& v, const Policy& pol)
 {
-   number<Backend, ExpressionTemplates> r = trunc(v, pol);
+   number<Backend, ExpressionTemplates> r(trunc(v, pol));
    if((r > (std::numeric_limits<int>::max)()) || r < (std::numeric_limits<int>::min)() || !(boost::math::isfinite)(v))
       return boost::math::policies::raise_rounding_error("boost::multiprecision::itrunc<%1%>(%1%)", 0, v, 0, pol);
    return r.template convert_to<int>();
@@ -2471,7 +2506,7 @@ template <class tag, class A1, class A2, class A3, class A4, class Policy>
 inline long ltrunc(const detail::expression<tag, A1, A2, A3, A4>& v, const Policy& pol)
 {
    typedef typename detail::expression<tag, A1, A2, A3, A4>::result_type number_type;
-   number_type r = trunc(v, pol);
+   number_type r(trunc(v, pol));
    if((r > (std::numeric_limits<long>::max)()) || r < (std::numeric_limits<long>::min)() || !(boost::math::isfinite)(v))
       return boost::math::policies::raise_rounding_error("boost::multiprecision::ltrunc<%1%>(%1%)", 0, number_type(v), 0L, pol);
    return r.template convert_to<long>();
@@ -2484,7 +2519,7 @@ inline long ltrunc(const detail::expression<tag, A1, A2, A3, A4>& v)
 template <class T, expression_template_option ExpressionTemplates, class Policy>
 inline long ltrunc(const number<T, ExpressionTemplates>& v, const Policy& pol)
 {
-   number<T, ExpressionTemplates> r = trunc(v, pol);
+   number<T, ExpressionTemplates> r(trunc(v, pol));
    if((r > (std::numeric_limits<long>::max)()) || r < (std::numeric_limits<long>::min)() || !(boost::math::isfinite)(v))
       return boost::math::policies::raise_rounding_error("boost::multiprecision::ltrunc<%1%>(%1%)", 0, v, 0L, pol);
    return r.template convert_to<long>();
@@ -2499,7 +2534,7 @@ template <class tag, class A1, class A2, class A3, class A4, class Policy>
 inline boost::long_long_type lltrunc(const detail::expression<tag, A1, A2, A3, A4>& v, const Policy& pol)
 {
    typedef typename detail::expression<tag, A1, A2, A3, A4>::result_type number_type;
-   number_type r = trunc(v, pol);
+   number_type r(trunc(v, pol));
    if((r > (std::numeric_limits<boost::long_long_type>::max)()) || r < (std::numeric_limits<boost::long_long_type>::min)() || !(boost::math::isfinite)(v))
       return boost::math::policies::raise_rounding_error("boost::multiprecision::lltrunc<%1%>(%1%)", 0, number_type(v), 0LL, pol);
    return r.template convert_to<boost::long_long_type>();
@@ -2512,7 +2547,7 @@ inline boost::long_long_type lltrunc(const detail::expression<tag, A1, A2, A3, A
 template <class T, expression_template_option ExpressionTemplates, class Policy>
 inline boost::long_long_type lltrunc(const number<T, ExpressionTemplates>& v, const Policy& pol)
 {
-   number<T, ExpressionTemplates> r = trunc(v, pol);
+   number<T, ExpressionTemplates> r(trunc(v, pol));
    if((r > (std::numeric_limits<boost::long_long_type>::max)()) || r < (std::numeric_limits<boost::long_long_type>::min)() || !(boost::math::isfinite)(v))
       return boost::math::policies::raise_rounding_error("boost::multiprecision::lltrunc<%1%>(%1%)", 0, v, 0LL, pol);
    return r.template convert_to<boost::long_long_type>();
@@ -2533,6 +2568,7 @@ template <class T, expression_template_option ExpressionTemplates, class Policy>
 inline number<T, ExpressionTemplates> round(const number<T, ExpressionTemplates>& v, const Policy&)
 {
    using default_ops::eval_round;
+   detail::scoped_default_precision<multiprecision::number<T, ExpressionTemplates> > precision_guard(v);
    number<T, ExpressionTemplates> result;
    eval_round(result.backend(), v.backend());
    return BOOST_MP_MOVE(result);
@@ -2542,7 +2578,7 @@ template <class tag, class A1, class A2, class A3, class A4, class Policy>
 inline int iround(const detail::expression<tag, A1, A2, A3, A4>& v, const Policy& pol)
 {
    typedef typename detail::expression<tag, A1, A2, A3, A4>::result_type number_type;
-   number_type r = round(v, pol);
+   number_type r(round(v, pol));
    if((r > (std::numeric_limits<int>::max)()) || r < (std::numeric_limits<int>::min)() || !(boost::math::isfinite)(v))
       return boost::math::policies::raise_rounding_error("boost::multiprecision::iround<%1%>(%1%)", 0, number_type(v), 0, pol);
    return r.template convert_to<int>();
@@ -2555,7 +2591,7 @@ inline int iround(const detail::expression<tag, A1, A2, A3, A4>& v)
 template <class T, expression_template_option ExpressionTemplates, class Policy>
 inline int iround(const number<T, ExpressionTemplates>& v, const Policy& pol)
 {
-   number<T, ExpressionTemplates> r = round(v, pol);
+   number<T, ExpressionTemplates> r(round(v, pol));
    if((r > (std::numeric_limits<int>::max)()) || r < (std::numeric_limits<int>::min)() || !(boost::math::isfinite)(v))
       return boost::math::policies::raise_rounding_error("boost::multiprecision::iround<%1%>(%1%)", 0, v, 0, pol);
    return r.template convert_to<int>();
@@ -2569,7 +2605,7 @@ template <class tag, class A1, class A2, class A3, class A4, class Policy>
 inline long lround(const detail::expression<tag, A1, A2, A3, A4>& v, const Policy& pol)
 {
    typedef typename detail::expression<tag, A1, A2, A3, A4>::result_type number_type;
-   number_type r = round(v, pol);
+   number_type r(round(v, pol));
    if((r > (std::numeric_limits<long>::max)()) || r < (std::numeric_limits<long>::min)() || !(boost::math::isfinite)(v))
       return boost::math::policies::raise_rounding_error("boost::multiprecision::lround<%1%>(%1%)", 0, number_type(v), 0L, pol);
    return r.template convert_to<long>();
@@ -2582,7 +2618,7 @@ inline long lround(const detail::expression<tag, A1, A2, A3, A4>& v)
 template <class T, expression_template_option ExpressionTemplates, class Policy>
 inline long lround(const number<T, ExpressionTemplates>& v, const Policy& pol)
 {
-   number<T, ExpressionTemplates> r = round(v, pol);
+   number<T, ExpressionTemplates> r(round(v, pol));
    if((r > (std::numeric_limits<long>::max)()) || r < (std::numeric_limits<long>::min)() || !(boost::math::isfinite)(v))
       return boost::math::policies::raise_rounding_error("boost::multiprecision::lround<%1%>(%1%)", 0, v, 0L, pol);
    return r.template convert_to<long>();
@@ -2597,7 +2633,7 @@ template <class tag, class A1, class A2, class A3, class A4, class Policy>
 inline boost::long_long_type llround(const detail::expression<tag, A1, A2, A3, A4>& v, const Policy& pol)
 {
    typedef typename detail::expression<tag, A1, A2, A3, A4>::result_type number_type;
-   number_type r = round(v, pol);
+   number_type r(round(v, pol));
    if((r > (std::numeric_limits<boost::long_long_type>::max)()) || r < (std::numeric_limits<boost::long_long_type>::min)() || !(boost::math::isfinite)(v))
       return boost::math::policies::raise_rounding_error("boost::multiprecision::iround<%1%>(%1%)", 0, number_type(v), 0LL, pol);
    return r.template convert_to<boost::long_long_type>();
@@ -2610,7 +2646,7 @@ inline boost::long_long_type llround(const detail::expression<tag, A1, A2, A3, A
 template <class T, expression_template_option ExpressionTemplates, class Policy>
 inline boost::long_long_type llround(const number<T, ExpressionTemplates>& v, const Policy& pol)
 {
-   number<T, ExpressionTemplates> r = round(v, pol);
+   number<T, ExpressionTemplates> r(round(v, pol));
    if((r > (std::numeric_limits<boost::long_long_type>::max)()) || r < (std::numeric_limits<boost::long_long_type>::min)() || !(boost::math::isfinite)(v))
       return boost::math::policies::raise_rounding_error("boost::multiprecision::iround<%1%>(%1%)", 0, v, 0LL, pol);
    return r.template convert_to<boost::long_long_type>();
@@ -2630,6 +2666,7 @@ template <class T, expression_template_option ExpressionTemplates>
 inline typename enable_if_c<number_category<T>::value == number_kind_floating_point, number<T, ExpressionTemplates> >::type frexp(const number<T, ExpressionTemplates>& v, short* pint)
 {
    using default_ops::eval_frexp;
+   detail::scoped_default_precision<multiprecision::number<T, ExpressionTemplates> > precision_guard(v);
    number<T, ExpressionTemplates> result;
    eval_frexp(result.backend(), v.backend(), pint);
    return BOOST_MP_MOVE(result);
@@ -2645,6 +2682,7 @@ template <class T, expression_template_option ExpressionTemplates>
 inline typename enable_if_c<number_category<T>::value == number_kind_floating_point, number<T, ExpressionTemplates> >::type frexp(const number<T, ExpressionTemplates>& v, int* pint)
 {
    using default_ops::eval_frexp;
+   detail::scoped_default_precision<multiprecision::number<T, ExpressionTemplates> > precision_guard(v);
    number<T, ExpressionTemplates> result;
    eval_frexp(result.backend(), v.backend(), pint);
    return BOOST_MP_MOVE(result);
@@ -2660,6 +2698,7 @@ template <class T, expression_template_option ExpressionTemplates>
 inline typename enable_if_c<number_category<T>::value == number_kind_floating_point, number<T, ExpressionTemplates> >::type frexp(const number<T, ExpressionTemplates>& v, long* pint)
 {
    using default_ops::eval_frexp;
+   detail::scoped_default_precision<multiprecision::number<T, ExpressionTemplates> > precision_guard(v);
    number<T, ExpressionTemplates> result;
    eval_frexp(result.backend(), v.backend(), pint);
    return BOOST_MP_MOVE(result);
@@ -2675,6 +2714,7 @@ template <class T, expression_template_option ExpressionTemplates>
 inline typename enable_if_c<number_category<T>::value == number_kind_floating_point, number<T, ExpressionTemplates> >::type frexp(const number<T, ExpressionTemplates>& v, boost::long_long_type* pint)
 {
    using default_ops::eval_frexp;
+   detail::scoped_default_precision<multiprecision::number<T, ExpressionTemplates> > precision_guard(v);
    number<T, ExpressionTemplates> result;
    eval_frexp(result.backend(), v.backend(), pint);
    return BOOST_MP_MOVE(result);
@@ -2695,6 +2735,7 @@ template <class T, expression_template_option ExpressionTemplates>
 inline typename enable_if_c<number_category<T>::value == number_kind_floating_point, number<T, ExpressionTemplates> >::type modf(const number<T, ExpressionTemplates>& v, number<T, ExpressionTemplates>* pipart)
 {
    using default_ops::eval_modf;
+   detail::scoped_default_precision<multiprecision::number<T, ExpressionTemplates> > precision_guard(v);
    number<T, ExpressionTemplates> result;
    eval_modf(result.backend(), v.backend(), pipart ? &pipart->backend() : 0);
    return BOOST_MP_MOVE(result);
@@ -2703,6 +2744,7 @@ template <class T, expression_template_option ExpressionTemplates, class tag, cl
 inline typename enable_if_c<number_category<T>::value == number_kind_floating_point, number<T, ExpressionTemplates> >::type modf(const detail::expression<tag, A1, A2, A3, A4>& v, number<T, ExpressionTemplates>* pipart)
 {
    using default_ops::eval_modf;
+   detail::scoped_default_precision<multiprecision::number<T, ExpressionTemplates> > precision_guard(v);
    number<T, ExpressionTemplates> result, arg(v);
    eval_modf(result.backend(), arg.backend(), pipart ? &pipart->backend() : 0);
    return BOOST_MP_MOVE(result);
@@ -2804,6 +2846,7 @@ inline typename enable_if<
 fma(const number<Backend, et_off>& a, const U& b, const V& c)
 {
    using default_ops::eval_multiply_add;
+   detail::scoped_default_precision<multiprecision::number<Backend, et_off> > precision_guard(a, b, c);
    number<Backend, et_off> result;
    eval_multiply_add(result.backend(), number<Backend, et_off>::canonical_value(a), number<Backend, et_off>::canonical_value(b), number<Backend, et_off>::canonical_value(c));
    return BOOST_MP_MOVE(result);
@@ -2863,6 +2906,7 @@ inline typename enable_if<
 fma(const U& a, const number<Backend, et_off>& b, const V& c)
 {
    using default_ops::eval_multiply_add;
+   detail::scoped_default_precision<multiprecision::number<Backend, et_off> > precision_guard(a, b, c);
    number<Backend, et_off> result;
    eval_multiply_add(result.backend(), number<Backend, et_off>::canonical_value(a), number<Backend, et_off>::canonical_value(b), number<Backend, et_off>::canonical_value(c));
    return BOOST_MP_MOVE(result);
@@ -2910,6 +2954,7 @@ inline typename enable_if<
 fma(const U& a, const V& b, const number<Backend, et_off>& c)
 {
    using default_ops::eval_multiply_add;
+   detail::scoped_default_precision<multiprecision::number<Backend, et_off> > precision_guard(a, b, c);
    number<Backend, et_off> result;
    eval_multiply_add(result.backend(), number<Backend, et_off>::canonical_value(a), number<Backend, et_off>::canonical_value(b), number<Backend, et_off>::canonical_value(c));
    return BOOST_MP_MOVE(result);
@@ -2982,6 +3027,7 @@ inline typename enable_if_c<
 remquo(const number<Backend, et_off>& a, const U& b, int* pi)
 {
    using default_ops::eval_remquo;
+   detail::scoped_default_precision<multiprecision::number<Backend, et_off> > precision_guard(a, b);
    number<Backend, et_off> result;
    eval_remquo(result.backend(), a.backend(), number<Backend, et_off>::canonical_value(b), pi);
    return BOOST_MP_MOVE(result);
@@ -2995,6 +3041,7 @@ number<Backend, et_off>
 remquo(const U& a, const number<Backend, et_off>& b, int* pi)
 {
    using default_ops::eval_remquo;
+   detail::scoped_default_precision<multiprecision::number<Backend, et_off> > precision_guard(a, b);
    number<Backend, et_off> result;
    eval_remquo(result.backend(), number<Backend, et_off>::canonical_value(a), b.backend(), pi);
    return BOOST_MP_MOVE(result);
@@ -3006,6 +3053,7 @@ inline typename enable_if_c<number_category<B>::value == number_kind_integer, nu
    sqrt(const number<B, ExpressionTemplates>& x, number<B, ExpressionTemplates>& r)
 {
    using default_ops::eval_integer_sqrt;
+   detail::scoped_default_precision<multiprecision::number<B, ExpressionTemplates> > precision_guard(x, r);
    number<B, ExpressionTemplates> s;
    eval_integer_sqrt(s.backend(), r.backend(), x.backend());
    return s;
@@ -3075,6 +3123,7 @@ inline typename boost::enable_if_c<\
    number<Backend, et_off> >::type \
 func(const number<Backend, et_off>& arg)\
 {\
+   detail::scoped_default_precision<multiprecision::number<Backend, et_off> > precision_guard(arg);\
    number<Backend, et_off> result;\
    using default_ops::BOOST_JOIN(eval_,func);\
    BOOST_JOIN(eval_,func)(result.backend(), arg.backend());\
@@ -3314,6 +3363,7 @@ inline typename enable_if_c<(number_category<Backend>::value == category),\
    number<Backend, et_off> >::type \
 func(const number<Backend, et_off>& arg, const number<Backend, et_off>& a)\
 {\
+   detail::scoped_default_precision<multiprecision::number<Backend, et_off> > precision_guard(arg, a);\
    number<Backend, et_off> result;\
    using default_ops:: BOOST_JOIN(eval_,func);\
    BOOST_JOIN(eval_,func)(result.backend(), arg.backend(), a.backend());\
@@ -3326,6 +3376,7 @@ inline typename enable_if_c<\
 >::type \
 func(const number<Backend, et_off>& arg, const Arithmetic& a)\
 {\
+   detail::scoped_default_precision<multiprecision::number<Backend, et_off> > precision_guard(arg);\
    number<Backend, et_off> result;\
    using default_ops:: BOOST_JOIN(eval_,func);\
    BOOST_JOIN(eval_,func)(result.backend(), arg.backend(), number<Backend, et_off>::canonical_value(a));\
@@ -3338,6 +3389,7 @@ inline typename enable_if_c<\
 >::type \
 func(const Arithmetic& a, const number<Backend, et_off>& arg)\
 {\
+   detail::scoped_default_precision<multiprecision::number<Backend, et_off> > precision_guard(arg);\
    number<Backend, et_off> result;\
    using default_ops:: BOOST_JOIN(eval_,func);\
    BOOST_JOIN(eval_,func)(result.backend(), number<Backend, et_off>::canonical_value(a), arg.backend());\
@@ -3395,6 +3447,7 @@ inline typename enable_if_c<\
   number<Backend, et_off> >::type \
 func(const number<Backend, et_off>& arg, Arg2 const& a)\
 {\
+   detail::scoped_default_precision<multiprecision::number<Backend, et_off> > precision_guard(arg, a);\
    number<Backend, et_off> result;\
    using default_ops:: BOOST_JOIN(eval_,func);\
    BOOST_JOIN(eval_,func)(result.backend(), arg.backend(), a);\
@@ -3487,6 +3540,7 @@ template <class Backend>
 inline typename disable_if_c<number_category<Backend>::value == number_kind_complex, number<Backend, et_off> >::type
 abs(const number<Backend, et_off>& arg)
 {
+   detail::scoped_default_precision<multiprecision::number<Backend, et_off> > precision_guard(arg);
    number<Backend, et_off> result;
    using default_ops::eval_abs;
    eval_abs(result.backend(), arg.backend());
@@ -3529,6 +3583,7 @@ template <class Backend>
 inline number<Backend, et_off>
 conj(const number<Backend, et_off>& arg)
 {
+   detail::scoped_default_precision<multiprecision::number<Backend, et_off> > precision_guard(arg);
    number<Backend, et_off> result;
    using default_ops::eval_conj;
    eval_conj(result.backend(), arg.backend());
@@ -3571,6 +3626,7 @@ template <class Backend>
 inline number<Backend, et_off>
 proj(const number<Backend, et_off>& arg)
 {
+   detail::scoped_default_precision<multiprecision::number<Backend, et_off> > precision_guard(arg);
    number<Backend, et_off> result;
    using default_ops::eval_proj;
    eval_proj(result.backend(), arg.backend());
@@ -3691,24 +3747,28 @@ namespace detail{
 template <class Backend, multiprecision::expression_template_option ExpressionTemplates>
 inline multiprecision::number<Backend, ExpressionTemplates> sinc_pi(const multiprecision::number<Backend, ExpressionTemplates>& x)
 {
+   boost::multiprecision::detail::scoped_default_precision<multiprecision::number<Backend, ExpressionTemplates> > precision_guard(x);
    return BOOST_MP_MOVE(detail::sinc_pi_imp(x));
 }
 
 template <class Backend, multiprecision::expression_template_option ExpressionTemplates, class Policy>
 inline multiprecision::number<Backend, ExpressionTemplates> sinc_pi(const multiprecision::number<Backend, ExpressionTemplates>& x, const Policy&)
 {
+   boost::multiprecision::detail::scoped_default_precision<multiprecision::number<Backend, ExpressionTemplates> > precision_guard(x);
    return BOOST_MP_MOVE(detail::sinc_pi_imp(x));
 }
 
 template <class Backend, multiprecision::expression_template_option ExpressionTemplates>
 inline multiprecision::number<Backend, ExpressionTemplates> sinhc_pi(const multiprecision::number<Backend, ExpressionTemplates>& x)
 {
+   boost::multiprecision::detail::scoped_default_precision<multiprecision::number<Backend, ExpressionTemplates> > precision_guard(x);
    return BOOST_MP_MOVE(detail::sinhc_pi_imp(x));
 }
 
 template <class Backend, multiprecision::expression_template_option ExpressionTemplates, class Policy>
 inline multiprecision::number<Backend, ExpressionTemplates> sinhc_pi(const multiprecision::number<Backend, ExpressionTemplates>& x, const Policy&)
 {
+   boost::multiprecision::detail::scoped_default_precision<multiprecision::number<Backend, ExpressionTemplates> > precision_guard(x);
    return BOOST_MP_MOVE(boost::math::sinhc_pi(x));
 }
 

--- a/include/boost/multiprecision/detail/no_et_ops.hpp
+++ b/include/boost/multiprecision/detail/no_et_ops.hpp
@@ -23,6 +23,7 @@ template <class B>
 BOOST_MP_FORCEINLINE number<B, et_off> operator - (const number<B, et_off>& v)
 {
    BOOST_STATIC_ASSERT_MSG(is_signed_number<B>::value, "Negating an unsigned type results in ill-defined behavior.");
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(v);
    number<B, et_off> result(v);
    result.backend().negate();
    return result;
@@ -30,6 +31,7 @@ BOOST_MP_FORCEINLINE number<B, et_off> operator - (const number<B, et_off>& v)
 template <class B>
 BOOST_MP_FORCEINLINE number<B, et_off> operator ~ (const number<B, et_off>& v)
 {
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(v);
    number<B, et_off> result;
    eval_complement(result.backend(), v.backend());
    return result;
@@ -40,6 +42,7 @@ BOOST_MP_FORCEINLINE number<B, et_off> operator ~ (const number<B, et_off>& v)
 template <class B>
 BOOST_MP_FORCEINLINE number<B, et_off> operator + (const number<B, et_off>& a, const number<B, et_off>& b)
 {
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(a, b);
    number<B, et_off> result;
    using default_ops::eval_add;
    eval_add(result.backend(), a.backend(), b.backend());
@@ -49,6 +52,7 @@ template <class B, class V>
 BOOST_MP_FORCEINLINE typename enable_if<is_compatible_arithmetic_type<V, number<B, et_off> >, number<B, et_off> >::type
    operator + (const number<B, et_off>& a, const V& b)
 {
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(a);
    number<B, et_off> result;
    using default_ops::eval_add;
    eval_add(result.backend(), a.backend(), number<B, et_off>::canonical_value(b));
@@ -58,6 +62,7 @@ template <class V, class B>
 BOOST_MP_FORCEINLINE typename enable_if<is_compatible_arithmetic_type<V, number<B, et_off> >, number<B, et_off> >::type
    operator + (const V& a, const number<B, et_off>& b)
 {
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(b);
    number<B, et_off> result;
    using default_ops::eval_add;
    eval_add(result.backend(), b.backend(), number<B, et_off>::canonical_value(a));
@@ -69,6 +74,7 @@ BOOST_MP_FORCEINLINE typename enable_if<is_compatible_arithmetic_type<V, number<
 template <class B>
 BOOST_MP_FORCEINLINE number<B, et_off> operator - (const number<B, et_off>& a, const number<B, et_off>& b)
 {
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(a, b);
    number<B, et_off> result;
    using default_ops::eval_subtract;
    eval_subtract(result.backend(), a.backend(), b.backend());
@@ -78,6 +84,7 @@ template <class B, class V>
 BOOST_MP_FORCEINLINE typename enable_if<is_compatible_arithmetic_type<V, number<B, et_off> >, number<B, et_off> >::type
    operator - (const number<B, et_off>& a, const V& b)
 {
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(a);
    number<B, et_off> result;
    using default_ops::eval_subtract;
    eval_subtract(result.backend(), a.backend(), number<B, et_off>::canonical_value(b));
@@ -87,6 +94,7 @@ template <class V, class B>
 BOOST_MP_FORCEINLINE typename enable_if<is_compatible_arithmetic_type<V, number<B, et_off> >, number<B, et_off> >::type
    operator - (const V& a, const number<B, et_off>& b)
 {
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(b);
    number<B, et_off> result;
    using default_ops::eval_subtract;
    eval_subtract(result.backend(), number<B, et_off>::canonical_value(a), b.backend());
@@ -98,6 +106,7 @@ BOOST_MP_FORCEINLINE typename enable_if<is_compatible_arithmetic_type<V, number<
 template <class B>
 BOOST_MP_FORCEINLINE number<B, et_off> operator * (const number<B, et_off>& a, const number<B, et_off>& b)
 {
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(a, b);
    number<B, et_off> result;
    using default_ops::eval_multiply;
    eval_multiply(result.backend(), a.backend(), b.backend());
@@ -107,6 +116,7 @@ template <class B, class V>
 BOOST_MP_FORCEINLINE typename enable_if<is_compatible_arithmetic_type<V, number<B, et_off> >, number<B, et_off> >::type
    operator * (const number<B, et_off>& a, const V& b)
 {
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(a);
    number<B, et_off> result;
    using default_ops::eval_multiply;
    eval_multiply(result.backend(), a.backend(), number<B, et_off>::canonical_value(b));
@@ -116,6 +126,7 @@ template <class V, class B>
 BOOST_MP_FORCEINLINE typename enable_if<is_compatible_arithmetic_type<V, number<B, et_off> >, number<B, et_off> >::type
    operator * (const V& a, const number<B, et_off>& b)
 {
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(b);
    number<B, et_off> result;
    using default_ops::eval_multiply;
    eval_multiply(result.backend(), b.backend(), number<B, et_off>::canonical_value(a));
@@ -127,6 +138,7 @@ BOOST_MP_FORCEINLINE typename enable_if<is_compatible_arithmetic_type<V, number<
 template <class B>
 BOOST_MP_FORCEINLINE number<B, et_off> operator / (const number<B, et_off>& a, const number<B, et_off>& b)
 {
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(a, b);
    number<B, et_off> result;
    using default_ops::eval_divide;
    eval_divide(result.backend(), a.backend(), b.backend());
@@ -136,6 +148,7 @@ template <class B, class V>
 BOOST_MP_FORCEINLINE typename enable_if<is_compatible_arithmetic_type<V, number<B, et_off> >, number<B, et_off> >::type
    operator / (const number<B, et_off>& a, const V& b)
 {
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(a);
    number<B, et_off> result;
    using default_ops::eval_divide;
    eval_divide(result.backend(), a.backend(), number<B, et_off>::canonical_value(b));
@@ -145,6 +158,7 @@ template <class V, class B>
 BOOST_MP_FORCEINLINE typename enable_if<is_compatible_arithmetic_type<V, number<B, et_off> >, number<B, et_off> >::type
    operator / (const V& a, const number<B, et_off>& b)
 {
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(b);
    number<B, et_off> result;
    using default_ops::eval_divide;
    eval_divide(result.backend(), number<B, et_off>::canonical_value(a), b.backend());
@@ -156,6 +170,7 @@ BOOST_MP_FORCEINLINE typename enable_if<is_compatible_arithmetic_type<V, number<
 template <class B>
 BOOST_MP_FORCEINLINE typename enable_if_c<number_category<B>::value == number_kind_integer, number<B, et_off> >::type operator % (const number<B, et_off>& a, const number<B, et_off>& b)
 {
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(a, b);
    number<B, et_off> result;
    using default_ops::eval_modulus;
    eval_modulus(result.backend(), a.backend(), b.backend());
@@ -165,6 +180,7 @@ template <class B, class V>
 BOOST_MP_FORCEINLINE typename enable_if_c<is_compatible_arithmetic_type<V, number<B, et_off> >::value && (number_category<B>::value == number_kind_integer), number<B, et_off> >::type
    operator % (const number<B, et_off>& a, const V& b)
 {
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(a);
    number<B, et_off> result;
    using default_ops::eval_modulus;
    eval_modulus(result.backend(), a.backend(), number<B, et_off>::canonical_value(b));
@@ -174,6 +190,7 @@ template <class V, class B>
 BOOST_MP_FORCEINLINE typename enable_if_c<is_compatible_arithmetic_type<V, number<B, et_off> >::value && (number_category<B>::value == number_kind_integer), number<B, et_off> >::type
    operator % (const V& a, const number<B, et_off>& b)
 {
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(b);
    number<B, et_off> result;
    using default_ops::eval_modulus;
    eval_modulus(result.backend(), number<B, et_off>::canonical_value(a), b.backend());
@@ -322,6 +339,7 @@ template <class B>
 BOOST_MP_FORCEINLINE number<B, et_off> operator + (number<B, et_off>&& a, const number<B, et_off>& b)
 {
    using default_ops::eval_add;
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(a, b);
    eval_add(a.backend(), b.backend());
    return static_cast<number<B, et_off>&&>(a);
 }
@@ -329,6 +347,7 @@ template <class B>
 BOOST_MP_FORCEINLINE number<B, et_off> operator + (const number<B, et_off>& a, number<B, et_off>&& b)
 {
    using default_ops::eval_add;
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(a, b);
    eval_add(b.backend(), a.backend());
    return static_cast<number<B, et_off>&&>(b);
 }
@@ -336,6 +355,7 @@ template <class B>
 BOOST_MP_FORCEINLINE number<B, et_off> operator + (number<B, et_off>&& a, number<B, et_off>&& b)
 {
    using default_ops::eval_add;
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(a, b);
    eval_add(a.backend(), b.backend());
    return static_cast<number<B, et_off>&&>(a);
 }
@@ -344,6 +364,7 @@ BOOST_MP_FORCEINLINE typename enable_if<is_compatible_arithmetic_type<V, number<
    operator + (number<B, et_off>&& a, const V& b)
 {
    using default_ops::eval_add;
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(a, b);
    eval_add(a.backend(), number<B, et_off>::canonical_value(b));
    return static_cast<number<B, et_off>&&>(a);
 }
@@ -352,6 +373,7 @@ BOOST_MP_FORCEINLINE typename enable_if<is_compatible_arithmetic_type<V, number<
    operator + (const V& a, number<B, et_off>&& b)
 {
    using default_ops::eval_add;
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(a, b);
    eval_add(b.backend(), number<B, et_off>::canonical_value(a));
    return static_cast<number<B, et_off>&&>(b);
 }
@@ -362,6 +384,7 @@ template <class B>
 BOOST_MP_FORCEINLINE number<B, et_off> operator - (number<B, et_off>&& a, const number<B, et_off>& b)
 {
    using default_ops::eval_subtract;
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(a, b);
    eval_subtract(a.backend(), b.backend());
    return static_cast<number<B, et_off>&&>(a);
 }
@@ -369,6 +392,7 @@ template <class B>
 BOOST_MP_FORCEINLINE typename enable_if<is_signed_number<B>, number<B, et_off> >::type operator - (const number<B, et_off>& a, number<B, et_off>&& b)
 {
    using default_ops::eval_subtract;
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(a, b);
    eval_subtract(b.backend(), a.backend());
    b.backend().negate();
    return static_cast<number<B, et_off>&&>(b);
@@ -377,6 +401,7 @@ template <class B>
 BOOST_MP_FORCEINLINE number<B, et_off> operator - (number<B, et_off>&& a, number<B, et_off>&& b)
 {
    using default_ops::eval_subtract;
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(a, b);
    eval_subtract(a.backend(), b.backend());
    return static_cast<number<B, et_off>&&>(a);
 }
@@ -385,6 +410,7 @@ BOOST_MP_FORCEINLINE typename enable_if<is_compatible_arithmetic_type<V, number<
    operator - (number<B, et_off>&& a, const V& b)
 {
    using default_ops::eval_subtract;
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(a, b);
    eval_subtract(a.backend(), number<B, et_off>::canonical_value(b));
    return static_cast<number<B, et_off>&&>(a);
 }
@@ -393,6 +419,7 @@ BOOST_MP_FORCEINLINE typename enable_if_c<(is_compatible_arithmetic_type<V, numb
    operator - (const V& a, number<B, et_off>&& b)
 {
    using default_ops::eval_subtract;
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(a, b);
    eval_subtract(b.backend(), number<B, et_off>::canonical_value(a));
    b.backend().negate();
    return static_cast<number<B, et_off>&&>(b);
@@ -404,6 +431,7 @@ template <class B>
 BOOST_MP_FORCEINLINE number<B, et_off> operator * (number<B, et_off>&& a, const number<B, et_off>& b)
 {
    using default_ops::eval_multiply;
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(a, b);
    eval_multiply(a.backend(), b.backend());
    return static_cast<number<B, et_off>&&>(a);
 }
@@ -411,6 +439,7 @@ template <class B>
 BOOST_MP_FORCEINLINE number<B, et_off> operator * (const number<B, et_off>& a, number<B, et_off>&& b)
 {
    using default_ops::eval_multiply;
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(a, b);
    eval_multiply(b.backend(), a.backend());
    return static_cast<number<B, et_off>&&>(b);
 }
@@ -418,6 +447,7 @@ template <class B>
 BOOST_MP_FORCEINLINE number<B, et_off> operator * (number<B, et_off>&& a, number<B, et_off>&& b)
 {
    using default_ops::eval_multiply;
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(a, b);
    eval_multiply(a.backend(), b.backend());
    return static_cast<number<B, et_off>&&>(a);
 }
@@ -426,6 +456,7 @@ BOOST_MP_FORCEINLINE typename enable_if<is_compatible_arithmetic_type<V, number<
    operator * (number<B, et_off>&& a, const V& b)
 {
    using default_ops::eval_multiply;
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(a, b);
    eval_multiply(a.backend(), number<B, et_off>::canonical_value(b));
    return static_cast<number<B, et_off>&&>(a);
 }
@@ -434,6 +465,7 @@ BOOST_MP_FORCEINLINE typename enable_if<is_compatible_arithmetic_type<V, number<
    operator * (const V& a, number<B, et_off>&& b)
 {
    using default_ops::eval_multiply;
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(a, b);
    eval_multiply(b.backend(), number<B, et_off>::canonical_value(a));
    return static_cast<number<B, et_off>&&>(b);
 }
@@ -444,6 +476,7 @@ template <class B>
 BOOST_MP_FORCEINLINE number<B, et_off> operator / (number<B, et_off>&& a, const number<B, et_off>& b)
 {
    using default_ops::eval_divide;
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(a, b);
    eval_divide(a.backend(), b.backend());
    return static_cast<number<B, et_off>&&>(a);
 }
@@ -452,6 +485,7 @@ BOOST_MP_FORCEINLINE typename enable_if<is_compatible_arithmetic_type<V, number<
    operator / (number<B, et_off>&& a, const V& b)
 {
    using default_ops::eval_divide;
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(a, b);
    eval_divide(a.backend(), number<B, et_off>::canonical_value(b));
    return static_cast<number<B, et_off>&&>(a);
 }
@@ -462,6 +496,7 @@ template <class B>
 BOOST_MP_FORCEINLINE typename enable_if_c<number_category<B>::value == number_kind_integer, number<B, et_off> >::type operator % (number<B, et_off>&& a, const number<B, et_off>& b)
 {
    using default_ops::eval_modulus;
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(a, b);
    eval_modulus(a.backend(), b.backend());
    return static_cast<number<B, et_off>&&>(a);
 }
@@ -470,6 +505,7 @@ BOOST_MP_FORCEINLINE typename enable_if_c<is_compatible_arithmetic_type<V, numbe
    operator % (number<B, et_off>&& a, const V& b)
 {
    using default_ops::eval_modulus;
+   detail::scoped_default_precision<multiprecision::number<B, et_off> > precision_guard(a, b);
    eval_modulus(a.backend(), number<B, et_off>::canonical_value(b));
    return static_cast<number<B, et_off>&&>(a);
 }

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -99,9 +99,11 @@ test-suite arithmetic_tests :
    [ run test_arithmetic_cpp_dec_float_1.cpp no_eh_support ]
    [ run test_arithmetic_cpp_dec_float_2.cpp no_eh_support ]
    [ run test_arithmetic_cpp_dec_float_3.cpp no_eh_support ]
+   [ run test_arithmetic_cpp_dec_float_3m.cpp no_eh_support ]
 
    [ run test_arithmetic_cpp_bin_float_1.cpp no_eh_support ]
    [ run test_arithmetic_cpp_bin_float_2.cpp no_eh_support ]
+   [ run test_arithmetic_cpp_bin_float_2m.cpp no_eh_support ]
    [ run test_arithmetic_cpp_bin_float_3.cpp no_eh_support ]
 
    [ run test_arithmetic_mpf_50.cpp gmp no_eh_support : : : [ check-target-builds ../config//has_gmp : : <build>no ] ]
@@ -150,6 +152,7 @@ test-suite arithmetic_tests :
    [ run test_arithmetic_logged_2.cpp no_eh_support ]
 
    [ run test_arithmetic_dbg_adptr1.cpp no_eh_support ]
+   [ run test_arithmetic_dbg_adptr1m.cpp no_eh_support ]
    [ run test_arithmetic_dbg_adptr2.cpp no_eh_support ]
 
    [ run test_arithmetic_mpfi_50.cpp mpfi mpfr gmp no_eh_support : : : [ check-target-builds ../config//has_mpfi : : <build>no ] ]
@@ -161,6 +164,7 @@ test-suite arithmetic_tests :
    [ run test_mpfr_mpc_precisions.cpp mpc mpfr gmp : : : [ check-target-builds ../config//has_mpc : : <build>no ] ]
    [ run test_complex.cpp : : : [ check-target-builds ../config//has_mpc : <define>TEST_MPC <source>mpc <source>mpfr <source>gmp ] [ check-target-builds ../config//has_float128 : <source>quadmath ] ]
    [ run test_arithmetic_complex_adaptor.cpp ]
+   [ run test_arithmetic_complex_adaptor_2.cpp ]
    [ run test_arithmetic_complex128.cpp : : : [ check-target-builds ../config//has_float128 : <source>quadmath ] ]
 
 ;
@@ -335,6 +339,7 @@ test-suite functions_and_limits :
       [ run test_sf_import_c99.cpp : : : <define>TEST_CPP_DEC_FLOAT_3 : test_sf_import_c99_cpp_dec_float_3 ]
       [ run test_sf_import_c99.cpp : : : <define>TEST_CPP_DEC_FLOAT_4 : test_sf_import_c99_cpp_dec_float_4 ]
       [ run test_sf_import_c99.cpp : : : <define>TEST_CPP_DEC_FLOAT_5 : test_sf_import_c99_cpp_dec_float_5 ]
+      [ run test_sf_import_c99.cpp : : : <define>TEST_CPP_DEC_FLOAT_6 : test_sf_import_c99_cpp_dec_float_6 ]
 
       [ run test_sf_import_c99.cpp : : : <define>TEST_CPP_BIN_FLOAT_2 : test_sf_import_c99_cpp_bin_float_2 ]
       [ run test_sf_import_c99.cpp : : : <define>TEST_CPP_BIN_FLOAT_2 : test_sf_import_c99_cpp_bin_float_3 ]
@@ -1112,6 +1117,7 @@ rule get_concept_checks
 	            <define>TEST_MPFR_50
                [ check-target-builds ../config//has_mpfr : : <build>no ]
                <debug-symbols>off
+               <optimization>space
               : $(source:B)_mpfr_50 ] ;
 
       result += [ compile $(source)  mpfr
@@ -1119,6 +1125,7 @@ rule get_concept_checks
 	            <define>TEST_MPFR_6
                [ check-target-builds ../config//has_mpfr : : <build>no ]
                <debug-symbols>off
+               <optimization>space
               : $(source:B)_mpfr_6 ] ;
 
       result += [ compile $(source)  mpfr
@@ -1126,6 +1133,7 @@ rule get_concept_checks
 	            <define>TEST_MPFR_15
                [ check-target-builds ../config//has_mpfr : : <build>no ]
                <debug-symbols>off
+               <optimization>space
               : $(source:B)_mpfr_15 ] ;
 
       result += [ compile $(source)  mpfr
@@ -1133,6 +1141,7 @@ rule get_concept_checks
 	            <define>TEST_MPFR_17
                [ check-target-builds ../config//has_mpfr : : <build>no ]
                <debug-symbols>off
+               <optimization>space
               : $(source:B)_mpfr_17 ] ;
 
       result += [ compile $(source)  mpfr
@@ -1140,6 +1149,7 @@ rule get_concept_checks
 	            <define>TEST_MPFR_30
                [ check-target-builds ../config//has_mpfr : : <build>no ]
                <debug-symbols>off
+               <optimization>space
               : $(source:B)_mpfr_30 ] ;
 
       result += [ compile $(source)  gmp
@@ -1147,36 +1157,42 @@ rule get_concept_checks
 	            <define>TEST_MPF_50
                [ check-target-builds ../config//has_gmp : : <build>no ]
                <debug-symbols>off
+               <optimization>space
               : $(source:B)_mpf50 ] ;
 
       result += [ compile $(source)
               : # requirements
 	            <define>TEST_CPP_DEC_FLOAT
                <debug-symbols>off
+               <optimization>space
               : $(source:B)_cpp_dec_float ] ;
 
       result += [ compile $(source)
               : # requirements
 	            <define>TEST_CPP_BIN_FLOAT
                <debug-symbols>off
+               <optimization>space
               : $(source:B)_cpp_bin_float ] ;
 
       result += [ compile $(source)
               : # requirements
 	            <define>TEST_CPP_DEC_FLOAT_NO_ET
                <debug-symbols>off
+               <optimization>space
               : $(source:B)_cpp_dec_float_no_et ] ;
 
       result += [ compile $(source)
               : # requirements
 	            <define>TEST_BACKEND
                <debug-symbols>off
+               <optimization>space
               : $(source:B)_backend_concept ] ;
 
       result += [ compile $(source)
               : # requirements
 	            <define>TEST_LOGGED_ADAPTER
                <debug-symbols>off
+               <optimization>space
               : $(source:B)_logged_adaptor ] ;
    }
    return $(result) ;

--- a/test/test_arithmetic.hpp
+++ b/test/test_arithmetic.hpp
@@ -2679,6 +2679,7 @@ void test()
    test_mixed<Real, std::complex<long double> >(complex_tag);
 
 #endif
+#ifndef MIXED_OPS_ONLY
    //
    // Integer only functions:
    //
@@ -2978,4 +2979,5 @@ void test()
    a = 2;
    a = (a + a) * a;
    BOOST_CHECK_EQUAL(a, 8);
+#endif
 }

--- a/test/test_arithmetic_complex_adaptor.cpp
+++ b/test/test_arithmetic_complex_adaptor.cpp
@@ -3,6 +3,8 @@
 //  Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_
 
+#define NO_MIXED_OPS
+
 #include <boost/multiprecision/cpp_complex.hpp>
 
 #include "libs/multiprecision/test/test_arithmetic.hpp"

--- a/test/test_arithmetic_cpp_bin_float_2.cpp
+++ b/test/test_arithmetic_cpp_bin_float_2.cpp
@@ -3,6 +3,8 @@
 //  Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_
 
+#define NO_MIXED_OPS
+
 #include <boost/multiprecision/cpp_bin_float.hpp>
 
 #include "libs/multiprecision/test/test_arithmetic.hpp"

--- a/test/test_arithmetic_cpp_dec_float_3.cpp
+++ b/test/test_arithmetic_cpp_dec_float_3.cpp
@@ -3,6 +3,8 @@
 //  Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_
 
+#define NO_MIXED_OPS
+
 #include <boost/multiprecision/cpp_dec_float.hpp>
 
 #include "test_arithmetic.hpp"

--- a/test/test_arithmetic_dbg_adptr1.cpp
+++ b/test/test_arithmetic_dbg_adptr1.cpp
@@ -7,6 +7,8 @@
 #  define _SCL_SECURE_NO_WARNINGS
 #endif
 
+#define NO_MIXED_OPS
+
 #include <boost/multiprecision/debug_adaptor.hpp>
 #include <boost/multiprecision/cpp_dec_float.hpp>
 #include "test_arithmetic.hpp"

--- a/test/test_mpfr_mpc_precisions.cpp
+++ b/test/test_mpfr_mpc_precisions.cpp
@@ -39,7 +39,7 @@ int main()
       mpfr_float b(2);
       BOOST_CHECK_EQUAL(b.precision(), 20);
       b = a;
-      BOOST_CHECK_EQUAL(b.precision(), 20);
+      BOOST_CHECK_EQUAL(b.precision(), a.precision());
    }
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
    {
@@ -47,7 +47,7 @@ int main()
       mpfr_float b(2);
       BOOST_CHECK_EQUAL(b.precision(), 20);
       b = make_rvalue_copy(a);
-      BOOST_CHECK_EQUAL(b.precision(), 100);
+      BOOST_CHECK_EQUAL(b.precision(), a.precision());
    }
 #endif
    mpfr_float::default_precision(20);
@@ -72,7 +72,7 @@ int main()
       mpc_complex b(2);
       BOOST_CHECK_EQUAL(b.precision(), 20);
       b = ca;
-      BOOST_CHECK_EQUAL(b.precision(), 20);
+      BOOST_CHECK_EQUAL(b.precision(), ca.precision());
    }
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
    {
@@ -80,19 +80,19 @@ int main()
       mpc_complex b(2);
       BOOST_CHECK_EQUAL(b.precision(), 20);
       b = make_rvalue_copy(ca);
-      BOOST_CHECK_EQUAL(b.precision(), 100);
+      BOOST_CHECK_EQUAL(b.precision(), ca.precision());
    }
 #endif
    {
       // test construct from lvalue:
       mpc_complex b(ca);
-      BOOST_CHECK_EQUAL(b.precision(), 100);
+      BOOST_CHECK_EQUAL(b.precision(), ca.precision());
    }
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
    {
       // test construct from rvalue:
       mpc_complex b(make_rvalue_copy(ca));
-      BOOST_CHECK_EQUAL(b.precision(), 100);
+      BOOST_CHECK_EQUAL(b.precision(), ca.precision());
    }
 #endif
    // real and imaginary:
@@ -107,6 +107,10 @@ int main()
    {
       mpfr_float f150(mpfr_float(), 150u);
       BOOST_CHECK_EQUAL(f150.precision(), 150);
+      mpc_complex f150c(mpc_complex(), 150u);
+      BOOST_CHECK_EQUAL(f150c.precision(), 150);
+      mpc_complex f150cc(mpfr_float(), mpfr_float(), 150u);
+      BOOST_CHECK_EQUAL(f150cc.precision(), 150);
    }
    {
       mpfr_float f150(2, 150);
@@ -230,7 +234,11 @@ int main()
       BOOST_CHECK_EQUAL(x.precision(), y.precision());
 #endif
    }
-
+   {
+      mpfr_float c(4), d(8), e(9), f;
+      f = (c + d) * d / e;
+      mpfr_float g((c + d) * d / e);
+   }
 
 
    return boost::report_errors();

--- a/test/test_sf_import_c99.cpp
+++ b/test/test_sf_import_c99.cpp
@@ -10,7 +10,7 @@
 #if !defined(TEST_MPF_50) && !defined(TEST_MPF) && !defined(TEST_BACKEND) && !defined(TEST_CPP_DEC_FLOAT)\
    && !defined(TEST_MPFR) && !defined(TEST_MPFR_50) && !defined(TEST_MPFI_50) && !defined(TEST_FLOAT128)\
    && !defined(TEST_CPP_BIN_FLOAT) && !defined(TEST_CPP_DEC_FLOAT_2) && !defined(TEST_CPP_DEC_FLOAT_3)\
-  && !defined(TEST_CPP_DEC_FLOAT_4) && !defined(TEST_CPP_DEC_FLOAT_5) && !defined(TEST_CPP_BIN_FLOAT_2) && !defined(TEST_CPP_BIN_FLOAT_3)
+  && !defined(TEST_CPP_DEC_FLOAT_4) && !defined(TEST_CPP_DEC_FLOAT_5) && !defined(TEST_CPP_DEC_FLOAT_6) && !defined(TEST_CPP_BIN_FLOAT_2) && !defined(TEST_CPP_BIN_FLOAT_3)
 #  define TEST_MPF_50
 #  define TEST_MPFR_50
 #  define TEST_MPFI_50
@@ -19,6 +19,7 @@
 #  define TEST_CPP_DEC_FLOAT_3
 #  define TEST_CPP_DEC_FLOAT_4
 #  define TEST_CPP_DEC_FLOAT_5
+#  define TEST_CPP_DEC_FLOAT_6
 #  define TEST_FLOAT128
 #  define TEST_CPP_BIN_FLOAT
 #  define TEST_CPP_BIN_FLOAT_2
@@ -42,7 +43,7 @@
 #ifdef TEST_MPFI_50
 #include <boost/multiprecision/mpfi.hpp>
 #endif
-#if defined(TEST_CPP_DEC_FLOAT) || defined(TEST_CPP_DEC_FLOAT_2) || defined(TEST_CPP_DEC_FLOAT_3) || defined(TEST_CPP_DEC_FLOAT_4) || defined(TEST_CPP_DEC_FLOAT_5)
+#if defined(TEST_CPP_DEC_FLOAT) || defined(TEST_CPP_DEC_FLOAT_2) || defined(TEST_CPP_DEC_FLOAT_3) || defined(TEST_CPP_DEC_FLOAT_4) || defined(TEST_CPP_DEC_FLOAT_5) || defined(TEST_CPP_DEC_FLOAT_6)
 #include <boost/multiprecision/cpp_dec_float.hpp>
 #endif
 #if defined(TEST_CPP_BIN_FLOAT) ||  defined(TEST_CPP_BIN_FLOAT_2) || defined(TEST_CPP_BIN_FLOAT_3)
@@ -2083,9 +2084,9 @@ int main()
 #endif
 #ifdef TEST_CPP_DEC_FLOAT_5
    test<boost::multiprecision::number<boost::multiprecision::cpp_dec_float<59, long long, std::allocator<char> > > >();
-#if !(defined(__GNUC__) && defined(_WIN32)) // Object file too large otherwise
-   test<boost::multiprecision::number<boost::multiprecision::cpp_dec_float<58, long long, std::allocator<char> > > >();
 #endif
+#ifdef TEST_CPP_DEC_FLOAT_6
+   test<boost::multiprecision::number<boost::multiprecision::cpp_dec_float<58, long long, std::allocator<char> > > >();
 #endif
 #ifdef TEST_CPP_BIN_FLOAT
    test<boost::multiprecision::cpp_bin_float_50>();


### PR DESCRIPTION
APPoS for short, throughout the library including in mixed precision arithmetic which should now always promote to the highest precision of any of the arguments.