### PR TITLE
Add basic CMake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,36 @@
+# Copyright 2019 Sam Day
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+#
+# NOTE: CMake support for Boost.multiprecision is currently experimental at best
+#       and the interface is likely to change in the future
+
+cmake_minimum_required(VERSION 3.5)
+project(BoostMultiprecision LANGUAGES CXX)
+
+add_library(boost_multiprecision INTERFACE)
+add_library(Boost::multiprecision ALIAS boost_multiprecision)
+
+target_include_directories(boost_multiprecision INTERFACE include)
+
+target_link_libraries(boost_multiprecision
+        INTERFACE
+        Boost::array
+        Boost::assert
+        Boost::config
+        Boost::container_hash
+        Boost::core
+        Boost::functional
+        Boost::integer
+        Boost::lexical_cast
+        Boost::math
+        Boost::mpl
+        Boost::predef
+        Boost::random
+        Boost::rational
+        Boost::smart_ptr
+        Boost::static_assert
+        Boost::throw_exception
+        Boost::type_traits
+        Boost::utility
+        )


### PR DESCRIPTION
Just directly ripping off the work I've noticed @Mike-Devel doing across a bunch of Boost modules.

I determined the list of dependencies by grepping for `#include` directives. I don't know this library very well, so let me know if any of the dependencies don't make sense.

This PR depends on:

 * [functional](https://github.com/boostorg/functional/pull/11)
 * [lexical_cast](https://github.com/boostorg/lexical_cast/pull/26)
 * [math](https://github.com/boostorg/math/pull/199) (cyclic!)
 * [random](https://github.com/boostorg/random/pull/55) (cyclic!)
