### PR TITLE
Fix compilation failure with clang C++03 and Boost.Optional

### DIFF
--- a/include/boost/multiprecision/detail/functions/pow.hpp
+++ b/include/boost/multiprecision/detail/functions/pow.hpp
@@ -537,6 +537,7 @@ inline void eval_pow(T& result, const T& x, const T& a)
          {
             // fallthrough..
          }
+         BOOST_FALLTHROUGH;
       }
       default:
          if(eval_signbit(a))

--- a/include/boost/multiprecision/traits/explicit_conversion.hpp
+++ b/include/boost/multiprecision/traits/explicit_conversion.hpp
@@ -7,48 +7,51 @@
 #ifndef BOOST_MP_EXPLICIT_CONVERTIBLE_HPP
 #define BOOST_MP_EXPLICIT_CONVERTIBLE_HPP
 
+#include <boost/config.hpp>
+#include <boost/type_traits/conditional.hpp>
+#include <boost/type_traits/integral_constant.hpp>
 #include <boost/type_traits/is_convertible.hpp>
-#include <boost/utility/declval.hpp>
-
+#include <boost/type_traits/declval.hpp>
+#include <boost/multiprecision/detail/number_base.hpp> // number_category
 
 namespace boost {
    namespace multiprecision {
       namespace detail {
 
-         template <int N>
+         template <unsigned int N>
          struct dummy_size {};
 
          template<typename S, typename T>
          struct has_generic_interconversion
          {
-            typedef typename mpl::if_c <
+            typedef typename boost::conditional <
                is_number<S>::value && is_number<T>::value,
-               typename mpl::if_c <
+               typename boost::conditional <
                number_category<S>::value == number_kind_integer,
-               typename mpl::if_c<
+               typename boost::conditional<
                number_category<T>::value == number_kind_integer
                || number_category<T>::value == number_kind_floating_point
                || number_category<T>::value == number_kind_rational
                || number_category<T>::value == number_kind_fixed_point,
-               mpl::true_,
-               mpl::false_
+               boost::true_type,
+               boost::false_type
                >::type,
-               typename mpl::if_c<
+               typename boost::conditional<
                number_category<S>::value == number_kind_rational,
-               typename mpl::if_c<
+               typename boost::conditional<
                number_category<T>::value == number_kind_rational
                || number_category<T>::value == number_kind_rational,
-               mpl::true_,
-               mpl::false_
+               boost::true_type,
+               boost::false_type
                >::type,
-               typename mpl::if_c<
+               typename boost::conditional<
                number_category<T>::value == number_kind_floating_point,
-               mpl::true_,
-               mpl::false_
+               boost::true_type,
+               boost::false_type
                >::type
                >::type
                > ::type,
-               mpl::false_
+               boost::false_type
             > ::type type;
          };
 
@@ -57,7 +60,13 @@ namespace boost {
          {
 #ifndef BOOST_NO_SFINAE_EXPR
             template<typename S1, typename T1>
-            static type_traits::yes_type selector(dummy_size<sizeof(static_cast<T1>(declval<S1>()))>*);
+            static type_traits::yes_type selector(dummy_size<sizeof(new T1(boost::declval<
+#if !defined(BOOST_NO_CXX11_RVALUE_REFERENCES)
+                S1
+#else
+                S1 const&
+#endif
+            >()))>*);
 
             template<typename S1, typename T1>
             static type_traits::no_type selector(...);
@@ -67,7 +76,7 @@ namespace boost {
             typedef boost::integral_constant<bool, value> type;
 #else
             typedef typename has_generic_interconversion<S, T>::type gen_type;
-            typedef mpl::bool_<boost::is_convertible<S, T>::value || gen_type::value> type;
+            typedef boost::integral_constant<bool, boost::is_convertible<S, T>::value || gen_type::value> type;
 #endif
          };
 

--- a/include/boost/multiprecision/traits/is_byte_container.hpp
+++ b/include/boost/multiprecision/traits/is_byte_container.hpp
@@ -6,25 +6,28 @@
 #ifndef BOOST_IS_BYTE_CONTAINER_HPP
 #define BOOST_IS_BYTE_CONTAINER_HPP
 
+#include <iterator>
 #include <boost/mpl/has_xxx.hpp>
 #include <boost/type_traits/is_integral.hpp>
+#include <boost/type_traits/remove_cv.hpp>
 
 namespace boost{ namespace multiprecision{ namespace detail{
 
-   BOOST_MPL_HAS_XXX_TRAIT_NAMED_DEF(has_member_value_type, value_type, false)
    BOOST_MPL_HAS_XXX_TRAIT_NAMED_DEF(has_member_const_iterator, const_iterator, false)
 
    template <class C, bool b>
    struct is_byte_container_imp
    {
-      static const bool value = boost::is_integral<typename C::value_type>::value && (sizeof(typename C::value_type) == 1);
+      // Note: Don't use C::value_type as this is a rather widespread typedef, even for non-range types
+      typedef typename boost::remove_cv<typename std::iterator_traits<typename C::const_iterator>::value_type>::type container_value_type;
+      static const bool value = boost::is_integral<container_value_type>::value && (sizeof(container_value_type) == 1);
    };
 
    template <class C>
    struct is_byte_container_imp<C, false> : public boost::false_type {};
 
    template <class C>
-   struct is_byte_container : public is_byte_container_imp<C, has_member_value_type<C>::value && has_member_const_iterator<C>::value> {};
+   struct is_byte_container : public is_byte_container_imp<C, has_member_const_iterator<C>::value> {};
 
 
 }}} // namespaces

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -947,6 +947,7 @@ test-suite misc :
          [ check-target-builds ../config//has_mpfi : <define>TEST_MPFI <source>gmp <source>mpfr <source>mpfi : ]
          [ check-target-builds ../config//has_tommath : <define>TEST_TOMMATH <source>tommath : ]
           ]
+      [ run test_optional_compat.cpp ]
       #
       # Eigen interoperability:
       #

--- a/test/test_optional_compat.cpp
+++ b/test/test_optional_compat.cpp
@@ -1,0 +1,31 @@
+/*
+ *  (c) Copyright Andrey Semashev 2018.
+ *
+ *  Use, modification and distribution are subject to the
+ *  Boost Software License, Version 1.0. (See accompanying file
+ *  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+ */
+/*
+ * The test verifies that Boost.Multiprecision does not cause conflict with Boost.Optional
+ * because of its restricted conversion constructors and operators. See comments in:
+ *
+ * https://github.com/boostorg/integer/pull/11
+ */
+
+#include <boost/multiprecision/cpp_int.hpp>
+#include <boost/optional/optional.hpp>
+#include <boost/core/lightweight_test.hpp>
+
+inline boost::optional< boost::multiprecision::int128_t > foo()
+{
+    return boost::optional< boost::multiprecision::int128_t >(10);
+}
+
+int main()
+{
+    boost::optional< boost::multiprecision::int128_t > num = foo();
+    BOOST_TEST(!!num);
+    BOOST_TEST(*num == 10);
+
+    return boost::report_errors();
+}


### PR DESCRIPTION
This PR fixes compilation failures with clang in C++03 mode that were found in https://github.com/boostorg/integer/pull/11#issuecomment-435649481. Two problems are fixed here:

- `is_explicitly_convertible` trait required a public destructor in C++03 mode because `declval` returns `T` by value in this mode. The compilation fails because `optional_base`, on which the trait gets instantiated during `optional` constructor compilation, has a protected destructor.
- `is_byte_container` trait required a public `value_type` typedef in the range type. `optional_base` defines a protected typedef `value_type`. In general, this typedef is quite commonly used in non-range types, so don't use it to detect container/range types.

More details are available in commit messages.

Also, the PR adds a few missing includes and fixes a gcc warning about implicit fallthough in switch/case. It also adds a test for compatibility between Boost.Multiprecision and Boost.Optional.
