### PR TITLE
Print float128 as hexadecimal floating point literals if the ios_base…

### DIFF
--- a/include/boost/multiprecision/float128.hpp
+++ b/include/boost/multiprecision/float128.hpp
@@ -264,8 +264,7 @@ public:
    std::string str(std::streamsize digits, std::ios_base::fmtflags f)const
    {
 #ifndef BOOST_MP_USE_QUAD
-      char buf[100];
-      boost::scoped_array<char> buf2;
+      char buf[128];
       std::string format = "%";
       if(f & std::ios_base::showpos)
          format += "+";
@@ -275,6 +274,7 @@ public:
       if(digits == 0)
          digits = 36;
       format += "Q";
+
       if(f & std::ios_base::scientific)
          format += "e";
       else if(f & std::ios_base::fixed)
@@ -282,11 +282,17 @@ public:
       else
          format += "g";
 
-      int v = quadmath_snprintf (buf, 100, format.c_str(), digits, m_value);
+      int v;
+      if (f & (std::ios_base::floatfield) ) {
+         v = quadmath_snprintf (buf, sizeof buf, "%Qa", m_value);
+      } else {
+         v = quadmath_snprintf (buf, sizeof buf, format.c_str(), digits, m_value);
+      }
 
-      if((v < 0) || (v >= 99))
+      if((v < 0) || (v >= 127))
       {
          int v_max = v;
+         boost::scoped_array<char> buf2;
          buf2.reset(new char[v+3]);
          v = quadmath_snprintf (&buf2[0], v_max + 3, format.c_str(), digits, m_value);
          if(v >= v_max + 3)

--- a/include/boost/multiprecision/float128.hpp
+++ b/include/boost/multiprecision/float128.hpp
@@ -283,7 +283,7 @@ public:
          format += "g";
 
       int v;
-      if (f & (std::ios_base::floatfield) ) {
+      if ((f & std::ios_base::scientific) && (f & std::ios_base::fixed) ) {
          v = quadmath_snprintf (buf, sizeof buf, "%Qa", m_value);
       } else {
          v = quadmath_snprintf (buf, sizeof buf, format.c_str(), digits, m_value);

--- a/test/test_float_io.cpp
+++ b/test/test_float_io.cpp
@@ -300,6 +300,32 @@ void test_round_trip()
    }
 }
 
+#ifdef TEST_FLOAT128
+void test_hexadecimal_floating_point()
+{
+   using boost::multiprecision::float128;
+
+   float128 x = 0x1p+0Q;
+
+   std::string s = x.str(0, std::ios_base::fmtflags(std::ios_base::fixed | std::ios_base::scientific));
+   BOOST_CHECK_EQUAL(s, "0x1p+0");
+
+   s = x.str(0, std::ios_base::fmtflags(std::ios_base::floatfield));
+   BOOST_CHECK_EQUAL(s, "0x1p+0");
+
+   x = -1;
+   s = x.str(0, std::ios_base::fmtflags(std::ios_base::floatfield));
+   BOOST_CHECK_EQUAL(s, "-0x1p+0");
+
+   // hexadecimal representation of pi; test a round trip:
+   float128 pi1 = 0x1.921fb54442d18469898cc51701b8p+1Q;
+   s = pi1.str(0, std::ios_base::fmtflags(std::ios_base::floatfield));
+   float128 pi2{s};
+   BOOST_CHECK_EQUAL(pi1, pi2);
+
+}
+#endif
+
 int main()
 {
 #ifdef TEST_MPFR_50
@@ -336,6 +362,7 @@ int main()
 #endif
 #ifdef TEST_FLOAT128
    test<boost::multiprecision::float128>();
+   test_hexadecimal_floating_point();
 #ifndef BOOST_INTEL
    test_round_trip<boost::multiprecision::float128>();
 #endif

--- a/test/test_float_io.cpp
+++ b/test/test_float_io.cpp
@@ -320,7 +320,7 @@ void test_hexadecimal_floating_point()
    // hexadecimal representation of pi; test a round trip:
    float128 pi1 = 0x1.921fb54442d18469898cc51701b8p+1Q;
    s = pi1.str(0, std::ios_base::fmtflags(std::ios_base::floatfield));
-   float128 pi2{s};
+   float128 pi2(s);
    BOOST_CHECK_EQUAL(pi1, pi2);
 
 }


### PR DESCRIPTION
… flag floatfield is set [CI SKIP]

1) The fmtflag for hexfloat should be tested with

f & (floatfield)

Not semantically precise, but ok.

http://www.cplusplus.com/reference/ios/hexfloat/

https://en.cppreference.com/w/cpp/io/ios_base/fmtflags

2) This has been implemented in quadmath:

See: 
https://gcc.gnu.org/onlinedocs/libquadmath.pdf

page 10, which is the reference I used. I also increased the buffer size to match quadmath's documentation.

The C++ standard says that you should ignore the 'digits' requested when printing as hexadecimal, which is what this does.

3) I didn't see any print tests, so I just wrote a little MWE:

```cpp
#include <iostream>
#include <boost/multiprecision/float128.hpp>
#include <boost/math/constants/constants.hpp>

using boost::multiprecision::float128;
using boost::math::constants::pi;

int main()
{
    std::cout << pi<float128>() << "\n";
    std::cout << std::hexfloat;
    std::cout << pi<float128>() << "\n";
}
```

I would of course be glad to add a test for this; do you have any print tests?

4) There are two paths for the .str() member of float128. I don't know how to test the other path since all my compilers hit the first path. But I believe this is an improvement on the status quo nonetheless.

