### PR TITLE
Don't construct stringstream multiple times

### DIFF
--- a/include/boost/multiprecision/cpp_dec_float.hpp
+++ b/include/boost/multiprecision/cpp_dec_float.hpp
@@ -1802,17 +1802,16 @@ std::string cpp_dec_float<Digits10, ExponentType, Allocator>::str(boost::intmax_
    // Extract the remaining digits from cpp_dec_float<Digits10, ExponentType, Allocator> after the decimal point.
    str = boost::lexical_cast<std::string>(data[0]);
 
+   std::stringstream ss;
    // Extract all of the digits from cpp_dec_float<Digits10, ExponentType, Allocator>, beginning with the first data element.
    for(std::size_t i = static_cast<std::size_t>(1u); i < number_of_elements; i++)
    {
-      std::stringstream ss;
-
       ss << std::setw(static_cast<std::streamsize>(cpp_dec_float_elem_digits10))
          << std::setfill(static_cast<char>('0'))
          << data[i];
 
-      str += ss.str();
    }
+   str += ss.str();
 
    bool have_leading_zeros = false;
 


### PR DESCRIPTION
It's inefficient to construct the stream object for each element in the array