### PR TITLE
Initial clang_format-based reformat #137

### DIFF
--- a/include/boost/multiprecision/concepts/mp_number_archetypes.hpp
+++ b/include/boost/multiprecision/concepts/mp_number_archetypes.hpp
@@ -6,67 +6,67 @@
 #ifndef BOOST_MATH_CONCEPTS_ER_HPP
 #define BOOST_MATH_CONCEPTS_ER_HPP
 
-#include <iostream>
-#include <sstream>
-#include <iomanip>
-#include <cmath>
+#include <boost/container_hash/hash.hpp>
 #include <boost/cstdint.hpp>
-#include <boost/multiprecision/number.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/mpl/list.hpp>
-#include <boost/container_hash/hash.hpp>
+#include <boost/multiprecision/number.hpp>
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
 
-namespace boost{
-namespace multiprecision{
-namespace concepts{
+namespace boost {
+namespace multiprecision {
+namespace concepts {
 
 #ifdef BOOST_MSVC
 #pragma warning(push)
-#pragma warning(disable:4244)
+#pragma warning(disable : 4244)
 #endif
 
 struct number_backend_float_architype
 {
-   typedef mpl::list<boost::long_long_type>                 signed_types;
-   typedef mpl::list<boost::ulong_long_type>        unsigned_types;
-   typedef mpl::list<long double>               float_types;
-   typedef int                                  exponent_type;
+   typedef mpl::list<boost::long_long_type>  signed_types;
+   typedef mpl::list<boost::ulong_long_type> unsigned_types;
+   typedef mpl::list<long double>            float_types;
+   typedef int                               exponent_type;
 
    number_backend_float_architype()
    {
       m_value = 0;
       std::cout << "Default construct" << std::endl;
    }
-   number_backend_float_architype(const number_backend_float_architype& o)
+   number_backend_float_architype(const number_backend_float_architype &o)
    {
       std::cout << "Copy construct" << std::endl;
       m_value = o.m_value;
    }
-   number_backend_float_architype& operator = (const number_backend_float_architype& o)
+   number_backend_float_architype &operator=(const number_backend_float_architype &o)
    {
       m_value = o.m_value;
       std::cout << "Assignment (" << m_value << ")" << std::endl;
       return *this;
    }
-   number_backend_float_architype& operator = (boost::ulong_long_type i)
+   number_backend_float_architype &operator=(boost::ulong_long_type i)
    {
       m_value = i;
       std::cout << "UInt Assignment (" << i << ")" << std::endl;
       return *this;
    }
-   number_backend_float_architype& operator = (boost::long_long_type i)
+   number_backend_float_architype &operator=(boost::long_long_type i)
    {
       m_value = i;
       std::cout << "Int Assignment (" << i << ")" << std::endl;
       return *this;
    }
-   number_backend_float_architype& operator = (long double d)
+   number_backend_float_architype &operator=(long double d)
    {
       m_value = d;
       std::cout << "long double Assignment (" << d << ")" << std::endl;
       return *this;
    }
-   number_backend_float_architype& operator = (const char* s)
+   number_backend_float_architype &operator=(const char *s)
    {
 #ifndef BOOST_NO_EXCEPTIONS
       try
@@ -75,7 +75,7 @@ struct number_backend_float_architype
          m_value = boost::lexical_cast<long double>(s);
 #ifndef BOOST_NO_EXCEPTIONS
       }
-      catch(const std::exception&)
+      catch (const std::exception &)
       {
          BOOST_THROW_EXCEPTION(std::runtime_error(std::string("Unable to parse input string: \"") + s + std::string("\" as a valid floating point number.")));
       }
@@ -83,24 +83,24 @@ struct number_backend_float_architype
       std::cout << "const char* Assignment (" << s << ")" << std::endl;
       return *this;
    }
-   void swap(number_backend_float_architype& o)
+   void swap(number_backend_float_architype &o)
    {
       std::cout << "Swapping (" << m_value << " with " << o.m_value << ")" << std::endl;
       std::swap(m_value, o.m_value);
    }
-   std::string str(std::streamsize digits, std::ios_base::fmtflags f)const
+   std::string str(std::streamsize digits, std::ios_base::fmtflags f) const
    {
       std::stringstream ss;
       ss.flags(f);
-      if(digits)
+      if (digits)
          ss.precision(digits);
       else
          ss.precision(std::numeric_limits<long double>::digits10 + 3);
-      boost::intmax_t i = m_value;
+      boost::intmax_t  i = m_value;
       boost::uintmax_t u = m_value;
-      if(!(f & std::ios_base::scientific) && m_value == i)
+      if (!(f & std::ios_base::scientific) && m_value == i)
          ss << i;
-      else if(!(f & std::ios_base::scientific) && m_value == u)
+      else if (!(f & std::ios_base::scientific) && m_value == u)
          ss << u;
       else
          ss << m_value;
@@ -113,22 +113,22 @@ struct number_backend_float_architype
       std::cout << "Negating (" << m_value << ")" << std::endl;
       m_value = -m_value;
    }
-   int compare(const number_backend_float_architype& o)const
+   int compare(const number_backend_float_architype &o) const
    {
       std::cout << "Comparison" << std::endl;
       return m_value > o.m_value ? 1 : (m_value < o.m_value ? -1 : 0);
    }
-   int compare(boost::long_long_type i)const
+   int compare(boost::long_long_type i) const
    {
       std::cout << "Comparison with int" << std::endl;
       return m_value > i ? 1 : (m_value < i ? -1 : 0);
    }
-   int compare(boost::ulong_long_type i)const
+   int compare(boost::ulong_long_type i) const
    {
       std::cout << "Comparison with unsigned" << std::endl;
       return m_value > i ? 1 : (m_value < i ? -1 : 0);
    }
-   int compare(long double d)const
+   int compare(long double d) const
    {
       std::cout << "Comparison with long double" << std::endl;
       return m_value > d ? 1 : (m_value < d ? -1 : 0);
@@ -136,71 +136,71 @@ struct number_backend_float_architype
    long double m_value;
 };
 
-inline void eval_add(number_backend_float_architype& result, const number_backend_float_architype& o)
+inline void eval_add(number_backend_float_architype &result, const number_backend_float_architype &o)
 {
    std::cout << "Addition (" << result.m_value << " += " << o.m_value << ")" << std::endl;
    result.m_value += o.m_value;
 }
-inline void eval_subtract(number_backend_float_architype& result, const number_backend_float_architype& o)
+inline void eval_subtract(number_backend_float_architype &result, const number_backend_float_architype &o)
 {
    std::cout << "Subtraction (" << result.m_value << " -= " << o.m_value << ")" << std::endl;
    result.m_value -= o.m_value;
 }
-inline void eval_multiply(number_backend_float_architype& result, const number_backend_float_architype& o)
+inline void eval_multiply(number_backend_float_architype &result, const number_backend_float_architype &o)
 {
    std::cout << "Multiplication (" << result.m_value << " *= " << o.m_value << ")" << std::endl;
    result.m_value *= o.m_value;
 }
-inline void eval_divide(number_backend_float_architype& result, const number_backend_float_architype& o)
+inline void eval_divide(number_backend_float_architype &result, const number_backend_float_architype &o)
 {
    std::cout << "Division (" << result.m_value << " /= " << o.m_value << ")" << std::endl;
    result.m_value /= o.m_value;
 }
 
-inline void eval_convert_to(boost::ulong_long_type* result, const number_backend_float_architype& val)
+inline void eval_convert_to(boost::ulong_long_type *result, const number_backend_float_architype &val)
 {
    *result = static_cast<boost::ulong_long_type>(val.m_value);
 }
-inline void eval_convert_to(boost::long_long_type* result, const number_backend_float_architype& val)
+inline void eval_convert_to(boost::long_long_type *result, const number_backend_float_architype &val)
 {
    *result = static_cast<boost::long_long_type>(val.m_value);
 }
-inline void eval_convert_to(long double* result, number_backend_float_architype& val)
+inline void eval_convert_to(long double *result, number_backend_float_architype &val)
 {
    *result = val.m_value;
 }
 
-inline void eval_frexp(number_backend_float_architype& result, const number_backend_float_architype& arg, int* exp)
+inline void eval_frexp(number_backend_float_architype &result, const number_backend_float_architype &arg, int *exp)
 {
    result = std::frexp(arg.m_value, exp);
 }
 
-inline void eval_ldexp(number_backend_float_architype& result, const number_backend_float_architype& arg, int exp)
+inline void eval_ldexp(number_backend_float_architype &result, const number_backend_float_architype &arg, int exp)
 {
    result = std::ldexp(arg.m_value, exp);
 }
 
-inline void eval_floor(number_backend_float_architype& result, const number_backend_float_architype& arg)
+inline void eval_floor(number_backend_float_architype &result, const number_backend_float_architype &arg)
 {
    result = std::floor(arg.m_value);
 }
 
-inline void eval_ceil(number_backend_float_architype& result, const number_backend_float_architype& arg)
+inline void eval_ceil(number_backend_float_architype &result, const number_backend_float_architype &arg)
 {
    result = std::ceil(arg.m_value);
 }
 
-inline void eval_sqrt(number_backend_float_architype& result, const number_backend_float_architype& arg)
+inline void eval_sqrt(number_backend_float_architype &result, const number_backend_float_architype &arg)
 {
    result = std::sqrt(arg.m_value);
 }
 
-inline int eval_fpclassify(const number_backend_float_architype& arg)
+inline int eval_fpclassify(const number_backend_float_architype &arg)
 {
    return (boost::math::fpclassify)(arg.m_value);
 }
 
-inline std::size_t hash_value(const number_backend_float_architype& v)
+inline std::size_t hash_value(const number_backend_float_architype &v)
 {
    boost::hash<long double> hasher;
    return hasher(v.m_value);
@@ -208,23 +208,25 @@ inline std::size_t hash_value(const number_backend_float_architype& v)
 
 typedef boost::multiprecision::number<number_backend_float_architype> mp_number_float_architype;
 
-} // namespace
+} // namespace concepts
 
-template<>
-struct number_category<concepts::number_backend_float_architype> : public mpl::int_<number_kind_floating_point>{};
+template <>
+struct number_category<concepts::number_backend_float_architype> : public mpl::int_<number_kind_floating_point>
+{};
 
-}} // namespaces
+}} // namespace boost::multiprecision
 
-namespace std{
+namespace std {
 
 template <boost::multiprecision::expression_template_option ExpressionTemplates>
 class numeric_limits<boost::multiprecision::number<boost::multiprecision::concepts::number_backend_float_architype, ExpressionTemplates> > : public std::numeric_limits<long double>
 {
-   typedef std::numeric_limits<long double> base_type;
+   typedef std::numeric_limits<long double>                                                                                    base_type;
    typedef boost::multiprecision::number<boost::multiprecision::concepts::number_backend_float_architype, ExpressionTemplates> number_type;
-public:
-   static number_type (min)() BOOST_NOEXCEPT { return (base_type::min)(); }
-   static number_type (max)() BOOST_NOEXCEPT { return (base_type::max)(); }
+
+ public:
+   static number_type(min)() BOOST_NOEXCEPT { return (base_type::min)(); }
+   static number_type(max)() BOOST_NOEXCEPT { return (base_type::max)(); }
    static number_type lowest() BOOST_NOEXCEPT { return -(max)(); }
    static number_type epsilon() BOOST_NOEXCEPT { return base_type::epsilon(); }
    static number_type round_error() BOOST_NOEXCEPT { return base_type::round_error(); }
@@ -234,7 +236,7 @@ public:
    static number_type denorm_min() BOOST_NOEXCEPT { return base_type::denorm_min(); }
 };
 
-}
+} // namespace std
 
 #ifdef BOOST_MSVC
 #pragma warning(pop)

--- a/include/boost/multiprecision/cpp_bin_float.hpp
+++ b/include/boost/multiprecision/cpp_bin_float.hpp
@@ -6,16 +6,16 @@
 #ifndef BOOST_MATH_CPP_BIN_FLOAT_HPP
 #define BOOST_MATH_CPP_BIN_FLOAT_HPP
 
-#include <boost/multiprecision/cpp_int.hpp>
-#include <boost/multiprecision/integer.hpp>
 #include <boost/math/special_functions/trunc.hpp>
+#include <boost/multiprecision/cpp_int.hpp>
 #include <boost/multiprecision/detail/float_string_cvt.hpp>
+#include <boost/multiprecision/integer.hpp>
 
 //
 // Some includes we need from Boost.Math, since we rely on that library to provide these functions:
 //
-#include <boost/math/special_functions/asinh.hpp>
 #include <boost/math/special_functions/acosh.hpp>
+#include <boost/math/special_functions/asinh.hpp>
 #include <boost/math/special_functions/atanh.hpp>
 #include <boost/math/special_functions/cbrt.hpp>
 #include <boost/math/special_functions/expm1.hpp>
@@ -25,20 +25,22 @@
 #include <quadmath.h>
 #endif
 
-namespace boost{ namespace multiprecision{ namespace backends{
+namespace boost {
+namespace multiprecision {
+namespace backends {
 
 enum digit_base_type
 {
-   digit_base_2 = 2, 
+   digit_base_2  = 2,
    digit_base_10 = 10
 };
 
 #ifdef BOOST_MSVC
 #pragma warning(push)
-#pragma warning(disable:4522 6326)  // multiple assignment operators specified, comparison of two constants
+#pragma warning(disable : 4522 6326) // multiple assignment operators specified, comparison of two constants
 #endif
 
-namespace detail{
+namespace detail {
 
 template <class U>
 inline typename enable_if_c<is_unsigned<U>::value, bool>::type is_negative(U) { return false; }
@@ -46,7 +48,7 @@ template <class S>
 inline typename disable_if_c<is_unsigned<S>::value, bool>::type is_negative(S s) { return s < 0; }
 
 template <class Float, int, bool = number_category<Float>::value == number_kind_floating_point>
-struct is_cpp_bin_float_implicitly_constructible_from_type 
+struct is_cpp_bin_float_implicitly_constructible_from_type
 {
    static const bool value = false;
 };
@@ -54,18 +56,15 @@ struct is_cpp_bin_float_implicitly_constructible_from_type
 template <class Float, int bit_count>
 struct is_cpp_bin_float_implicitly_constructible_from_type<Float, bit_count, true>
 {
-   static const bool value = (std::numeric_limits<Float>::digits <= (int)bit_count)
-      && (std::numeric_limits<Float>::radix == 2)
-      && std::numeric_limits<Float>::is_specialized
+   static const bool value = (std::numeric_limits<Float>::digits <= (int)bit_count) && (std::numeric_limits<Float>::radix == 2) && std::numeric_limits<Float>::is_specialized
 #ifdef BOOST_HAS_FLOAT128
-      && !boost::is_same<Float, __float128>::value
+                             && !boost::is_same<Float, __float128>::value
 #endif
-      && (is_floating_point<Float>::value || is_number<Float>::value)
-      ;
+                             && (is_floating_point<Float>::value || is_number<Float>::value);
 };
 
 template <class Float, int, bool = number_category<Float>::value == number_kind_floating_point>
-struct is_cpp_bin_float_explicitly_constructible_from_type 
+struct is_cpp_bin_float_explicitly_constructible_from_type
 {
    static const bool value = false;
 };
@@ -73,29 +72,27 @@ struct is_cpp_bin_float_explicitly_constructible_from_type
 template <class Float, int bit_count>
 struct is_cpp_bin_float_explicitly_constructible_from_type<Float, bit_count, true>
 {
-   static const bool value = (std::numeric_limits<Float>::digits > (int)bit_count)
-      && (std::numeric_limits<Float>::radix == 2)
-      && std::numeric_limits<Float>::is_specialized
+   static const bool value = (std::numeric_limits<Float>::digits > (int)bit_count) && (std::numeric_limits<Float>::radix == 2) && std::numeric_limits<Float>::is_specialized
 #ifdef BOOST_HAS_FLOAT128
-      && !boost::is_same<Float, __float128>::value
+                             && !boost::is_same<Float, __float128>::value
 #endif
-      ;
+       ;
 };
 
-}
+} // namespace detail
 
 template <unsigned Digits, digit_base_type DigitBase = digit_base_10, class Allocator = void, class Exponent = int, Exponent MinExponent = 0, Exponent MaxExponent = 0>
 class cpp_bin_float
 {
-public:
-   static const unsigned bit_count = DigitBase == digit_base_2 ? Digits : (Digits * 1000uL) / 301uL + (((Digits * 1000uL) % 301) ? 2u : 1u);
-   typedef cpp_int_backend<is_void<Allocator>::value ? bit_count : 0, bit_count, is_void<Allocator>::value ? unsigned_magnitude : signed_magnitude, unchecked, Allocator> rep_type;
+ public:
+   static const unsigned                                                                                                                                                          bit_count = DigitBase == digit_base_2 ? Digits : (Digits * 1000uL) / 301uL + (((Digits * 1000uL) % 301) ? 2u : 1u);
+   typedef cpp_int_backend<is_void<Allocator>::value ? bit_count : 0, bit_count, is_void<Allocator>::value ? unsigned_magnitude : signed_magnitude, unchecked, Allocator>         rep_type;
    typedef cpp_int_backend<is_void<Allocator>::value ? 2 * bit_count : 0, 2 * bit_count, is_void<Allocator>::value ? unsigned_magnitude : signed_magnitude, unchecked, Allocator> double_rep_type;
 
-   typedef typename rep_type::signed_types                        signed_types;
-   typedef typename rep_type::unsigned_types                      unsigned_types;
-   typedef boost::mpl::list<float, double, long double>           float_types;
-   typedef Exponent                                               exponent_type;
+   typedef typename rep_type::signed_types              signed_types;
+   typedef typename rep_type::unsigned_types            unsigned_types;
+   typedef boost::mpl::list<float, double, long double> float_types;
+   typedef Exponent                                     exponent_type;
 
    static const exponent_type max_exponent_limit = boost::integer_traits<exponent_type>::const_max - 2 * static_cast<exponent_type>(bit_count);
    static const exponent_type min_exponent_limit = boost::integer_traits<exponent_type>::const_min + 2 * static_cast<exponent_type>(bit_count);
@@ -108,101 +105,98 @@ public:
    static const exponent_type max_exponent = MaxExponent == 0 ? max_exponent_limit : MaxExponent;
    static const exponent_type min_exponent = MinExponent == 0 ? min_exponent_limit : MinExponent;
 
-   static const exponent_type exponent_zero = max_exponent + 1;
+   static const exponent_type exponent_zero     = max_exponent + 1;
    static const exponent_type exponent_infinity = max_exponent + 2;
-   static const exponent_type exponent_nan = max_exponent + 3;
+   static const exponent_type exponent_nan      = max_exponent + 3;
 
-private:
-
-   rep_type m_data;
+ private:
+   rep_type      m_data;
    exponent_type m_exponent;
-   bool m_sign;
-public:
+   bool          m_sign;
+
+ public:
    cpp_bin_float() BOOST_MP_NOEXCEPT_IF(noexcept(rep_type())) : m_data(), m_exponent(exponent_zero), m_sign(false) {}
 
-   cpp_bin_float(const cpp_bin_float &o) BOOST_MP_NOEXCEPT_IF(noexcept(rep_type(std::declval<const rep_type&>())))
-      : m_data(o.m_data), m_exponent(o.m_exponent), m_sign(o.m_sign) {}
+   cpp_bin_float(const cpp_bin_float &o) BOOST_MP_NOEXCEPT_IF(noexcept(rep_type(std::declval<const rep_type &>())))
+       : m_data(o.m_data), m_exponent(o.m_exponent), m_sign(o.m_sign) {}
 
    template <unsigned D, digit_base_type B, class A, class E, E MinE, E MaxE>
-   cpp_bin_float(const cpp_bin_float<D, B, A, E, MinE, MaxE> &o, typename boost::enable_if_c<(bit_count >= cpp_bin_float<D, B, A, E, MinE, MaxE>::bit_count)>::type const* = 0)
+   cpp_bin_float(const cpp_bin_float<D, B, A, E, MinE, MaxE> &o, typename boost::enable_if_c<(bit_count >= cpp_bin_float<D, B, A, E, MinE, MaxE>::bit_count)>::type const * = 0)
    {
       *this = o;
    }
    template <unsigned D, digit_base_type B, class A, class E, E MinE, E MaxE>
-   explicit cpp_bin_float(const cpp_bin_float<D, B, A, E, MinE, MaxE> &o, typename boost::disable_if_c<(bit_count >= cpp_bin_float<D, B, A, E, MinE, MaxE>::bit_count)>::type const* = 0)
-      : m_exponent(o.exponent()), m_sign(o.sign()) 
+   explicit cpp_bin_float(const cpp_bin_float<D, B, A, E, MinE, MaxE> &o, typename boost::disable_if_c<(bit_count >= cpp_bin_float<D, B, A, E, MinE, MaxE>::bit_count)>::type const * = 0)
+       : m_exponent(o.exponent()), m_sign(o.sign())
    {
       *this = o;
    }
    template <class Float>
-   cpp_bin_float(const Float& f, 
-      typename boost::enable_if_c<detail::is_cpp_bin_float_implicitly_constructible_from_type<Float, bit_count>::value>::type const* = 0)
-      : m_data(), m_exponent(0), m_sign(false)
+   cpp_bin_float(const Float &f,
+                 typename boost::enable_if_c<detail::is_cpp_bin_float_implicitly_constructible_from_type<Float, bit_count>::value>::type const * = 0)
+       : m_data(), m_exponent(0), m_sign(false)
    {
       this->assign_float(f);
    }
 
    template <class Float>
-   explicit cpp_bin_float(const Float& f,
-      typename boost::enable_if_c<detail::is_cpp_bin_float_explicitly_constructible_from_type<Float, bit_count>::value>::type const* = 0)
-      : m_data(), m_exponent(0), m_sign(false)
+   explicit cpp_bin_float(const Float &f,
+                          typename boost::enable_if_c<detail::is_cpp_bin_float_explicitly_constructible_from_type<Float, bit_count>::value>::type const * = 0)
+       : m_data(), m_exponent(0), m_sign(false)
    {
       this->assign_float(f);
    }
 #ifdef BOOST_HAS_FLOAT128
    template <class Float>
-   cpp_bin_float(const Float& f,
-      typename boost::enable_if_c<
-      boost::is_same<Float, __float128>::value
-      && ((int)bit_count >= 113)
-      >::type const* = 0)
-      : m_data(), m_exponent(0), m_sign(false)
+   cpp_bin_float(const Float &f,
+                 typename boost::enable_if_c<
+                     boost::is_same<Float, __float128>::value && ((int)bit_count >= 113)>::type const * = 0)
+       : m_data(), m_exponent(0), m_sign(false)
    {
       this->assign_float(f);
    }
    template <class Float>
-   explicit cpp_bin_float(const Float& f,
-      typename boost::enable_if_c<
-      boost::is_same<Float, __float128>::value
-      && ((int)bit_count < 113)
-      >::type const* = 0)
-      : m_data(), m_exponent(0), m_sign(false)
+   explicit cpp_bin_float(const Float &f,
+                          typename boost::enable_if_c<
+                              boost::is_same<Float, __float128>::value && ((int)bit_count < 113)>::type const * = 0)
+       : m_data(), m_exponent(0), m_sign(false)
    {
       this->assign_float(f);
    }
 #endif
-   cpp_bin_float& operator=(const cpp_bin_float &o) BOOST_MP_NOEXCEPT_IF(noexcept(std::declval<rep_type&>() = std::declval<const rep_type&>()))
+   cpp_bin_float &operator=(const cpp_bin_float &o) BOOST_MP_NOEXCEPT_IF(noexcept(std::declval<rep_type &>() = std::declval<const rep_type &>()))
    {
-      m_data = o.m_data;
+      m_data     = o.m_data;
       m_exponent = o.m_exponent;
-      m_sign = o.m_sign;
+      m_sign     = o.m_sign;
       return *this;
    }
 
    template <unsigned D, digit_base_type B, class A, class E, E MinE, E MaxE>
-   cpp_bin_float& operator=(const cpp_bin_float<D, B, A, E, MinE, MaxE> &f)
+   cpp_bin_float &operator=(const cpp_bin_float<D, B, A, E, MinE, MaxE> &f)
    {
-      switch(eval_fpclassify(f))
+      switch (eval_fpclassify(f))
       {
       case FP_ZERO:
-         m_data = limb_type(0);
-         m_sign = f.sign();
+         m_data     = limb_type(0);
+         m_sign     = f.sign();
          m_exponent = exponent_zero;
          break;
       case FP_NAN:
-         m_data = limb_type(0);
-         m_sign = false;
+         m_data     = limb_type(0);
+         m_sign     = false;
          m_exponent = exponent_nan;
-         break;;
+         break;
+         ;
       case FP_INFINITE:
-         m_data = limb_type(0);
-         m_sign = f.sign();
+         m_data     = limb_type(0);
+         m_sign     = f.sign();
          m_exponent = exponent_infinity;
          break;
       default:
          typename cpp_bin_float<D, B, A, E, MinE, MaxE>::rep_type b(f.bits());
          this->exponent() = f.exponent() + (E)bit_count - (E)cpp_bin_float<D, B, A, E, MinE, MaxE>::bit_count;
-         this->sign() = f.sign();
+         this->sign()     = f.sign();
          copy_and_round(*this, b);
       }
       return *this;
@@ -210,17 +204,19 @@ public:
 #ifdef BOOST_HAS_FLOAT128
    template <class Float>
    typename boost::enable_if_c<
-      (number_category<Float>::value == number_kind_floating_point)
-      //&& (std::numeric_limits<Float>::digits <= (int)bit_count)
-      && ((std::numeric_limits<Float>::radix == 2) || (boost::is_same<Float, __float128>::value)), cpp_bin_float&>::type 
-      operator=(const Float& f)
+       (number_category<Float>::value == number_kind_floating_point)
+           //&& (std::numeric_limits<Float>::digits <= (int)bit_count)
+           && ((std::numeric_limits<Float>::radix == 2) || (boost::is_same<Float, __float128>::value)),
+       cpp_bin_float &>::type
+   operator=(const Float &f)
 #else
    template <class Float>
    typename boost::enable_if_c<
-      (number_category<Float>::value == number_kind_floating_point)
-      //&& (std::numeric_limits<Float>::digits <= (int)bit_count)
-      && (std::numeric_limits<Float>::radix == 2), cpp_bin_float&>::type 
-      operator=(const Float& f)
+       (number_category<Float>::value == number_kind_floating_point)
+           //&& (std::numeric_limits<Float>::digits <= (int)bit_count)
+           && (std::numeric_limits<Float>::radix == 2),
+       cpp_bin_float &>::type
+   operator=(const Float &f)
 #endif
    {
       return assign_float(f);
@@ -228,32 +224,32 @@ public:
 
 #ifdef BOOST_HAS_FLOAT128
    template <class Float>
-   typename boost::enable_if_c<boost::is_same<Float, __float128>::value, cpp_bin_float& >::type assign_float(Float f)
+   typename boost::enable_if_c<boost::is_same<Float, __float128>::value, cpp_bin_float &>::type assign_float(Float f)
    {
       using default_ops::eval_add;
       typedef typename boost::multiprecision::detail::canonical<int, cpp_bin_float>::type bf_int_type;
-      if(f == 0)
+      if (f == 0)
       {
-         m_data = limb_type(0);
-         m_sign = (signbitq(f) > 0);
+         m_data     = limb_type(0);
+         m_sign     = (signbitq(f) > 0);
          m_exponent = exponent_zero;
          return *this;
       }
-      else if(isnanq(f))
+      else if (isnanq(f))
       {
-         m_data = limb_type(0);
-         m_sign = false;
+         m_data     = limb_type(0);
+         m_sign     = false;
          m_exponent = exponent_nan;
          return *this;
       }
-      else if(isinfq(f))
+      else if (isinfq(f))
       {
-         m_data = limb_type(0);
-         m_sign = (f < 0);
+         m_data     = limb_type(0);
+         m_sign     = (f < 0);
          m_exponent = exponent_infinity;
          return *this;
       }
-      if(f < 0)
+      if (f < 0)
       {
          *this = -f;
          this->negate();
@@ -261,14 +257,14 @@ public:
       }
 
       typedef typename mpl::front<unsigned_types>::type ui_type;
-      m_data = static_cast<ui_type>(0u);
-      m_sign = false;
+      m_data     = static_cast<ui_type>(0u);
+      m_sign     = false;
       m_exponent = 0;
 
       static const int bits = sizeof(int) * CHAR_BIT - 1;
-      int e;
+      int              e;
       f = frexpq(f, &e);
-      while(f)
+      while (f)
       {
          f = ldexpq(f, bits);
          e -= bits;
@@ -285,35 +281,35 @@ public:
 #endif
 #ifdef BOOST_HAS_FLOAT128
    template <class Float>
-   typename boost::enable_if_c<is_floating_point<Float>::value && !is_same<Float, __float128>::value, cpp_bin_float&>::type assign_float(Float f)
+   typename boost::enable_if_c<is_floating_point<Float>::value && !is_same<Float, __float128>::value, cpp_bin_float &>::type assign_float(Float f)
 #else
    template <class Float>
-   typename boost::enable_if_c<is_floating_point<Float>::value, cpp_bin_float&>::type assign_float(Float f)
+   typename boost::enable_if_c<is_floating_point<Float>::value, cpp_bin_float &>::type assign_float(Float f)
 #endif
    {
       BOOST_MATH_STD_USING
       using default_ops::eval_add;
       typedef typename boost::multiprecision::detail::canonical<int, cpp_bin_float>::type bf_int_type;
 
-      switch((boost::math::fpclassify)(f))
+      switch ((boost::math::fpclassify)(f))
       {
       case FP_ZERO:
-         m_data = limb_type(0);
-         m_sign = ((boost::math::signbit)(f) > 0);
+         m_data     = limb_type(0);
+         m_sign     = ((boost::math::signbit)(f) > 0);
          m_exponent = exponent_zero;
          return *this;
       case FP_NAN:
-         m_data = limb_type(0);
-         m_sign = false;
+         m_data     = limb_type(0);
+         m_sign     = false;
          m_exponent = exponent_nan;
          return *this;
       case FP_INFINITE:
-         m_data = limb_type(0);
-         m_sign = (f < 0);
+         m_data     = limb_type(0);
+         m_sign     = (f < 0);
          m_exponent = exponent_infinity;
          return *this;
       }
-      if(f < 0)
+      if (f < 0)
       {
          *this = -f;
          this->negate();
@@ -321,14 +317,14 @@ public:
       }
 
       typedef typename mpl::front<unsigned_types>::type ui_type;
-      m_data = static_cast<ui_type>(0u);
-      m_sign = false;
+      m_data     = static_cast<ui_type>(0u);
+      m_sign     = false;
       m_exponent = 0;
 
       static const int bits = sizeof(int) * CHAR_BIT - 1;
-      int e;
+      int              e;
       f = frexp(f, &e);
-      while(f)
+      while (f)
       {
          f = ldexp(f, bits);
          e -= bits;
@@ -349,39 +345,38 @@ public:
 
    template <class Float>
    typename boost::enable_if_c<
-      (number_category<Float>::value == number_kind_floating_point) 
-         && !boost::is_floating_point<Float>::value
-         && is_number<Float>::value, 
-      cpp_bin_float&>::type assign_float(Float f)
+       (number_category<Float>::value == number_kind_floating_point) && !boost::is_floating_point<Float>::value && is_number<Float>::value,
+       cpp_bin_float &>::type
+   assign_float(Float f)
    {
       BOOST_MATH_STD_USING
       using default_ops::eval_add;
-      using default_ops::eval_get_sign;
       using default_ops::eval_convert_to;
+      using default_ops::eval_get_sign;
       using default_ops::eval_subtract;
 
-      typedef typename boost::multiprecision::detail::canonical<int, Float>::type f_int_type;
+      typedef typename boost::multiprecision::detail::canonical<int, Float>::type         f_int_type;
       typedef typename boost::multiprecision::detail::canonical<int, cpp_bin_float>::type bf_int_type;
 
-      switch(eval_fpclassify(f))
+      switch (eval_fpclassify(f))
       {
       case FP_ZERO:
-         m_data = limb_type(0);
-         m_sign = ((boost::math::signbit)(f) > 0);
+         m_data     = limb_type(0);
+         m_sign     = ((boost::math::signbit)(f) > 0);
          m_exponent = exponent_zero;
          return *this;
       case FP_NAN:
-         m_data = limb_type(0);
-         m_sign = false;
+         m_data     = limb_type(0);
+         m_sign     = false;
          m_exponent = exponent_nan;
          return *this;
       case FP_INFINITE:
-         m_data = limb_type(0);
-         m_sign = (f < 0);
+         m_data     = limb_type(0);
+         m_sign     = (f < 0);
          m_exponent = exponent_infinity;
          return *this;
       }
-      if(eval_get_sign(f) < 0)
+      if (eval_get_sign(f) < 0)
       {
          f.negate();
          *this = f;
@@ -390,14 +385,14 @@ public:
       }
 
       typedef typename mpl::front<unsigned_types>::type ui_type;
-      m_data = static_cast<ui_type>(0u);
-      m_sign = false;
+      m_data     = static_cast<ui_type>(0u);
+      m_sign     = false;
       m_exponent = 0;
 
       static const int bits = sizeof(int) * CHAR_BIT - 1;
-      int e;
+      int              e;
       eval_frexp(f, f, &e);
-      while(eval_get_sign(f) != 0)
+      while (eval_get_sign(f) != 0)
       {
          eval_ldexp(f, f, bits);
          e -= bits;
@@ -408,56 +403,56 @@ public:
          eval_add(*this, static_cast<bf_int_type>(ipart));
       }
       m_exponent += e;
-      if(m_exponent > max_exponent)
+      if (m_exponent > max_exponent)
          m_exponent = exponent_infinity;
-      if(m_exponent < min_exponent)
+      if (m_exponent < min_exponent)
       {
-         m_data = limb_type(0u);
+         m_data     = limb_type(0u);
          m_exponent = exponent_zero;
-         m_sign = ((boost::math::signbit)(f) > 0);
+         m_sign     = ((boost::math::signbit)(f) > 0);
       }
-      else if(eval_get_sign(m_data) == 0)
+      else if (eval_get_sign(m_data) == 0)
       {
          m_exponent = exponent_zero;
-         m_sign = ((boost::math::signbit)(f) > 0);
+         m_sign     = ((boost::math::signbit)(f) > 0);
       }
       return *this;
    }
 
    template <class I>
-   typename boost::enable_if<is_integral<I>, cpp_bin_float&>::type operator=(const I& i)
+   typename boost::enable_if<is_integral<I>, cpp_bin_float &>::type operator=(const I &i)
    {
       using default_ops::eval_bit_test;
-      if(!i)
+      if (!i)
       {
-         m_data = static_cast<limb_type>(0);
+         m_data     = static_cast<limb_type>(0);
          m_exponent = exponent_zero;
-         m_sign = false;
+         m_sign     = false;
       }
       else
       {
-         typedef typename make_unsigned<I>::type ui_type;
-         ui_type fi = static_cast<ui_type>(boost::multiprecision::detail::unsigned_abs(i));
+         typedef typename make_unsigned<I>::type                                            ui_type;
+         ui_type                                                                            fi = static_cast<ui_type>(boost::multiprecision::detail::unsigned_abs(i));
          typedef typename boost::multiprecision::detail::canonical<ui_type, rep_type>::type ar_type;
-         m_data = static_cast<ar_type>(fi);
+         m_data         = static_cast<ar_type>(fi);
          unsigned shift = msb(fi);
-         if(shift >= bit_count)
+         if (shift >= bit_count)
          {
             m_exponent = static_cast<Exponent>(shift);
-            m_data = static_cast<ar_type>(fi >> (shift + 1 - bit_count));
+            m_data     = static_cast<ar_type>(fi >> (shift + 1 - bit_count));
          }
          else
          {
             m_exponent = static_cast<Exponent>(shift);
             eval_left_shift(m_data, bit_count - shift - 1);
          }
-         BOOST_ASSERT(eval_bit_test(m_data, bit_count-1));
+         BOOST_ASSERT(eval_bit_test(m_data, bit_count - 1));
          m_sign = detail::is_negative(i);
       }
       return *this;
    }
 
-   cpp_bin_float& operator=(const char *s);
+   cpp_bin_float &operator=(const char *s);
 
    void swap(cpp_bin_float &o) BOOST_NOEXCEPT
    {
@@ -470,51 +465,51 @@ public:
 
    void negate()
    {
-      if(m_exponent != exponent_nan)
+      if (m_exponent != exponent_nan)
          m_sign = !m_sign;
    }
 
    int compare(const cpp_bin_float &o) const BOOST_NOEXCEPT
    {
-      if(m_sign != o.m_sign)
+      if (m_sign != o.m_sign)
          return (m_exponent == exponent_zero) && (m_exponent == o.m_exponent) ? 0 : m_sign ? -1 : 1;
       int result;
-      if(m_exponent == exponent_nan)
+      if (m_exponent == exponent_nan)
          return -1;
-      else if(m_exponent != o.m_exponent)
+      else if (m_exponent != o.m_exponent)
       {
-         if(m_exponent == exponent_zero)
+         if (m_exponent == exponent_zero)
             result = -1;
-         else if(o.m_exponent == exponent_zero)
+         else if (o.m_exponent == exponent_zero)
             result = 1;
-         else 
+         else
             result = m_exponent > o.m_exponent ? 1 : -1;
       }
       else
          result = m_data.compare(o.m_data);
-      if(m_sign)
+      if (m_sign)
          result = -result;
       return result;
    }
    template <class A>
-   int compare(const A& o) const BOOST_NOEXCEPT
+   int compare(const A &o) const BOOST_NOEXCEPT
    {
       cpp_bin_float b;
       b = o;
       return compare(b);
    }
 
-   rep_type& bits() { return m_data; }
-   const rep_type& bits()const { return m_data; }
-   exponent_type& exponent() { return m_exponent; }
-   const exponent_type& exponent()const { return m_exponent; }
-   bool& sign() { return m_sign; }
-   const bool& sign()const { return m_sign; }
-   void check_invariants()
+   rep_type &           bits() { return m_data; }
+   const rep_type &     bits() const { return m_data; }
+   exponent_type &      exponent() { return m_exponent; }
+   const exponent_type &exponent() const { return m_exponent; }
+   bool &               sign() { return m_sign; }
+   const bool &         sign() const { return m_sign; }
+   void                 check_invariants()
    {
       using default_ops::eval_bit_test;
       using default_ops::eval_is_zero;
-      if((m_exponent <= max_exponent) && (m_exponent >= min_exponent))
+      if ((m_exponent <= max_exponent) && (m_exponent >= min_exponent))
       {
          BOOST_ASSERT(eval_bit_test(m_data, bit_count - 1));
       }
@@ -525,12 +520,12 @@ public:
          BOOST_ASSERT(eval_is_zero(m_data));
       }
    }
-   template<class Archive>
-   void serialize(Archive & ar, const unsigned int /*version*/)
+   template <class Archive>
+   void serialize(Archive &ar, const unsigned int /*version*/)
    {
-      ar & boost::serialization::make_nvp("data", m_data);
-      ar & boost::serialization::make_nvp("exponent", m_exponent);
-      ar & boost::serialization::make_nvp("sign", m_sign);
+      ar &boost::serialization::make_nvp("data", m_data);
+      ar &boost::serialization::make_nvp("exponent", m_exponent);
+      ar &boost::serialization::make_nvp("sign", m_sign);
    }
 };
 
@@ -543,24 +538,24 @@ inline void copy_and_round(cpp_bin_float<Digits, DigitBase, Allocator, Exponent,
 {
    // Precondition: exponent of res must have been set before this function is called
    // as we may need to adjust it based on how many bits_to_keep in arg are set.
-   using default_ops::eval_msb;
-   using default_ops::eval_lsb;
-   using default_ops::eval_left_shift;
    using default_ops::eval_bit_test;
-   using default_ops::eval_right_shift;
-   using default_ops::eval_increment;
    using default_ops::eval_get_sign;
+   using default_ops::eval_increment;
+   using default_ops::eval_left_shift;
+   using default_ops::eval_lsb;
+   using default_ops::eval_msb;
+   using default_ops::eval_right_shift;
 
    // cancellation may have resulted in arg being all zeros:
-   if(eval_get_sign(arg) == 0)
+   if (eval_get_sign(arg) == 0)
    {
       res.exponent() = cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero;
-      res.sign() = false;
-      res.bits() = static_cast<limb_type>(0u);
+      res.sign()     = false;
+      res.bits()     = static_cast<limb_type>(0u);
       return;
    }
    int msb = eval_msb(arg);
-   if(static_cast<int>(bits_to_keep) > msb + 1)
+   if (static_cast<int>(bits_to_keep) > msb + 1)
    {
       // Must have had cancellation in subtraction,
       // or be converting from a narrower type, so shift left:
@@ -568,27 +563,27 @@ inline void copy_and_round(cpp_bin_float<Digits, DigitBase, Allocator, Exponent,
       eval_left_shift(res.bits(), bits_to_keep - msb - 1);
       res.exponent() -= static_cast<Exponent>(bits_to_keep - msb - 1);
    }
-   else if(static_cast<int>(bits_to_keep) < msb + 1)
+   else if (static_cast<int>(bits_to_keep) < msb + 1)
    {
-      // We have more bits_to_keep than we need, so round as required, 
+      // We have more bits_to_keep than we need, so round as required,
       // first get the rounding bit:
       bool roundup = eval_bit_test(arg, msb - bits_to_keep);
       // Then check for a tie:
-      if(roundup && (msb - bits_to_keep == (int)eval_lsb(arg)))
+      if (roundup && (msb - bits_to_keep == (int)eval_lsb(arg)))
       {
          // Ties round towards even:
-         if(!eval_bit_test(arg, msb - bits_to_keep + 1))
+         if (!eval_bit_test(arg, msb - bits_to_keep + 1))
             roundup = false;
       }
       // Shift off the bits_to_keep we don't need:
       eval_right_shift(arg, msb - bits_to_keep + 1);
       res.exponent() += static_cast<Exponent>(msb - bits_to_keep + 1);
-      if(roundup)
+      if (roundup)
       {
          eval_increment(arg);
-         if(bits_to_keep)
+         if (bits_to_keep)
          {
-            if(eval_bit_test(arg, bits_to_keep))
+            if (eval_bit_test(arg, bits_to_keep))
             {
                // This happens very very rairly, all the bits left after
                // truncation must be 1's and we're rounding up an order of magnitude:
@@ -603,7 +598,7 @@ inline void copy_and_round(cpp_bin_float<Digits, DigitBase, Allocator, Exponent,
             ++bits_to_keep;
          }
       }
-      if(bits_to_keep != cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count)
+      if (bits_to_keep != cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count)
       {
          // Normalize result when we're rounding to fewer bits than we can hold, only happens in conversions
          // to narrower types:
@@ -616,7 +611,7 @@ inline void copy_and_round(cpp_bin_float<Digits, DigitBase, Allocator, Exponent,
    {
       res.bits() = arg;
    }
-   if(!bits_to_keep && !res.bits().limbs()[0])
+   if (!bits_to_keep && !res.bits().limbs()[0])
    {
       // We're keeping zero bits and did not round up, so result is zero:
       res.exponent() = cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero;
@@ -625,28 +620,28 @@ inline void copy_and_round(cpp_bin_float<Digits, DigitBase, Allocator, Exponent,
    // Result must be normalized:
    BOOST_ASSERT(((int)eval_msb(res.bits()) == cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - 1));
 
-   if(res.exponent() > cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::max_exponent)
+   if (res.exponent() > cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::max_exponent)
    {
       // Overflow:
       res.exponent() = cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_infinity;
-      res.bits() = static_cast<limb_type>(0u);
+      res.bits()     = static_cast<limb_type>(0u);
    }
-   else if(res.exponent() < cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::min_exponent)
+   else if (res.exponent() < cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::min_exponent)
    {
       // Underflow:
       res.exponent() = cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero;
-      res.bits() = static_cast<limb_type>(0u);
+      res.bits()     = static_cast<limb_type>(0u);
    }
 }
 
 template <unsigned Digits, digit_base_type DigitBase, class Allocator, class Exponent, Exponent MinE, Exponent MaxE>
 inline void do_eval_add(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &res, const cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &a, const cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &b)
 {
-   if(a.exponent() < b.exponent())
+   if (a.exponent() < b.exponent())
    {
       bool s = a.sign();
       do_eval_add(res, b, a);
-      if(res.sign() != s)
+      if (res.sign() != s)
          res.negate();
       return;
    }
@@ -659,17 +654,17 @@ inline void do_eval_add(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, Mi
    typename cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::double_rep_type dt;
 
    // Special cases first:
-   switch(a.exponent())
+   switch (a.exponent())
    {
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero:
    {
-      bool s = a.sign();
-      res = b;
+      bool s     = a.sign();
+      res        = b;
       res.sign() = s;
       return;
    }
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_infinity:
-      if(b.exponent() == cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_nan)
+      if (b.exponent() == cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_nan)
          res = b;
       else
          res = a;
@@ -678,14 +673,14 @@ inline void do_eval_add(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, Mi
       res = a;
       return; // result is still a NaN.
    }
-   switch(b.exponent())
+   switch (b.exponent())
    {
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero:
       res = a;
       return;
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_infinity:
       res = b;
-      if(res.sign())
+      if (res.sign())
          res.negate();
       return; // result is infinite.
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_nan:
@@ -696,8 +691,8 @@ inline void do_eval_add(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, Mi
    BOOST_STATIC_ASSERT(boost::integer_traits<exponent_type>::const_max - cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count > cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::max_exponent);
 
    bool s = a.sign();
-   dt = a.bits();
-   if(a.exponent() > (int)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count + b.exponent())
+   dt     = a.bits();
+   if (a.exponent() > (int)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count + b.exponent())
    {
       res.exponent() = a.exponent();
    }
@@ -709,40 +704,40 @@ inline void do_eval_add(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, Mi
       res.exponent() = a.exponent() - e_diff;
       eval_add(dt, b.bits());
    }
-   
+
    copy_and_round(res, dt);
    res.check_invariants();
-   if(res.sign() != s)
+   if (res.sign() != s)
       res.negate();
 }
 
 template <unsigned Digits, digit_base_type DigitBase, class Allocator, class Exponent, Exponent MinE, Exponent MaxE>
 inline void do_eval_subtract(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &res, const cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &a, const cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &b)
 {
-   using default_ops::eval_subtract;
    using default_ops::eval_bit_test;
    using default_ops::eval_decrement;
+   using default_ops::eval_subtract;
 
    typename cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::double_rep_type dt;
-   
+
    // Special cases first:
-   switch(a.exponent())
+   switch (a.exponent())
    {
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero:
-      if(b.exponent() == cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_nan)
+      if (b.exponent() == cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_nan)
          res = std::numeric_limits<number<cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> > >::quiet_NaN().backend();
       else
       {
          bool s = a.sign();
-         res = b;
-         if(res.exponent() == cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero)
+         res    = b;
+         if (res.exponent() == cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero)
             res.sign() = false;
-         else if(res.sign() == s)
+         else if (res.sign() == s)
             res.negate();
       }
       return;
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_infinity:
-      if((b.exponent() == cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_nan) || (b.exponent() == cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_infinity))
+      if ((b.exponent() == cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_nan) || (b.exponent() == cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_infinity))
          res = std::numeric_limits<number<cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> > >::quiet_NaN().backend();
       else
          res = a;
@@ -751,15 +746,15 @@ inline void do_eval_subtract(cpp_bin_float<Digits, DigitBase, Allocator, Exponen
       res = a;
       return; // result is still a NaN.
    }
-   switch(b.exponent())
+   switch (b.exponent())
    {
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero:
       res = a;
       return;
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_infinity:
       res.exponent() = cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_infinity;
-      res.sign() = !a.sign();
-      res.bits() = static_cast<limb_type>(0u);
+      res.sign()     = !a.sign();
+      res.bits()     = static_cast<limb_type>(0u);
       return; // result is a NaN.
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_nan:
       res = b;
@@ -767,19 +762,19 @@ inline void do_eval_subtract(cpp_bin_float<Digits, DigitBase, Allocator, Exponen
    }
 
    bool s = a.sign();
-   if((a.exponent() > b.exponent()) || ((a.exponent() == b.exponent()) && a.bits().compare(b.bits()) >= 0))
+   if ((a.exponent() > b.exponent()) || ((a.exponent() == b.exponent()) && a.bits().compare(b.bits()) >= 0))
    {
       dt = a.bits();
-      if(a.exponent() <= (int)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count + b.exponent())
+      if (a.exponent() <= (int)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count + b.exponent())
       {
          typename cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_type e_diff = a.exponent() - b.exponent();
          eval_left_shift(dt, e_diff);
          res.exponent() = a.exponent() - e_diff;
          eval_subtract(dt, b.bits());
       }
-      else if(a.exponent() == (int)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count + b.exponent() + 1)
+      else if (a.exponent() == (int)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count + b.exponent() + 1)
       {
-         if(eval_lsb(b.bits()) != cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - 1)
+         if (eval_lsb(b.bits()) != cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - 1)
          {
             eval_left_shift(dt, 1);
             eval_decrement(dt);
@@ -794,16 +789,16 @@ inline void do_eval_subtract(cpp_bin_float<Digits, DigitBase, Allocator, Exponen
    else
    {
       dt = b.bits();
-      if(b.exponent() <= (int)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count + a.exponent())
+      if (b.exponent() <= (int)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count + a.exponent())
       {
          typename cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_type e_diff = a.exponent() - b.exponent();
          eval_left_shift(dt, -e_diff);
          res.exponent() = b.exponent() + e_diff;
          eval_subtract(dt, a.bits());
       }
-      else if(b.exponent() == (int)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count + a.exponent() + 1)
+      else if (b.exponent() == (int)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count + a.exponent() + 1)
       {
-         if(eval_lsb(a.bits()) != cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - 1)
+         if (eval_lsb(a.bits()) != cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - 1)
          {
             eval_left_shift(dt, 1);
             eval_decrement(dt);
@@ -816,11 +811,11 @@ inline void do_eval_subtract(cpp_bin_float<Digits, DigitBase, Allocator, Exponen
          res.exponent() = b.exponent();
       s = !s;
    }
-   
+
    copy_and_round(res, dt);
-   if(res.exponent() == cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero)
+   if (res.exponent() == cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero)
       res.sign() = false;
-   else if(res.sign() != s)
+   else if (res.sign() != s)
       res.negate();
    res.check_invariants();
 }
@@ -828,7 +823,7 @@ inline void do_eval_subtract(cpp_bin_float<Digits, DigitBase, Allocator, Exponen
 template <unsigned Digits, digit_base_type DigitBase, class Allocator, class Exponent, Exponent MinE, Exponent MaxE>
 inline void eval_add(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &res, const cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &a, const cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &b)
 {
-   if(a.sign() == b.sign())
+   if (a.sign() == b.sign())
       do_eval_add(res, a, b);
    else
       do_eval_subtract(res, a, b);
@@ -843,7 +838,7 @@ inline void eval_add(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE,
 template <unsigned Digits, digit_base_type DigitBase, class Allocator, class Exponent, Exponent MinE, Exponent MaxE>
 inline void eval_subtract(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &res, const cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &a, const cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &b)
 {
-   if(a.sign() != b.sign())
+   if (a.sign() != b.sign())
       do_eval_add(res, a, b);
    else
       do_eval_subtract(res, a, b);
@@ -862,24 +857,24 @@ inline void eval_multiply(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, 
    using default_ops::eval_multiply;
 
    // Special cases first:
-   switch(a.exponent())
+   switch (a.exponent())
    {
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero:
    {
-      if(b.exponent() == cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_nan)
+      if (b.exponent() == cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_nan)
          res = b;
-      else if(b.exponent() == cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_infinity)
+      else if (b.exponent() == cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_infinity)
          res = std::numeric_limits<number<cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> > >::quiet_NaN().backend();
       else
       {
-         bool s = a.sign() != b.sign();
-         res = a;
+         bool s     = a.sign() != b.sign();
+         res        = a;
          res.sign() = s;
       }
       return;
    }
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_infinity:
-      switch(b.exponent())
+      switch (b.exponent())
       {
       case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero:
          res = std::numeric_limits<number<cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> > >::quiet_NaN().backend();
@@ -888,8 +883,8 @@ inline void eval_multiply(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, 
          res = b;
          break;
       default:
-         bool s = a.sign() != b.sign();
-         res = a;
+         bool s     = a.sign() != b.sign();
+         res        = a;
          res.sign() = s;
          break;
       }
@@ -898,33 +893,33 @@ inline void eval_multiply(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, 
       res = a;
       return;
    }
-   if(b.exponent() > cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::max_exponent)
+   if (b.exponent() > cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::max_exponent)
    {
-      bool s = a.sign() != b.sign();
-      res = b;
+      bool s     = a.sign() != b.sign();
+      res        = b;
       res.sign() = s;
       return;
    }
-   if((a.exponent() > 0) && (b.exponent() > 0))
+   if ((a.exponent() > 0) && (b.exponent() > 0))
    {
-      if(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::max_exponent + 2 - a.exponent() < b.exponent())
+      if (cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::max_exponent + 2 - a.exponent() < b.exponent())
       {
          // We will certainly overflow:
-         bool s = a.sign() != b.sign();
+         bool s         = a.sign() != b.sign();
          res.exponent() = cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_infinity;
-         res.sign() = s;
-         res.bits() = static_cast<limb_type>(0u);
+         res.sign()     = s;
+         res.bits()     = static_cast<limb_type>(0u);
          return;
       }
    }
-   if((a.exponent() < 0) && (b.exponent() < 0))
+   if ((a.exponent() < 0) && (b.exponent() < 0))
    {
-      if(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::min_exponent - 2 - a.exponent() > b.exponent())
+      if (cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::min_exponent - 2 - a.exponent() > b.exponent())
       {
          // We will certainly underflow:
          res.exponent() = cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero;
-         res.sign() = a.sign() != b.sign();
-         res.bits() = static_cast<limb_type>(0u);
+         res.sign()     = a.sign() != b.sign();
+         res.bits()     = static_cast<limb_type>(0u);
          return;
       }
    }
@@ -950,17 +945,17 @@ inline typename enable_if_c<is_unsigned<U>::value>::type eval_multiply(cpp_bin_f
    using default_ops::eval_multiply;
 
    // Special cases first:
-   switch(a.exponent())
+   switch (a.exponent())
    {
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero:
    {
-      bool s = a.sign();
-      res = a;
+      bool s     = a.sign();
+      res        = a;
       res.sign() = s;
       return;
    }
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_infinity:
-      if(b == 0)
+      if (b == 0)
          res = std::numeric_limits<number<cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> > >::quiet_NaN().backend();
       else
          res = a;
@@ -970,7 +965,7 @@ inline typename enable_if_c<is_unsigned<U>::value>::type eval_multiply(cpp_bin_f
       return;
    }
 
-   typename cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::double_rep_type dt;
+   typename cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::double_rep_type                                                                     dt;
    typedef typename boost::multiprecision::detail::canonical<U, typename cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::double_rep_type>::type canon_ui_type;
    eval_multiply(dt, a.bits(), static_cast<canon_ui_type>(b));
    res.exponent() = a.exponent();
@@ -990,7 +985,7 @@ inline typename enable_if_c<is_signed<S>::value>::type eval_multiply(cpp_bin_flo
 {
    typedef typename make_unsigned<S>::type ui_type;
    eval_multiply(res, a, static_cast<ui_type>(boost::multiprecision::detail::unsigned_abs(b)));
-   if(b < 0)
+   if (b < 0)
       res.negate();
 }
 
@@ -1005,44 +1000,44 @@ inline void eval_divide(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, Mi
 {
 #ifdef BOOST_MSVC
 #pragma warning(push)
-#pragma warning(disable:6326)  // comparison of two constants
+#pragma warning(disable : 6326) // comparison of two constants
 #endif
-   using default_ops::eval_subtract;
-   using default_ops::eval_qr;
    using default_ops::eval_bit_test;
    using default_ops::eval_get_sign;
    using default_ops::eval_increment;
+   using default_ops::eval_qr;
+   using default_ops::eval_subtract;
 
    //
    // Special cases first:
    //
-   switch(u.exponent())
+   switch (u.exponent())
    {
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero:
    {
-      switch(v.exponent())
+      switch (v.exponent())
       {
       case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero:
       case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_nan:
          res = std::numeric_limits<number<cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> > >::quiet_NaN().backend();
          return;
       }
-      bool s = u.sign() != v.sign();
-      res = u;
+      bool s     = u.sign() != v.sign();
+      res        = u;
       res.sign() = s;
       return;
    }
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_infinity:
    {
-      switch(v.exponent())
+      switch (v.exponent())
       {
       case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_infinity:
       case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_nan:
          res = std::numeric_limits<number<cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> > >::quiet_NaN().backend();
          return;
       }
-      bool s = u.sign() != v.sign();
-      res = u;
+      bool s     = u.sign() != v.sign();
+      res        = u;
       res.sign() = s;
       return;
    }
@@ -1050,19 +1045,19 @@ inline void eval_divide(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, Mi
       res = std::numeric_limits<number<cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> > >::quiet_NaN().backend();
       return;
    }
-   switch(v.exponent())
+   switch (v.exponent())
    {
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero:
-      {
-      bool s = u.sign() != v.sign();
-      res = std::numeric_limits<number<cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> > >::infinity().backend();
+   {
+      bool s     = u.sign() != v.sign();
+      res        = std::numeric_limits<number<cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> > >::infinity().backend();
       res.sign() = s;
       return;
-      }
+   }
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_infinity:
       res.exponent() = cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero;
-      res.bits() = limb_type(0);
-      res.sign() = u.sign() != v.sign();
+      res.bits()     = limb_type(0);
+      res.sign()     = u.sign() != v.sign();
       return;
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_nan:
       res = std::numeric_limits<number<cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> > >::quiet_NaN().backend();
@@ -1078,38 +1073,38 @@ inline void eval_divide(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, Mi
    //
    // q + r/v = u/v
    //
-   // From this, assuming q has cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count 
+   // From this, assuming q has cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count
    // bits we only need to determine whether
-   // r/v is less than, equal to, or greater than 0.5 to determine rounding - 
+   // r/v is less than, equal to, or greater than 0.5 to determine rounding -
    // this we can do with a shift and comparison.
    //
    // We can set the exponent and sign of the result up front:
    //
-   if((v.exponent() < 0) && (u.exponent() > 0))
+   if ((v.exponent() < 0) && (u.exponent() > 0))
    {
       // Check for overflow:
-      if(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::max_exponent + v.exponent() < u.exponent() - 1)
+      if (cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::max_exponent + v.exponent() < u.exponent() - 1)
       {
          res.exponent() = cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_infinity;
-         res.sign() = u.sign() != v.sign();
-         res.bits() = static_cast<limb_type>(0u);
+         res.sign()     = u.sign() != v.sign();
+         res.bits()     = static_cast<limb_type>(0u);
          return;
       }
    }
-   else if((v.exponent() > 0) && (u.exponent() < 0))
+   else if ((v.exponent() > 0) && (u.exponent() < 0))
    {
       // Check for underflow:
-      if(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::min_exponent + v.exponent() > u.exponent())
+      if (cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::min_exponent + v.exponent() > u.exponent())
       {
          // We will certainly underflow:
          res.exponent() = cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero;
-         res.sign() = u.sign() != v.sign();
-         res.bits() = static_cast<limb_type>(0u);
+         res.sign()     = u.sign() != v.sign();
+         res.bits()     = static_cast<limb_type>(0u);
          return;
       }
    }
    res.exponent() = u.exponent() - v.exponent() - 1;
-   res.sign() = u.sign() != v.sign();
+   res.sign()     = u.sign() != v.sign();
    //
    // Now get the quotient and remainder:
    //
@@ -1117,22 +1112,22 @@ inline void eval_divide(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, Mi
    eval_left_shift(t, cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count);
    eval_qr(t, t2, q, r);
    //
-   // We now have either "cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count" 
-   // or "cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count+1" significant 
+   // We now have either "cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count"
+   // or "cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count+1" significant
    // bits in q.
    //
    static const unsigned limb_bits = sizeof(limb_type) * CHAR_BIT;
-   if(eval_bit_test(q, cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count))
+   if (eval_bit_test(q, cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count))
    {
       //
-      // OK we have cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count+1 bits, 
+      // OK we have cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count+1 bits,
       // so we already have rounding info,
       // we just need to changes things if the last bit is 1 and either the
       // remainder is non-zero (ie we do not have a tie) or the quotient would
       // be odd if it were shifted to the correct number of bits (ie a tiebreak).
       //
       BOOST_ASSERT((eval_msb(q) == cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count));
-      if((q.limbs()[0] & 1u) && (eval_get_sign(r) || (q.limbs()[0] & 2u)))
+      if ((q.limbs()[0] & 1u) && (eval_get_sign(r) || (q.limbs()[0] & 2u)))
       {
          eval_increment(q);
       }
@@ -1152,9 +1147,9 @@ inline void eval_divide(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, Mi
       res.exponent() -= lshift;
       eval_left_shift(r, 1u);
       int c = r.compare(v.bits());
-      if(c == 0)
+      if (c == 0)
          q.limbs()[0] |= static_cast<limb_type>(1u) << (lshift - 1);
-      else if(c > 0)
+      else if (c > 0)
          q.limbs()[0] |= (static_cast<limb_type>(1u) << (lshift - 1)) + static_cast<limb_type>(1u);
    }
    copy_and_round(res, q);
@@ -1174,28 +1169,28 @@ inline typename enable_if_c<is_unsigned<U>::value>::type eval_divide(cpp_bin_flo
 {
 #ifdef BOOST_MSVC
 #pragma warning(push)
-#pragma warning(disable:6326)  // comparison of two constants
+#pragma warning(disable : 6326) // comparison of two constants
 #endif
-   using default_ops::eval_subtract;
-   using default_ops::eval_qr;
    using default_ops::eval_bit_test;
    using default_ops::eval_get_sign;
    using default_ops::eval_increment;
+   using default_ops::eval_qr;
+   using default_ops::eval_subtract;
 
    //
    // Special cases first:
    //
-   switch(u.exponent())
+   switch (u.exponent())
    {
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero:
    {
-      if(v == 0)
+      if (v == 0)
       {
          res = std::numeric_limits<number<cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> > >::quiet_NaN().backend();
          return;
       }
-      bool s = u.sign() != (v < 0);
-      res = u;
+      bool s     = u.sign() != (v < 0);
+      res        = u;
       res.sign() = s;
       return;
    }
@@ -1206,10 +1201,10 @@ inline typename enable_if_c<is_unsigned<U>::value>::type eval_divide(cpp_bin_flo
       res = std::numeric_limits<number<cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> > >::quiet_NaN().backend();
       return;
    }
-   if(v == 0)
+   if (v == 0)
    {
-      bool s = u.sign();
-      res = std::numeric_limits<number<cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> > >::infinity().backend();
+      bool s     = u.sign();
+      res        = std::numeric_limits<number<cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> > >::infinity().backend();
       res.sign() = s;
       return;
    }
@@ -1224,14 +1219,14 @@ inline typename enable_if_c<is_unsigned<U>::value>::type eval_divide(cpp_bin_flo
    // q + r/v = u/v
    //
    // From this, assuming q has "cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count" cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count, we only need to determine whether
-   // r/v is less than, equal to, or greater than 0.5 to determine rounding - 
+   // r/v is less than, equal to, or greater than 0.5 to determine rounding -
    // this we can do with a shift and comparison.
    //
    // We can set the exponent and sign of the result up front:
    //
-   int gb = msb(v);
+   int gb         = msb(v);
    res.exponent() = u.exponent() - static_cast<Exponent>(gb) - static_cast<Exponent>(1);
-   res.sign() = u.sign();
+   res.sign()     = u.sign();
    //
    // Now get the quotient and remainder:
    //
@@ -1242,7 +1237,7 @@ inline typename enable_if_c<is_unsigned<U>::value>::type eval_divide(cpp_bin_flo
    // We now have either "cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count" or "cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count+1" significant cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count in q.
    //
    static const unsigned limb_bits = sizeof(limb_type) * CHAR_BIT;
-   if(eval_bit_test(q, cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count))
+   if (eval_bit_test(q, cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count))
    {
       //
       // OK we have cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count+1 cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count, so we already have rounding info,
@@ -1250,7 +1245,7 @@ inline typename enable_if_c<is_unsigned<U>::value>::type eval_divide(cpp_bin_flo
       // remainder is non-zero (ie we do not have a tie).
       //
       BOOST_ASSERT((eval_msb(q) == cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count));
-      if((q.limbs()[0] & 1u) && eval_get_sign(r))
+      if ((q.limbs()[0] & 1u) && eval_get_sign(r))
       {
          eval_increment(q);
       }
@@ -1270,9 +1265,9 @@ inline typename enable_if_c<is_unsigned<U>::value>::type eval_divide(cpp_bin_flo
       res.exponent() -= lshift;
       eval_left_shift(r, 1u);
       int c = r.compare(number<typename cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::double_rep_type>::canonical_value(v));
-      if(c == 0)
+      if (c == 0)
          q.limbs()[0] |= static_cast<limb_type>(1u) << (lshift - 1);
-      else if(c > 0)
+      else if (c > 0)
          q.limbs()[0] |= (static_cast<limb_type>(1u) << (lshift - 1)) + static_cast<limb_type>(1u);
    }
    copy_and_round(res, q);
@@ -1292,7 +1287,7 @@ inline typename enable_if_c<is_signed<S>::value>::type eval_divide(cpp_bin_float
 {
    typedef typename make_unsigned<S>::type ui_type;
    eval_divide(res, u, static_cast<ui_type>(boost::multiprecision::detail::unsigned_abs(v)));
-   if(v < 0)
+   if (v < 0)
       res.negate();
 }
 
@@ -1317,13 +1312,11 @@ inline bool eval_is_zero(const cpp_bin_float<Digits, DigitBase, Allocator, Expon
 template <unsigned Digits, digit_base_type DigitBase, class Allocator, class Exponent, Exponent MinE, Exponent MaxE>
 inline bool eval_eq(const cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &a, cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &b)
 {
-   if(a.exponent() == b.exponent())
+   if (a.exponent() == b.exponent())
    {
-      if(a.exponent() == cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero)
+      if (a.exponent() == cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero)
          return true;
-      return (a.sign() == b.sign())
-         && (a.bits().compare(b.bits()) == 0)
-         && (a.exponent() != cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_nan);
+      return (a.sign() == b.sign()) && (a.bits().compare(b.bits()) == 0) && (a.exponent() != cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_nan);
    }
    return false;
 }
@@ -1331,7 +1324,7 @@ inline bool eval_eq(const cpp_bin_float<Digits, DigitBase, Allocator, Exponent, 
 template <unsigned Digits, digit_base_type DigitBase, class Allocator, class Exponent, Exponent MinE, Exponent MaxE>
 inline void eval_convert_to(boost::long_long_type *res, const cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &arg)
 {
-   switch(arg.exponent())
+   switch (arg.exponent())
    {
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero:
       *res = 0;
@@ -1340,25 +1333,24 @@ inline void eval_convert_to(boost::long_long_type *res, const cpp_bin_float<Digi
       BOOST_THROW_EXCEPTION(std::runtime_error("Could not convert NaN to integer."));
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_infinity:
       *res = (std::numeric_limits<boost::long_long_type>::max)();
-      if(arg.sign())
+      if (arg.sign())
          *res = -*res;
       return;
    }
-   typedef typename mpl::if_c < sizeof(typename cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_type) < sizeof(int), int, typename cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_type > ::type shift_type;
-   typename cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::rep_type man(arg.bits());
-   shift_type shift 
-      = (shift_type)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - 1 - arg.exponent();
-   if(shift > (shift_type)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - 1)
+   typedef typename mpl::if_c<sizeof(typename cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_type) < sizeof(int), int, typename cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_type>::type shift_type;
+   typename cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::rep_type                                                                                                                                                              man(arg.bits());
+   shift_type                                                                                                                                                                                                                                        shift = (shift_type)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - 1 - arg.exponent();
+   if (shift > (shift_type)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - 1)
    {
       *res = 0;
       return;
    }
-   if(arg.sign() && (arg.compare((std::numeric_limits<boost::long_long_type>::min)()) <= 0))
+   if (arg.sign() && (arg.compare((std::numeric_limits<boost::long_long_type>::min)()) <= 0))
    {
       *res = (std::numeric_limits<boost::long_long_type>::min)();
       return;
    }
-   else if(!arg.sign() && (arg.compare((std::numeric_limits<boost::long_long_type>::max)()) >= 0))
+   else if (!arg.sign() && (arg.compare((std::numeric_limits<boost::long_long_type>::max)()) >= 0))
    {
       *res = (std::numeric_limits<boost::long_long_type>::max)();
       return;
@@ -1383,7 +1375,7 @@ inline void eval_convert_to(boost::long_long_type *res, const cpp_bin_float<Digi
       eval_right_shift(man, shift);
       eval_convert_to(res, man);
    }
-   if(arg.sign())
+   if (arg.sign())
    {
       *res = -*res;
    }
@@ -1392,7 +1384,7 @@ inline void eval_convert_to(boost::long_long_type *res, const cpp_bin_float<Digi
 template <unsigned Digits, digit_base_type DigitBase, class Allocator, class Exponent, Exponent MinE, Exponent MaxE>
 inline void eval_convert_to(boost::ulong_long_type *res, const cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &arg)
 {
-   switch(arg.exponent())
+   switch (arg.exponent())
    {
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero:
       *res = 0;
@@ -1403,16 +1395,15 @@ inline void eval_convert_to(boost::ulong_long_type *res, const cpp_bin_float<Dig
       *res = (std::numeric_limits<boost::ulong_long_type>::max)();
       return;
    }
-   typename cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::rep_type man(arg.bits());
-   typedef typename mpl::if_c < sizeof(typename cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_type) < sizeof(int), int, typename cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_type > ::type shift_type;
-   shift_type shift 
-      = (shift_type)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - 1 - arg.exponent();
-   if(shift > (shift_type)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - 1)
+   typename cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::rep_type                                                                                                                                                              man(arg.bits());
+   typedef typename mpl::if_c<sizeof(typename cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_type) < sizeof(int), int, typename cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_type>::type shift_type;
+   shift_type                                                                                                                                                                                                                                        shift = (shift_type)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - 1 - arg.exponent();
+   if (shift > (shift_type)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - 1)
    {
       *res = 0;
       return;
    }
-   else if(shift < 0)
+   else if (shift < 0)
    {
       if (cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - shift <= std::numeric_limits<boost::ulong_long_type>::digits)
       {
@@ -1431,16 +1422,16 @@ inline void eval_convert_to(boost::ulong_long_type *res, const cpp_bin_float<Dig
 template <class Float, unsigned Digits, digit_base_type DigitBase, class Allocator, class Exponent, Exponent MinE, Exponent MaxE>
 inline typename boost::enable_if_c<boost::is_float<Float>::value>::type eval_convert_to(Float *res, const cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &original_arg)
 {
-   typedef cpp_bin_float<std::numeric_limits<Float>::digits, digit_base_2, void, Exponent, MinE, MaxE>  conv_type;
-   typedef typename common_type<typename conv_type::exponent_type, int>::type                           common_exp_type;
+   typedef cpp_bin_float<std::numeric_limits<Float>::digits, digit_base_2, void, Exponent, MinE, MaxE> conv_type;
+   typedef typename common_type<typename conv_type::exponent_type, int>::type                          common_exp_type;
    //
    // Special cases first:
    //
-   switch(original_arg.exponent())
+   switch (original_arg.exponent())
    {
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero:
       *res = 0;
-      if(original_arg.sign())
+      if (original_arg.sign())
          *res = -*res;
       return;
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_nan:
@@ -1448,36 +1439,36 @@ inline typename boost::enable_if_c<boost::is_float<Float>::value>::type eval_con
       return;
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_infinity:
       *res = (std::numeric_limits<Float>::infinity)();
-      if(original_arg.sign())
+      if (original_arg.sign())
          *res = -*res;
       return;
    }
    //
    // Check for super large exponent that must be converted to infinity:
    //
-   if(original_arg.exponent() > std::numeric_limits<Float>::max_exponent)
+   if (original_arg.exponent() > std::numeric_limits<Float>::max_exponent)
    {
       *res = std::numeric_limits<Float>::has_infinity ? std::numeric_limits<Float>::infinity() : (std::numeric_limits<Float>::max)();
-      if(original_arg.sign())
+      if (original_arg.sign())
          *res = -*res;
       return;
    }
    //
-   // Figure out how many digits we will have in our result, 
+   // Figure out how many digits we will have in our result,
    // allowing for a possibly denormalized result:
    //
    common_exp_type digits_to_round_to = std::numeric_limits<Float>::digits;
-   if(original_arg.exponent() < std::numeric_limits<Float>::min_exponent - 1)
+   if (original_arg.exponent() < std::numeric_limits<Float>::min_exponent - 1)
    {
       common_exp_type diff = original_arg.exponent();
       diff -= std::numeric_limits<Float>::min_exponent - 1;
       digits_to_round_to += diff;
    }
-   if(digits_to_round_to < 0)
+   if (digits_to_round_to < 0)
    {
       // Result must be zero:
       *res = 0;
-      if(original_arg.sign())
+      if (original_arg.sign())
          *res = -*res;
       return;
    }
@@ -1485,40 +1476,39 @@ inline typename boost::enable_if_c<boost::is_float<Float>::value>::type eval_con
    // Perform rounding first, then afterwards extract the digits:
    //
    cpp_bin_float<std::numeric_limits<Float>::digits, digit_base_2, Allocator, Exponent, MinE, MaxE> arg;
-   typename cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::rep_type bits(original_arg.bits());
+   typename cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::rep_type             bits(original_arg.bits());
    arg.exponent() = original_arg.exponent();
    copy_and_round(arg, bits, (int)digits_to_round_to);
    common_exp_type e = arg.exponent();
    e -= cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - 1;
-   static const unsigned limbs_needed = std::numeric_limits<Float>::digits / (sizeof(*arg.bits().limbs()) * CHAR_BIT)
-      + (std::numeric_limits<Float>::digits % (sizeof(*arg.bits().limbs()) * CHAR_BIT) ? 1 : 0);
-   unsigned first_limb_needed = arg.bits().size() - limbs_needed;
-   *res = 0;
+   static const unsigned limbs_needed      = std::numeric_limits<Float>::digits / (sizeof(*arg.bits().limbs()) * CHAR_BIT) + (std::numeric_limits<Float>::digits % (sizeof(*arg.bits().limbs()) * CHAR_BIT) ? 1 : 0);
+   unsigned              first_limb_needed = arg.bits().size() - limbs_needed;
+   *res                                    = 0;
    e += first_limb_needed * sizeof(*arg.bits().limbs()) * CHAR_BIT;
-   while(first_limb_needed < arg.bits().size())
+   while (first_limb_needed < arg.bits().size())
    {
       *res += std::ldexp(static_cast<Float>(arg.bits().limbs()[first_limb_needed]), static_cast<int>(e));
       ++first_limb_needed;
       e += sizeof(*arg.bits().limbs()) * CHAR_BIT;
    }
-   if(original_arg.sign())
+   if (original_arg.sign())
       *res = -*res;
 }
 
 template <unsigned Digits, digit_base_type DigitBase, class Allocator, class Exponent, Exponent MinE, Exponent MaxE>
 inline void eval_frexp(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &res, const cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &arg, Exponent *e)
 {
-   switch(arg.exponent())
+   switch (arg.exponent())
    {
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero:
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_nan:
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_infinity:
-      *e = 0;
+      *e  = 0;
       res = arg;
       return;
    }
-   res = arg;
-   *e = arg.exponent() + 1;
+   res            = arg;
+   *e             = arg.exponent() + 1;
    res.exponent() = -1;
 }
 
@@ -1527,7 +1517,7 @@ inline void eval_frexp(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, Min
 {
    Exponent e;
    eval_frexp(res, arg, &e);
-   if((e > (std::numeric_limits<I>::max)()) || (e < (std::numeric_limits<I>::min)()))
+   if ((e > (std::numeric_limits<I>::max)()) || (e < (std::numeric_limits<I>::min)()))
    {
       BOOST_THROW_EXCEPTION(std::runtime_error("Exponent was outside of the range of the argument type to frexp."));
    }
@@ -1537,7 +1527,7 @@ inline void eval_frexp(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, Min
 template <unsigned Digits, digit_base_type DigitBase, class Allocator, class Exponent, Exponent MinE, Exponent MaxE>
 inline void eval_ldexp(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &res, const cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &arg, Exponent e)
 {
-   switch(arg.exponent())
+   switch (arg.exponent())
    {
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero:
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_nan:
@@ -1545,13 +1535,13 @@ inline void eval_ldexp(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, Min
       res = arg;
       return;
    }
-   if((e > 0) && (cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::max_exponent - e < arg.exponent()))
+   if ((e > 0) && (cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::max_exponent - e < arg.exponent()))
    {
       // Overflow:
-      res = std::numeric_limits<number<cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> > >::infinity().backend();
+      res        = std::numeric_limits<number<cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> > >::infinity().backend();
       res.sign() = arg.sign();
    }
-   else if((e < 0) && (cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::min_exponent - e > arg.exponent()))
+   else if ((e < 0) && (cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::min_exponent - e > arg.exponent()))
    {
       // Underflow:
       res = limb_type(0);
@@ -1567,7 +1557,7 @@ template <unsigned Digits, digit_base_type DigitBase, class Allocator, class Exp
 inline typename enable_if_c<is_unsigned<I>::value>::type eval_ldexp(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &res, const cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &arg, I e)
 {
    typedef typename make_signed<I>::type si_type;
-   if(e > static_cast<I>((std::numeric_limits<si_type>::max)()))
+   if (e > static_cast<I>((std::numeric_limits<si_type>::max)()))
       res = std::numeric_limits<number<cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> > >::infinity().backend();
    else
       eval_ldexp(res, arg, static_cast<si_type>(e));
@@ -1576,10 +1566,10 @@ inline typename enable_if_c<is_unsigned<I>::value>::type eval_ldexp(cpp_bin_floa
 template <unsigned Digits, digit_base_type DigitBase, class Allocator, class Exponent, Exponent MinE, Exponent MaxE, class I>
 inline typename enable_if_c<is_signed<I>::value>::type eval_ldexp(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &res, const cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &arg, I e)
 {
-   if((e > (std::numeric_limits<Exponent>::max)()) || (e < (std::numeric_limits<Exponent>::min)()))
+   if ((e > (std::numeric_limits<Exponent>::max)()) || (e < (std::numeric_limits<Exponent>::min)()))
    {
       res = std::numeric_limits<number<cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> > >::infinity().backend();
-      if(e < 0)
+      if (e < 0)
          res.negate();
    }
    else
@@ -1593,21 +1583,21 @@ inline typename enable_if_c<is_signed<I>::value>::type eval_ldexp(cpp_bin_float<
 template <unsigned Digits, digit_base_type DigitBase, class Allocator, class Exponent, Exponent MinE, Exponent MaxE>
 inline void eval_abs(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &res, const cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &arg)
 {
-   res = arg;
+   res        = arg;
    res.sign() = false;
 }
 
 template <unsigned Digits, digit_base_type DigitBase, class Allocator, class Exponent, Exponent MinE, Exponent MaxE>
 inline void eval_fabs(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &res, const cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &arg)
 {
-   res = arg;
+   res        = arg;
    res.sign() = false;
 }
 
 template <unsigned Digits, digit_base_type DigitBase, class Allocator, class Exponent, Exponent MinE, Exponent MaxE>
 inline int eval_fpclassify(const cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &arg)
 {
-   switch(arg.exponent())
+   switch (arg.exponent())
    {
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero:
       return FP_ZERO;
@@ -1622,10 +1612,10 @@ inline int eval_fpclassify(const cpp_bin_float<Digits, DigitBase, Allocator, Exp
 template <unsigned Digits, digit_base_type DigitBase, class Allocator, class Exponent, Exponent MinE, Exponent MaxE>
 inline void eval_sqrt(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &res, const cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &arg)
 {
-   using default_ops::eval_integer_sqrt;
    using default_ops::eval_bit_test;
    using default_ops::eval_increment;
-   switch(arg.exponent())
+   using default_ops::eval_integer_sqrt;
+   switch (arg.exponent())
    {
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_nan:
       errno = EDOM;
@@ -1634,18 +1624,18 @@ inline void eval_sqrt(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE
       res = arg;
       return;
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_infinity:
-      if(arg.sign())
+      if (arg.sign())
       {
-         res = std::numeric_limits<number<cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> > >::quiet_NaN().backend();
+         res   = std::numeric_limits<number<cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> > >::quiet_NaN().backend();
          errno = EDOM;
       }
       else
          res = arg;
       return;
    }
-   if(arg.sign())
+   if (arg.sign())
    {
-      res = std::numeric_limits<number<cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> > >::quiet_NaN().backend();
+      res   = std::numeric_limits<number<cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> > >::quiet_NaN().backend();
       errno = EDOM;
       return;
    }
@@ -1654,17 +1644,17 @@ inline void eval_sqrt(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE
    eval_left_shift(t, arg.exponent() & 1 ? cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count : cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - 1);
    eval_integer_sqrt(s, r, t);
 
-   if(!eval_bit_test(s, cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count))
+   if (!eval_bit_test(s, cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count))
    {
       // We have exactly the right number of cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count in the result, round as required:
-      if(s.compare(r) < 0)
+      if (s.compare(r) < 0)
       {
          eval_increment(s);
       }
    }
    typename cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_type ae = arg.exponent();
-   res.exponent() = ae / 2;
-   if((ae & 1) && (ae < 0))
+   res.exponent()                                                                               = ae / 2;
+   if ((ae & 1) && (ae < 0))
       --res.exponent();
    copy_and_round(res, s);
 }
@@ -1673,7 +1663,7 @@ template <unsigned Digits, digit_base_type DigitBase, class Allocator, class Exp
 inline void eval_floor(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &res, const cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &arg)
 {
    using default_ops::eval_increment;
-   switch(arg.exponent())
+   switch (arg.exponent())
    {
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_nan:
       errno = EDOM;
@@ -1683,27 +1673,27 @@ inline void eval_floor(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, Min
       res = arg;
       return;
    }
-   typedef typename mpl::if_c < sizeof(typename cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_type) < sizeof(int), int, typename cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_type > ::type shift_type;
-   shift_type shift = 
-      (shift_type)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - arg.exponent() - 1;
-   if((arg.exponent() > (shift_type)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::max_exponent) || (shift <= 0))
+   typedef typename mpl::if_c<sizeof(typename cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_type) < sizeof(int), int, typename cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_type>::type shift_type;
+   shift_type                                                                                                                                                                                                                                        shift =
+       (shift_type)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - arg.exponent() - 1;
+   if ((arg.exponent() > (shift_type)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::max_exponent) || (shift <= 0))
    {
       // Either arg is already an integer, or a special value:
       res = arg;
       return;
    }
-   if(shift >= (shift_type)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count)
+   if (shift >= (shift_type)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count)
    {
       res = static_cast<signed_limb_type>(arg.sign() ? -1 : 0);
       return;
    }
    bool fractional = (shift_type)eval_lsb(arg.bits()) < shift;
-   res = arg;
+   res             = arg;
    eval_right_shift(res.bits(), shift);
-   if(fractional && res.sign())
+   if (fractional && res.sign())
    {
       eval_increment(res.bits());
-      if(eval_msb(res.bits()) != cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - 1 - shift)
+      if (eval_msb(res.bits()) != cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - 1 - shift)
       {
          // Must have extended result by one bit in the increment:
          --shift;
@@ -1717,7 +1707,7 @@ template <unsigned Digits, digit_base_type DigitBase, class Allocator, class Exp
 inline void eval_ceil(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &res, const cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &arg)
 {
    using default_ops::eval_increment;
-   switch(arg.exponent())
+   switch (arg.exponent())
    {
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_infinity:
       errno = EDOM;
@@ -1727,28 +1717,28 @@ inline void eval_ceil(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE
       res = arg;
       return;
    }
-   typedef typename mpl::if_c < sizeof(typename cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_type) < sizeof(int), int, typename cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_type > ::type shift_type;
-   shift_type shift = (shift_type)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - arg.exponent() - 1;
-   if((arg.exponent() > (shift_type)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::max_exponent) || (shift <= 0))
+   typedef typename mpl::if_c<sizeof(typename cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_type) < sizeof(int), int, typename cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_type>::type shift_type;
+   shift_type                                                                                                                                                                                                                                        shift = (shift_type)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - arg.exponent() - 1;
+   if ((arg.exponent() > (shift_type)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::max_exponent) || (shift <= 0))
    {
       // Either arg is already an integer, or a special value:
       res = arg;
       return;
    }
-   if(shift >= (shift_type)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count)
+   if (shift >= (shift_type)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count)
    {
-      bool s = arg.sign(); // takes care of signed zeros
-      res = static_cast<signed_limb_type>(arg.sign() ? 0 : 1);
+      bool s     = arg.sign(); // takes care of signed zeros
+      res        = static_cast<signed_limb_type>(arg.sign() ? 0 : 1);
       res.sign() = s;
       return;
    }
    bool fractional = (shift_type)eval_lsb(arg.bits()) < shift;
-   res = arg;
+   res             = arg;
    eval_right_shift(res.bits(), shift);
-   if(fractional && !res.sign())
+   if (fractional && !res.sign())
    {
       eval_increment(res.bits());
-      if(eval_msb(res.bits()) != cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - 1 - shift)
+      if (eval_msb(res.bits()) != cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - 1 - shift)
       {
          // Must have extended result by one bit in the increment:
          --shift;
@@ -1758,14 +1748,14 @@ inline void eval_ceil(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE
    eval_left_shift(res.bits(), shift);
 }
 
-template<unsigned D1, backends::digit_base_type B1, class A1, class E1, E1 M1, E1 M2>
-int eval_signbit(const cpp_bin_float<D1, B1, A1, E1, M1, M2>& val)
+template <unsigned D1, backends::digit_base_type B1, class A1, class E1, E1 M1, E1 M2>
+int eval_signbit(const cpp_bin_float<D1, B1, A1, E1, M1, M2> &val)
 {
    return val.sign();
 }
 
-template<unsigned D1, backends::digit_base_type B1, class A1, class E1, E1 M1, E1 M2>
-inline std::size_t hash_value(const cpp_bin_float<D1, B1, A1, E1, M1, M2>& val)
+template <unsigned D1, backends::digit_base_type B1, class A1, class E1, E1 M1, E1 M2>
+inline std::size_t hash_value(const cpp_bin_float<D1, B1, A1, E1, M1, M2> &val)
 {
    std::size_t result = hash_value(val.bits());
    boost::hash_combine(result, val.exponent());
@@ -1773,26 +1763,27 @@ inline std::size_t hash_value(const cpp_bin_float<D1, B1, A1, E1, M1, M2>& val)
    return result;
 }
 
-
 } // namespace backends
 
 #ifdef BOOST_NO_SFINAE_EXPR
 
-namespace detail{
+namespace detail {
 
-template<unsigned D1, backends::digit_base_type B1, class A1, class E1, E1 M1, E1 M2, unsigned D2, backends::digit_base_type B2, class A2, class E2, E2 M3, E2 M4>
-struct is_explicitly_convertible<backends::cpp_bin_float<D1, B1, A1, E1, M1, M2>, backends::cpp_bin_float<D2, B2, A2, E2, M3, M4> > : public mpl::true_ {};
-template<class FloatT, unsigned D2, backends::digit_base_type B2, class A2, class E2, E2 M3, E2 M4>
-struct is_explicitly_convertible<FloatT, backends::cpp_bin_float<D2, B2, A2, E2, M3, M4> > : public boost::is_floating_point<FloatT> {};
+template <unsigned D1, backends::digit_base_type B1, class A1, class E1, E1 M1, E1 M2, unsigned D2, backends::digit_base_type B2, class A2, class E2, E2 M3, E2 M4>
+struct is_explicitly_convertible<backends::cpp_bin_float<D1, B1, A1, E1, M1, M2>, backends::cpp_bin_float<D2, B2, A2, E2, M3, M4> > : public mpl::true_
+{};
+template <class FloatT, unsigned D2, backends::digit_base_type B2, class A2, class E2, E2 M3, E2 M4>
+struct is_explicitly_convertible<FloatT, backends::cpp_bin_float<D2, B2, A2, E2, M3, M4> > : public boost::is_floating_point<FloatT>
+{};
 
-}
+} // namespace detail
 #endif
 
-template<unsigned Digits, boost::multiprecision::backends::digit_base_type DigitBase, class Exponent, Exponent MinE, Exponent MaxE, class Allocator, boost::multiprecision::expression_template_option ExpressionTemplates>
+template <unsigned Digits, boost::multiprecision::backends::digit_base_type DigitBase, class Exponent, Exponent MinE, Exponent MaxE, class Allocator, boost::multiprecision::expression_template_option ExpressionTemplates>
 inline boost::multiprecision::number<boost::multiprecision::backends::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>, ExpressionTemplates>
-copysign BOOST_PREVENT_MACRO_SUBSTITUTION(
-   const boost::multiprecision::number<boost::multiprecision::backends::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>, ExpressionTemplates>& a,
-   const boost::multiprecision::number<boost::multiprecision::backends::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>, ExpressionTemplates>& b)
+    copysign BOOST_PREVENT_MACRO_SUBSTITUTION(
+        const boost::multiprecision::number<boost::multiprecision::backends::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>, ExpressionTemplates> &a,
+        const boost::multiprecision::number<boost::multiprecision::backends::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>, ExpressionTemplates> &b)
 {
    boost::multiprecision::number<boost::multiprecision::backends::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>, ExpressionTemplates> res(a);
    res.backend().sign() = b.backend().sign();
@@ -1800,33 +1791,34 @@ copysign BOOST_PREVENT_MACRO_SUBSTITUTION(
 }
 
 using backends::cpp_bin_float;
-using backends::digit_base_2;
 using backends::digit_base_10;
+using backends::digit_base_2;
 
-template<unsigned Digits, backends::digit_base_type DigitBase, class Exponent, Exponent MinE, Exponent MaxE, class Allocator>
-struct number_category<cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> > : public boost::mpl::int_<boost::multiprecision::number_kind_floating_point>{};
+template <unsigned Digits, backends::digit_base_type DigitBase, class Exponent, Exponent MinE, Exponent MaxE, class Allocator>
+struct number_category<cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> > : public boost::mpl::int_<boost::multiprecision::number_kind_floating_point>
+{};
 
-template<unsigned Digits, backends::digit_base_type DigitBase, class Allocator, class Exponent, Exponent MinE, Exponent MaxE>
+template <unsigned Digits, backends::digit_base_type DigitBase, class Allocator, class Exponent, Exponent MinE, Exponent MaxE>
 struct expression_template_default<cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> >
 {
    static const expression_template_option value = is_void<Allocator>::value ? et_off : et_on;
 };
 
-typedef number<backends::cpp_bin_float<50> > cpp_bin_float_50;
+typedef number<backends::cpp_bin_float<50> >  cpp_bin_float_50;
 typedef number<backends::cpp_bin_float<100> > cpp_bin_float_100;
 
-typedef number<backends::cpp_bin_float<24, backends::digit_base_2, void, boost::int16_t, -126, 127>, et_off> cpp_bin_float_single;
-typedef number<backends::cpp_bin_float<53, backends::digit_base_2, void, boost::int16_t, -1022, 1023>, et_off> cpp_bin_float_double;
-typedef number<backends::cpp_bin_float<64, backends::digit_base_2, void, boost::int16_t, -16382, 16383>, et_off> cpp_bin_float_double_extended;
-typedef number<backends::cpp_bin_float<113, backends::digit_base_2, void, boost::int16_t, -16382, 16383>, et_off> cpp_bin_float_quad;
+typedef number<backends::cpp_bin_float<24, backends::digit_base_2, void, boost::int16_t, -126, 127>, et_off>        cpp_bin_float_single;
+typedef number<backends::cpp_bin_float<53, backends::digit_base_2, void, boost::int16_t, -1022, 1023>, et_off>      cpp_bin_float_double;
+typedef number<backends::cpp_bin_float<64, backends::digit_base_2, void, boost::int16_t, -16382, 16383>, et_off>    cpp_bin_float_double_extended;
+typedef number<backends::cpp_bin_float<113, backends::digit_base_2, void, boost::int16_t, -16382, 16383>, et_off>   cpp_bin_float_quad;
 typedef number<backends::cpp_bin_float<237, backends::digit_base_2, void, boost::int32_t, -262142, 262143>, et_off> cpp_bin_float_oct;
 
 } // namespace multiprecision
 
 namespace math {
 
-   using boost::multiprecision::signbit;
-   using boost::multiprecision::copysign;
+using boost::multiprecision::copysign;
+using boost::multiprecision::signbit;
 
 } // namespace math
 
@@ -1835,49 +1827,50 @@ namespace math {
 #include <boost/multiprecision/cpp_bin_float/io.hpp>
 #include <boost/multiprecision/cpp_bin_float/transcendental.hpp>
 
-namespace std{
+namespace std {
 
 //
 // numeric_limits [partial] specializations for the types declared in this header:
 //
-template<unsigned Digits, boost::multiprecision::backends::digit_base_type DigitBase, class Allocator, class Exponent, Exponent MinE, Exponent MaxE, boost::multiprecision::expression_template_option ExpressionTemplates>
+template <unsigned Digits, boost::multiprecision::backends::digit_base_type DigitBase, class Allocator, class Exponent, Exponent MinE, Exponent MaxE, boost::multiprecision::expression_template_option ExpressionTemplates>
 class numeric_limits<boost::multiprecision::number<boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>, ExpressionTemplates> >
 {
    typedef boost::multiprecision::number<boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>, ExpressionTemplates> number_type;
-public:
+
+ public:
    BOOST_STATIC_CONSTEXPR bool is_specialized = true;
-   static number_type (min)()
+   static number_type(min)()
    {
       initializer.do_nothing();
       static std::pair<bool, number_type> value;
-      if(!value.first)
+      if (!value.first)
       {
          value.first = true;
          typedef typename boost::mpl::front<typename number_type::backend_type::unsigned_types>::type ui_type;
-         value.second.backend() = ui_type(1u);
+         value.second.backend()            = ui_type(1u);
          value.second.backend().exponent() = boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::min_exponent;
       }
       return value.second;
    }
-   static number_type (max)()
+   static number_type(max)()
    {
       initializer.do_nothing();
       static std::pair<bool, number_type> value;
-      if(!value.first)
+      if (!value.first)
       {
          value.first = true;
-         if(boost::is_void<Allocator>::value)
+         if (boost::is_void<Allocator>::value)
             eval_complement(value.second.backend().bits(), value.second.backend().bits());
          else
          {
-            // We jump through hoops here using the backend type directly just to keep VC12 happy 
+            // We jump through hoops here using the backend type directly just to keep VC12 happy
             // (ie compiler workaround, for very strange compiler bug):
             using boost::multiprecision::default_ops::eval_add;
             using boost::multiprecision::default_ops::eval_decrement;
             using boost::multiprecision::default_ops::eval_left_shift;
-            typedef typename number_type::backend_type::rep_type int_backend_type;
+            typedef typename number_type::backend_type::rep_type                                int_backend_type;
             typedef typename boost::mpl::front<typename int_backend_type::unsigned_types>::type ui_type;
-            int_backend_type i;
+            int_backend_type                                                                    i;
             i = ui_type(1u);
             eval_left_shift(i, boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - 1);
             int_backend_type j(i);
@@ -1893,25 +1886,25 @@ public:
    {
       return -(max)();
    }
-   BOOST_STATIC_CONSTEXPR int digits = boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count;
+   BOOST_STATIC_CONSTEXPR int digits   = boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count;
    BOOST_STATIC_CONSTEXPR int digits10 = (digits - 1) * 301 / 1000;
    // Is this really correct???
-   BOOST_STATIC_CONSTEXPR int max_digits10 = (digits * 301 / 1000) + 3;
-   BOOST_STATIC_CONSTEXPR bool is_signed = true;
-   BOOST_STATIC_CONSTEXPR bool is_integer = false;
-   BOOST_STATIC_CONSTEXPR bool is_exact = false;
-   BOOST_STATIC_CONSTEXPR int radix = 2;
-   static number_type epsilon()
+   BOOST_STATIC_CONSTEXPR int  max_digits10 = (digits * 301 / 1000) + 3;
+   BOOST_STATIC_CONSTEXPR bool is_signed    = true;
+   BOOST_STATIC_CONSTEXPR bool is_integer   = false;
+   BOOST_STATIC_CONSTEXPR bool is_exact     = false;
+   BOOST_STATIC_CONSTEXPR int  radix        = 2;
+   static number_type          epsilon()
    {
       initializer.do_nothing();
       static std::pair<bool, number_type> value;
-      if(!value.first)
+      if (!value.first)
       {
          // We jump through hoops here just to keep VC12 happy (ie compiler workaround, for very strange compiler bug):
          typedef typename boost::mpl::front<typename number_type::backend_type::unsigned_types>::type ui_type;
-         value.first = true;
+         value.first            = true;
          value.second.backend() = ui_type(1u);
-         value.second = ldexp(value.second, 1 - (int)digits);
+         value.second           = ldexp(value.second, 1 - (int)digits);
       }
       return value.second;
    }
@@ -1921,32 +1914,32 @@ public:
       // returns 0.5
       initializer.do_nothing();
       static std::pair<bool, number_type> value;
-      if(!value.first)
+      if (!value.first)
       {
          value.first = true;
          // We jump through hoops here just to keep VC12 happy (ie compiler workaround, for very strange compiler bug):
          typedef typename boost::mpl::front<typename number_type::backend_type::unsigned_types>::type ui_type;
          value.second.backend() = ui_type(1u);
-         value.second = ldexp(value.second, -1);
+         value.second           = ldexp(value.second, -1);
       }
       return value.second;
    }
-   BOOST_STATIC_CONSTEXPR typename boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_type min_exponent = boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::min_exponent;
-   BOOST_STATIC_CONSTEXPR typename boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_type min_exponent10 = (min_exponent / 1000) * 301L;
-   BOOST_STATIC_CONSTEXPR typename boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_type max_exponent = boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::max_exponent;
-   BOOST_STATIC_CONSTEXPR typename boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_type max_exponent10 = (max_exponent / 1000) * 301L;
-   BOOST_STATIC_CONSTEXPR bool has_infinity = true;
-   BOOST_STATIC_CONSTEXPR bool has_quiet_NaN = true;
-   BOOST_STATIC_CONSTEXPR bool has_signaling_NaN = false;
-   BOOST_STATIC_CONSTEXPR float_denorm_style has_denorm = denorm_absent;
-   BOOST_STATIC_CONSTEXPR bool has_denorm_loss = false;
-   static number_type infinity()
+   BOOST_STATIC_CONSTEXPR typename boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_type min_exponent      = boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::min_exponent;
+   BOOST_STATIC_CONSTEXPR typename boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_type min_exponent10    = (min_exponent / 1000) * 301L;
+   BOOST_STATIC_CONSTEXPR typename boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_type max_exponent      = boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::max_exponent;
+   BOOST_STATIC_CONSTEXPR typename boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_type max_exponent10    = (max_exponent / 1000) * 301L;
+   BOOST_STATIC_CONSTEXPR bool                                                                                                             has_infinity      = true;
+   BOOST_STATIC_CONSTEXPR bool                                                                                                             has_quiet_NaN     = true;
+   BOOST_STATIC_CONSTEXPR bool                                                                                                             has_signaling_NaN = false;
+   BOOST_STATIC_CONSTEXPR float_denorm_style has_denorm                                                                                                      = denorm_absent;
+   BOOST_STATIC_CONSTEXPR bool               has_denorm_loss                                                                                                 = false;
+   static number_type                        infinity()
    {
       initializer.do_nothing();
       static std::pair<bool, number_type> value;
-      if(!value.first)
+      if (!value.first)
       {
-         value.first = true;
+         value.first                       = true;
          value.second.backend().exponent() = boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_infinity;
       }
       return value.second;
@@ -1955,9 +1948,9 @@ public:
    {
       initializer.do_nothing();
       static std::pair<bool, number_type> value;
-      if(!value.first)
+      if (!value.first)
       {
-         value.first = true;
+         value.first                       = true;
          value.second.backend().exponent() = boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_nan;
       }
       return value.second;
@@ -1967,13 +1960,14 @@ public:
       return number_type(0);
    }
    BOOST_STATIC_CONSTEXPR number_type denorm_min() { return number_type(0); }
-   BOOST_STATIC_CONSTEXPR bool is_iec559 = false;
-   BOOST_STATIC_CONSTEXPR bool is_bounded = true;
-   BOOST_STATIC_CONSTEXPR bool is_modulo = false;
-   BOOST_STATIC_CONSTEXPR bool traps = true;
-   BOOST_STATIC_CONSTEXPR bool tinyness_before = false;
+   BOOST_STATIC_CONSTEXPR bool        is_iec559         = false;
+   BOOST_STATIC_CONSTEXPR bool        is_bounded        = true;
+   BOOST_STATIC_CONSTEXPR bool        is_modulo         = false;
+   BOOST_STATIC_CONSTEXPR bool        traps             = true;
+   BOOST_STATIC_CONSTEXPR bool        tinyness_before   = false;
    BOOST_STATIC_CONSTEXPR float_round_style round_style = round_to_nearest;
-private:
+
+ private:
    struct data_initializer
    {
       data_initializer()
@@ -1985,12 +1979,12 @@ private:
          std::numeric_limits<boost::multiprecision::number<boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> > >::infinity();
          std::numeric_limits<boost::multiprecision::number<boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> > >::quiet_NaN();
       }
-      void do_nothing()const{}
+      void do_nothing() const {}
    };
    static const data_initializer initializer;
 };
 
-template<unsigned Digits, boost::multiprecision::backends::digit_base_type DigitBase, class Allocator, class Exponent, Exponent MinE, Exponent MaxE, boost::multiprecision::expression_template_option ExpressionTemplates>
+template <unsigned Digits, boost::multiprecision::backends::digit_base_type DigitBase, class Allocator, class Exponent, Exponent MinE, Exponent MaxE, boost::multiprecision::expression_template_option ExpressionTemplates>
 const typename numeric_limits<boost::multiprecision::number<boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>, ExpressionTemplates> >::data_initializer numeric_limits<boost::multiprecision::number<boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>, ExpressionTemplates> >::initializer;
 
 #ifndef BOOST_NO_INCLASS_MEMBER_INITIALIZATION

--- a/include/boost/multiprecision/cpp_bin_float/io.hpp
+++ b/include/boost/multiprecision/cpp_bin_float/io.hpp
@@ -6,47 +6,47 @@
 #ifndef BOOST_MP_CPP_BIN_FLOAT_IO_HPP
 #define BOOST_MP_CPP_BIN_FLOAT_IO_HPP
 
-namespace boost{ namespace multiprecision{ namespace cpp_bf_io_detail{
+namespace boost { namespace multiprecision {
+namespace cpp_bf_io_detail {
 
 #ifdef BOOST_MSVC
 #pragma warning(push)
-#pragma warning(disable:4127) // conditional expression is constant
+#pragma warning(disable : 4127) // conditional expression is constant
 #endif
 
-
 //
-// Multiplies a by b and shifts the result so it fits inside max_bits bits, 
+// Multiplies a by b and shifts the result so it fits inside max_bits bits,
 // returns by how much the result was shifted.
 //
 template <class I>
-inline I restricted_multiply(cpp_int& result, const cpp_int& a, const cpp_int& b, I max_bits, boost::int64_t& error)
+inline I restricted_multiply(cpp_int &result, const cpp_int &a, const cpp_int &b, I max_bits, boost::int64_t &error)
 {
-   result = a * b;
-   I gb = msb(result);
+   result   = a * b;
+   I gb     = msb(result);
    I rshift = 0;
-   if(gb > max_bits)
+   if (gb > max_bits)
    {
-      rshift = gb - max_bits;
-      I lb = lsb(result);
+      rshift      = gb - max_bits;
+      I   lb      = lsb(result);
       int roundup = 0;
-      // The error rate increases by the error of both a and b, 
+      // The error rate increases by the error of both a and b,
       // this may be overly pessimistic in many case as we're assuming
       // that a and b have the same level of uncertainty...
-      if(lb < rshift)
+      if (lb < rshift)
          error = error ? error * 2 : 1;
-      if(rshift)
+      if (rshift)
       {
          BOOST_ASSERT(rshift < INT_MAX);
-         if(bit_test(result, static_cast<unsigned>(rshift - 1)))
+         if (bit_test(result, static_cast<unsigned>(rshift - 1)))
          {
-            if(lb == rshift - 1)
+            if (lb == rshift - 1)
                roundup = 1;
             else
                roundup = 2;
          }
          result >>= rshift;
       }
-      if((roundup == 2) || ((roundup == 1) && (result.backend().limbs()[0] & 1)))
+      if ((roundup == 2) || ((roundup == 1) && (result.backend().limbs()[0] & 1)))
          ++result;
    }
    return rshift;
@@ -56,20 +56,20 @@ inline I restricted_multiply(cpp_int& result, const cpp_int& a, const cpp_int& b
 // to the right we are shifted.
 //
 template <class I>
-inline I restricted_pow(cpp_int& result, const cpp_int& a, I e, I max_bits, boost::int64_t& error)
+inline I restricted_pow(cpp_int &result, const cpp_int &a, I e, I max_bits, boost::int64_t &error)
 {
    BOOST_ASSERT(&result != &a);
    I exp = 0;
-   if(e == 1)
+   if (e == 1)
    {
       result = a;
       return exp;
    }
-   else if(e == 2)
+   else if (e == 2)
    {
       return restricted_multiply(result, a, a, max_bits, error);
    }
-   else if(e == 3)
+   else if (e == 3)
    {
       exp = restricted_multiply(result, a, a, max_bits, error);
       exp += restricted_multiply(result, result, a, max_bits, error);
@@ -79,12 +79,12 @@ inline I restricted_pow(cpp_int& result, const cpp_int& a, I e, I max_bits, boos
    exp = restricted_pow(result, a, p, max_bits, error);
    exp *= 2;
    exp += restricted_multiply(result, result, result, max_bits, error);
-   if(e & 1)
+   if (e & 1)
       exp += restricted_multiply(result, result, a, max_bits, error);
    return exp;
 }
 
-inline int get_round_mode(const cpp_int& what, boost::int64_t location, boost::int64_t error)
+inline int get_round_mode(const cpp_int &what, boost::int64_t location, boost::int64_t error)
 {
    //
    // Can we round what at /location/, if the error in what is /error/ in
@@ -98,20 +98,20 @@ inline int get_round_mode(const cpp_int& what, boost::int64_t location, boost::i
    BOOST_ASSERT(location >= 0);
    BOOST_ASSERT(location < INT_MAX);
    boost::int64_t error_radius = error & 1 ? (1 + error) / 2 : error / 2;
-   if(error_radius && ((int)msb(error_radius) >= location))
+   if (error_radius && ((int)msb(error_radius) >= location))
       return -1;
-   if(bit_test(what, static_cast<unsigned>(location)))
+   if (bit_test(what, static_cast<unsigned>(location)))
    {
-      if((int)lsb(what) == location)
-         return error ? -1 : 1;   // Either a tie or can't round depending on whether we have any error
-      if(!error)
-         return 2;  // no error, round up.
+      if ((int)lsb(what) == location)
+         return error ? -1 : 1; // Either a tie or can't round depending on whether we have any error
+      if (!error)
+         return 2; // no error, round up.
       cpp_int t = what - error_radius;
-      if((int)lsb(t) >= location)
+      if ((int)lsb(t) >= location)
          return -1;
       return 2;
    }
-   else if(error)
+   else if (error)
    {
       cpp_int t = what + error_radius;
       return bit_test(t, static_cast<unsigned>(location)) ? -1 : 0;
@@ -119,7 +119,7 @@ inline int get_round_mode(const cpp_int& what, boost::int64_t location, boost::i
    return 0;
 }
 
-inline int get_round_mode(cpp_int& r, cpp_int& d, boost::int64_t error, const cpp_int& q)
+inline int get_round_mode(cpp_int &r, cpp_int &d, boost::int64_t error, const cpp_int &q)
 {
    //
    // Lets suppose we have an inexact division by d+delta, where the true
@@ -146,18 +146,18 @@ inline int get_round_mode(cpp_int& r, cpp_int& d, boost::int64_t error, const cp
    //
    r <<= 1;
    int c = r.compare(d);
-   if(c == 0)
+   if (c == 0)
       return error ? -1 : 1;
-   if(c > 0)
+   if (c > 0)
    {
-      if(error)
+      if (error)
       {
          r -= error * q;
          return r.compare(d) > 0 ? 2 : -1;
       }
       return 2;
    }
-   if(error)
+   if (error)
    {
       r += error * q;
       return r.compare(d) < 0 ? 0 : -1;
@@ -165,108 +165,108 @@ inline int get_round_mode(cpp_int& r, cpp_int& d, boost::int64_t error, const cp
    return 0;
 }
 
-} // namespace
+} // namespace cpp_bf_io_detail
 
-namespace backends{
+namespace backends {
 
 template <unsigned Digits, digit_base_type DigitBase, class Allocator, class Exponent, Exponent MinE, Exponent MaxE>
-cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>& cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::operator=(const char *s)
+cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> &cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::operator=(const char *s)
 {
-   cpp_int n;
-   boost::intmax_t decimal_exp = 0;
-   boost::intmax_t digits_seen = 0;
+   cpp_int                      n;
+   boost::intmax_t              decimal_exp     = 0;
+   boost::intmax_t              digits_seen     = 0;
    static const boost::intmax_t max_digits_seen = 4 + (cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count * 301L) / 1000;
-   bool ss = false;
+   bool                         ss              = false;
    //
    // Extract the sign:
    //
-   if(*s == '-')
+   if (*s == '-')
    {
       ss = true;
       ++s;
    }
-   else if(*s == '+')
+   else if (*s == '+')
       ++s;
    //
    // Special cases first:
    //
-   if((std::strcmp(s, "nan") == 0) || (std::strcmp(s, "NaN") == 0) || (std::strcmp(s, "NAN") == 0))
+   if ((std::strcmp(s, "nan") == 0) || (std::strcmp(s, "NaN") == 0) || (std::strcmp(s, "NAN") == 0))
    {
       return *this = std::numeric_limits<number<cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> > >::quiet_NaN().backend();
    }
-   if((std::strcmp(s, "inf") == 0) || (std::strcmp(s, "Inf") == 0) || (std::strcmp(s, "INF") == 0) || (std::strcmp(s, "infinity") == 0) || (std::strcmp(s, "Infinity") == 0) || (std::strcmp(s, "INFINITY") == 0))
+   if ((std::strcmp(s, "inf") == 0) || (std::strcmp(s, "Inf") == 0) || (std::strcmp(s, "INF") == 0) || (std::strcmp(s, "infinity") == 0) || (std::strcmp(s, "Infinity") == 0) || (std::strcmp(s, "INFINITY") == 0))
    {
       *this = std::numeric_limits<number<cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> > >::infinity().backend();
-      if(ss)
+      if (ss)
          negate();
       return *this;
    }
    //
    // Digits before the point:
    //
-   while(*s && (*s >= '0') && (*s <= '9'))
+   while (*s && (*s >= '0') && (*s <= '9'))
    {
       n *= 10u;
       n += *s - '0';
-      if(digits_seen || (*s != '0'))
+      if (digits_seen || (*s != '0'))
          ++digits_seen;
       ++s;
    }
    // The decimal point (we really should localise this!!)
-   if(*s && (*s == '.'))
+   if (*s && (*s == '.'))
       ++s;
    //
    // Digits after the point:
    //
-   while(*s && (*s >= '0') && (*s <= '9'))
+   while (*s && (*s >= '0') && (*s <= '9'))
    {
       n *= 10u;
       n += *s - '0';
       --decimal_exp;
-      if(digits_seen || (*s != '0'))
+      if (digits_seen || (*s != '0'))
          ++digits_seen;
       ++s;
-      if(digits_seen > max_digits_seen)
+      if (digits_seen > max_digits_seen)
          break;
    }
    //
    // Digits we're skipping:
    //
-   while(*s && (*s >= '0') && (*s <= '9'))
+   while (*s && (*s >= '0') && (*s <= '9'))
       ++s;
    //
    // See if there's an exponent:
    //
-   if(*s && ((*s == 'e') || (*s == 'E')))
+   if (*s && ((*s == 'e') || (*s == 'E')))
    {
       ++s;
-      boost::intmax_t e = 0;
-      bool es = false;
-      if(*s && (*s == '-'))
+      boost::intmax_t e  = 0;
+      bool            es = false;
+      if (*s && (*s == '-'))
       {
          es = true;
          ++s;
       }
-      else if(*s && (*s == '+'))
+      else if (*s && (*s == '+'))
          ++s;
-      while(*s && (*s >= '0') && (*s <= '9'))
+      while (*s && (*s >= '0') && (*s <= '9'))
       {
          e *= 10u;
          e += *s - '0';
          ++s;
       }
-      if(es)
+      if (es)
          e = -e;
       decimal_exp += e;
    }
-   if(*s)
+   if (*s)
    {
       //
       // Oops unexpected input at the end of the number:
       //
       BOOST_THROW_EXCEPTION(std::runtime_error("Unable to parse string as a valid floating point number."));
    }
-   if(n == 0)
+   if (n == 0)
    {
       // Result is necessarily zero:
       *this = static_cast<limb_type>(0u);
@@ -290,17 +290,17 @@ cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>& cpp_bin_float
 #else
    boost::intmax_t max_bits = cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count + ((cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count % limb_bits) ? (limb_bits - cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count % limb_bits) : 0) + limb_bits;
 #endif
-   boost::int64_t error = 0;
-   boost::intmax_t calc_exp = 0;
+   boost::int64_t  error          = 0;
+   boost::intmax_t calc_exp       = 0;
    boost::intmax_t final_exponent = 0;
 
-   if(decimal_exp >= 0)
+   if (decimal_exp >= 0)
    {
       // Nice and simple, the result is an integer...
       do
       {
          cpp_int t;
-         if(decimal_exp)
+         if (decimal_exp)
          {
             calc_exp = boost::multiprecision::cpp_bf_io_detail::restricted_pow(t, cpp_int(5), decimal_exp, max_bits, error);
             calc_exp += boost::multiprecision::cpp_bf_io_detail::restricted_multiply(t, t, n, max_bits, error);
@@ -308,15 +308,15 @@ cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>& cpp_bin_float
          else
             t = n;
          final_exponent = (boost::int64_t)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - 1 + decimal_exp + calc_exp;
-         int rshift = msb(t) - cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count + 1;
-         if(rshift > 0)
+         int rshift     = msb(t) - cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count + 1;
+         if (rshift > 0)
          {
             final_exponent += rshift;
             int roundup = boost::multiprecision::cpp_bf_io_detail::get_round_mode(t, rshift - 1, error);
             t >>= rshift;
-            if((roundup == 2) || ((roundup == 1) && t.backend().limbs()[0] & 1))
+            if ((roundup == 2) || ((roundup == 1) && t.backend().limbs()[0] & 1))
                ++t;
-            else if(roundup < 0)
+            else if (roundup < 0)
             {
 #ifdef BOOST_MP_STRESS_IO
                max_bits += 32;
@@ -331,12 +331,12 @@ cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>& cpp_bin_float
          {
             BOOST_ASSERT(!error);
          }
-         if(final_exponent > cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::max_exponent)
+         if (final_exponent > cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::max_exponent)
          {
             exponent() = cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::max_exponent;
             final_exponent -= cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::max_exponent;
          }
-         else if(final_exponent < cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::min_exponent)
+         else if (final_exponent < cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::min_exponent)
          {
             // Underflow:
             exponent() = cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::min_exponent;
@@ -344,15 +344,14 @@ cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>& cpp_bin_float
          }
          else
          {
-            exponent() = static_cast<Exponent>(final_exponent);
+            exponent()     = static_cast<Exponent>(final_exponent);
             final_exponent = 0;
          }
          copy_and_round(*this, t.backend());
          break;
-      }
-      while(true);
+      } while (true);
 
-      if(ss != sign())
+      if (ss != sign())
          negate();
    }
    else
@@ -364,10 +363,10 @@ cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>& cpp_bin_float
       do
       {
          cpp_int d;
-         calc_exp = boost::multiprecision::cpp_bf_io_detail::restricted_pow(d, cpp_int(5), -decimal_exp, max_bits, error);
-         int shift = (int)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - msb(n) + msb(d);
+         calc_exp       = boost::multiprecision::cpp_bf_io_detail::restricted_pow(d, cpp_int(5), -decimal_exp, max_bits, error);
+         int shift      = (int)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - msb(n) + msb(d);
          final_exponent = cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - 1 + decimal_exp - calc_exp;
-         if(shift > 0)
+         if (shift > 0)
          {
             n <<= shift;
             final_exponent -= static_cast<Exponent>(shift);
@@ -381,12 +380,12 @@ cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>& cpp_bin_float
          // handle ourselves:
          //
          int roundup = 0;
-         if(gb == cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - 1)
+         if (gb == cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - 1)
          {
             // Exactly the right number of bits, use the remainder to round:
             roundup = boost::multiprecision::cpp_bf_io_detail::get_round_mode(r, d, error, q);
          }
-         else if(bit_test(q, gb - (int)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count) && ((int)lsb(q) == (gb - (int)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count)))
+         else if (bit_test(q, gb - (int)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count) && ((int)lsb(q) == (gb - (int)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count)))
          {
             // Too many bits in q and the bits in q indicate a tie, but we can break that using r,
             // note that the radius of error in r is error/2 * q:
@@ -394,19 +393,19 @@ cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>& cpp_bin_float
             q >>= lshift;
             final_exponent += static_cast<Exponent>(lshift);
             BOOST_ASSERT((msb(q) >= cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - 1));
-            if(error && (r < (error / 2) * q))
+            if (error && (r < (error / 2) * q))
                roundup = -1;
-            else if(error && (r + (error / 2) * q >= d))
+            else if (error && (r + (error / 2) * q >= d))
                roundup = -1;
             else
                roundup = r ? 2 : 1;
          }
-         else if(error && (((error / 2) * q + r >= d) || (r < (error / 2) * q)))
+         else if (error && (((error / 2) * q + r >= d) || (r < (error / 2) * q)))
          {
             // We might have been rounding up, or got the wrong quotient: can't tell!
             roundup = -1;
          }
-         if(roundup < 0)
+         if (roundup < 0)
          {
 #ifdef BOOST_MP_STRESS_IO
             max_bits += 32;
@@ -414,22 +413,22 @@ cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>& cpp_bin_float
             max_bits *= 2;
 #endif
             error = 0;
-            if(shift > 0)
+            if (shift > 0)
             {
                n >>= shift;
                final_exponent += static_cast<Exponent>(shift);
             }
             continue;
          }
-         else if((roundup == 2) || ((roundup == 1) && q.backend().limbs()[0] & 1))
+         else if ((roundup == 2) || ((roundup == 1) && q.backend().limbs()[0] & 1))
             ++q;
-         if(final_exponent > cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::max_exponent)
+         if (final_exponent > cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::max_exponent)
          {
             // Overflow:
             exponent() = cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::max_exponent;
             final_exponent -= cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::max_exponent;
          }
-         else if(final_exponent < cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::min_exponent)
+         else if (final_exponent < cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::min_exponent)
          {
             // Underflow:
             exponent() = cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::min_exponent;
@@ -437,32 +436,31 @@ cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>& cpp_bin_float
          }
          else
          {
-            exponent() = static_cast<Exponent>(final_exponent);
+            exponent()     = static_cast<Exponent>(final_exponent);
             final_exponent = 0;
          }
          copy_and_round(*this, q.backend());
-         if(ss != sign())
+         if (ss != sign())
             negate();
          break;
-      }
-      while(true);
+      } while (true);
    }
    //
    // Check for scaling and/or over/under-flow:
    //
    final_exponent += exponent();
-   if(final_exponent > cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::max_exponent)
+   if (final_exponent > cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::max_exponent)
    {
       // Overflow:
       exponent() = cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_infinity;
-      bits() = limb_type(0);
+      bits()     = limb_type(0);
    }
-   else if(final_exponent < cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::min_exponent)
+   else if (final_exponent < cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::min_exponent)
    {
       // Underflow:
       exponent() = cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero;
-      bits() = limb_type(0);
-      sign() = 0;
+      bits()     = limb_type(0);
+      sign()     = 0;
    }
    else
    {
@@ -474,34 +472,34 @@ cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>& cpp_bin_float
 template <unsigned Digits, digit_base_type DigitBase, class Allocator, class Exponent, Exponent MinE, Exponent MaxE>
 std::string cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::str(std::streamsize dig, std::ios_base::fmtflags f) const
 {
-   if(dig == 0)
+   if (dig == 0)
       dig = std::numeric_limits<number<cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE> > >::max_digits10;
 
    bool scientific = (f & std::ios_base::scientific) == std::ios_base::scientific;
-   bool fixed = !scientific && (f & std::ios_base::fixed);
+   bool fixed      = !scientific && (f & std::ios_base::fixed);
 
    std::string s;
 
-   if(exponent() <= cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::max_exponent)
+   if (exponent() <= cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::max_exponent)
    {
       // How far to left-shift in order to demormalise the mantissa:
-      boost::intmax_t shift = (boost::intmax_t)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - (boost::intmax_t)exponent() - 1;
+      boost::intmax_t shift         = (boost::intmax_t)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - (boost::intmax_t)exponent() - 1;
       boost::intmax_t digits_wanted = static_cast<int>(dig);
-      boost::intmax_t base10_exp = exponent() >= 0 ? static_cast<boost::intmax_t>(std::floor(0.30103 * exponent())) : static_cast<boost::intmax_t>(std::ceil(0.30103 * exponent()));
+      boost::intmax_t base10_exp    = exponent() >= 0 ? static_cast<boost::intmax_t>(std::floor(0.30103 * exponent())) : static_cast<boost::intmax_t>(std::ceil(0.30103 * exponent()));
       //
       // For fixed formatting we want /dig/ digits after the decimal point,
       // so if the exponent is zero, allowing for the one digit before the
       // decimal point, we want 1 + dig digits etc.
       //
-      if(fixed)
+      if (fixed)
          digits_wanted += 1 + base10_exp;
-      if(scientific)
+      if (scientific)
          digits_wanted += 1;
-      if(digits_wanted < -1)
+      if (digits_wanted < -1)
       {
          // Fixed precision, no significant digits, and nothing to round!
          s = "0";
-         if(sign())
+         if (sign())
             s.insert(static_cast<std::string::size_type>(0), 1, '-');
          boost::multiprecision::detail::format_float_string(s, base10_exp, dig, f, true);
          return s;
@@ -516,8 +514,8 @@ std::string cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::s
       // 2^power10 into /shift/
       //
       shift -= power10;
-      cpp_int i;
-      int roundup = 0; // 0=no rounding, 1=tie, 2=up
+      cpp_int               i;
+      int                   roundup   = 0; // 0=no rounding, 1=tie, 2=up
       static const unsigned limb_bits = sizeof(limb_type) * CHAR_BIT;
       //
       // Set our working precision - this is heuristic based, we want
@@ -532,29 +530,29 @@ std::string cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::s
       boost::intmax_t max_bits = cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count + 32;
 #else
       boost::intmax_t max_bits = cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count + ((cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count % limb_bits) ? (limb_bits - cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count % limb_bits) : 0) + limb_bits;
-      if(power10)
+      if (power10)
          max_bits += (msb(boost::multiprecision::detail::abs(power10)) / 8) * limb_bits;
 #endif
       do
       {
-         boost::int64_t error = 0;
+         boost::int64_t  error    = 0;
          boost::intmax_t calc_exp = 0;
          //
          // Our integer result is: bits() * 2^-shift * 5^power10
          //
          i = bits();
-         if(shift < 0)
+         if (shift < 0)
          {
-            if(power10 >= 0)
+            if (power10 >= 0)
             {
                // We go straight to the answer with all integer arithmetic,
                // the result is always exact and never needs rounding:
                BOOST_ASSERT(power10 <= (boost::intmax_t)INT_MAX);
                i <<= -shift;
-               if(power10)
+               if (power10)
                   i *= pow(cpp_int(5), static_cast<unsigned>(power10));
             }
-            else if(power10 < 0)
+            else if (power10 < 0)
             {
                cpp_int d;
                calc_exp = boost::multiprecision::cpp_bf_io_detail::restricted_pow(d, cpp_int(5), -power10, max_bits, error);
@@ -564,7 +562,7 @@ std::string cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::s
                cpp_int r;
                divide_qr(i, d, i, r);
                roundup = boost::multiprecision::cpp_bf_io_detail::get_round_mode(r, d, error, i);
-               if(roundup < 0)
+               if (roundup < 0)
                {
 #ifdef BOOST_MP_STRESS_IO
                   max_bits += 32;
@@ -581,16 +579,16 @@ std::string cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::s
             //
             // Our integer is bits() * 2^-shift * 10^power10
             //
-            if(power10 > 0)
+            if (power10 > 0)
             {
-               if(power10)
+               if (power10)
                {
                   cpp_int t;
                   calc_exp = boost::multiprecision::cpp_bf_io_detail::restricted_pow(t, cpp_int(5), power10, max_bits, error);
                   calc_exp += boost::multiprecision::cpp_bf_io_detail::restricted_multiply(i, i, t, max_bits, error);
                   shift -= calc_exp;
                }
-               if((shift < 0) || ((shift == 0) && error))
+               if ((shift < 0) || ((shift == 0) && error))
                {
                   // We only get here if we were asked for a crazy number of decimal digits -
                   // more than are present in a 2^max_bits number.
@@ -602,10 +600,10 @@ std::string cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::s
                   shift = (boost::intmax_t)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - exponent() - 1 - power10;
                   continue;
                }
-               if(shift)
+               if (shift)
                {
                   roundup = boost::multiprecision::cpp_bf_io_detail::get_round_mode(i, shift - 1, error);
-                  if(roundup < 0)
+                  if (roundup < 0)
                   {
 #ifdef BOOST_MP_STRESS_IO
                      max_bits += 32;
@@ -629,7 +627,7 @@ std::string cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::s
                d <<= shift;
                divide_qr(i, d, i, r);
                r <<= 1;
-               int c = r.compare(d);
+               int c   = r.compare(d);
                roundup = c < 0 ? 0 : c == 0 ? 1 : 2;
             }
          }
@@ -640,40 +638,39 @@ std::string cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::s
          // decimal exponent correctly:
          //
          boost::intmax_t digits_got = i ? static_cast<boost::intmax_t>(s.size()) : 0;
-         if(digits_got != digits_wanted)
+         if (digits_got != digits_wanted)
          {
             base10_exp += digits_got - digits_wanted;
-            if(fixed)
-               digits_wanted = digits_got;  // strange but true.
+            if (fixed)
+               digits_wanted = digits_got; // strange but true.
             power10 = digits_wanted - base10_exp - 1;
-            shift = (boost::intmax_t)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - exponent() - 1 - power10;
-            if(fixed)
+            shift   = (boost::intmax_t)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - exponent() - 1 - power10;
+            if (fixed)
                break;
             roundup = 0;
          }
          else
             break;
-      }
-      while(true);
+      } while (true);
       //
       // Check whether we need to round up: note that we could equally round up
       // the integer /i/ above, but since we need to perform the rounding *after*
       // the conversion to a string and the digit count check, we might as well
       // do it here:
       //
-      if((roundup == 2) || ((roundup == 1) && ((s[s.size() - 1] - '0') & 1)))
+      if ((roundup == 2) || ((roundup == 1) && ((s[s.size() - 1] - '0') & 1)))
       {
          boost::multiprecision::detail::round_string_up_at(s, static_cast<int>(s.size() - 1), base10_exp);
       }
 
-      if(sign())
+      if (sign())
          s.insert(static_cast<std::string::size_type>(0), 1, '-');
 
       boost::multiprecision::detail::format_float_string(s, base10_exp, dig, f, false);
    }
    else
    {
-      switch(exponent())
+      switch (exponent())
       {
       case exponent_zero:
          s = sign() ? "-0" : f & std::ios_base::showpos ? "+0" : "0";
@@ -694,7 +691,7 @@ std::string cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::s
 #pragma warning(pop)
 #endif
 
-}}} // namespaces
+} // namespace backends
+}} // namespace boost::multiprecision
 
 #endif
-

--- a/include/boost/multiprecision/cpp_int/add.hpp
+++ b/include/boost/multiprecision/cpp_int/add.hpp
@@ -8,28 +8,28 @@
 #ifndef BOOST_MP_CPP_INT_ADD_HPP
 #define BOOST_MP_CPP_INT_ADD_HPP
 
-namespace boost{ namespace multiprecision{ namespace backends{
+namespace boost { namespace multiprecision { namespace backends {
 
 #ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning(disable:4127) // conditional expression is constant
+#pragma warning(disable : 4127) // conditional expression is constant
 #endif
 
 //
 // This is the key addition routine where all the argument types are non-trivial cpp_int's:
 //
 template <class CppInt1, class CppInt2, class CppInt3>
-inline void add_unsigned(CppInt1& result, const CppInt2& a, const CppInt3& b) BOOST_MP_NOEXCEPT_IF(is_non_throwing_cpp_int<CppInt1>::value)
+inline void add_unsigned(CppInt1 &result, const CppInt2 &a, const CppInt3 &b) BOOST_MP_NOEXCEPT_IF(is_non_throwing_cpp_int<CppInt1>::value)
 {
    using std::swap;
 
    // Nothing fancy, just let uintmax_t take the strain:
    double_limb_type carry = 0;
-   unsigned m, x;
-   unsigned as = a.size();
-   unsigned bs = b.size();
+   unsigned         m, x;
+   unsigned         as = a.size();
+   unsigned         bs = b.size();
    minmax(as, bs, m, x);
-   if(x == 1)
+   if (x == 1)
    {
       bool s = a.sign();
       result = static_cast<double_limb_type>(*a.limbs()) + static_cast<double_limb_type>(*b.limbs());
@@ -37,16 +37,16 @@ inline void add_unsigned(CppInt1& result, const CppInt2& a, const CppInt3& b) BO
       return;
    }
    result.resize(x, x);
-   typename CppInt2::const_limb_pointer pa = a.limbs();
-   typename CppInt3::const_limb_pointer pb = b.limbs();
-   typename CppInt1::limb_pointer pr = result.limbs();
-   typename CppInt1::limb_pointer pr_end = pr + m;
+   typename CppInt2::const_limb_pointer pa     = a.limbs();
+   typename CppInt3::const_limb_pointer pb     = b.limbs();
+   typename CppInt1::limb_pointer       pr     = result.limbs();
+   typename CppInt1::limb_pointer       pr_end = pr + m;
 
-   if(as < bs)
+   if (as < bs)
       swap(pa, pb);
-   
+
    // First where a and b overlap:
-   while(pr != pr_end)
+   while (pr != pr_end)
    {
       carry += static_cast<double_limb_type>(*pa) + static_cast<double_limb_type>(*pb);
 #ifdef __MSVC_RUNTIME_CHECKS
@@ -59,13 +59,13 @@ inline void add_unsigned(CppInt1& result, const CppInt2& a, const CppInt3& b) BO
    }
    pr_end += x - m;
    // Now where only a has digits:
-   while(pr != pr_end)
+   while (pr != pr_end)
    {
-      if(!carry)
+      if (!carry)
       {
-         if(pa != pr)
+         if (pa != pr)
 #if BOOST_WORKAROUND(BOOST_MSVC, >= 1600)
-            std::copy(pa, pa + (pr_end - pr), stdext::checked_array_iterator<limb_type*>(pr, result.size()));
+            std::copy(pa, pa + (pr_end - pr), stdext::checked_array_iterator<limb_type *>(pr, result.size()));
 #else
             std::copy(pa, pa + (pr_end - pr), pr);
 #endif
@@ -75,16 +75,16 @@ inline void add_unsigned(CppInt1& result, const CppInt2& a, const CppInt3& b) BO
 #ifdef __MSVC_RUNTIME_CHECKS
       *pr = static_cast<limb_type>(carry & ~static_cast<limb_type>(0));
 #else
-      *pr = static_cast<limb_type>(carry);
+      *pr   = static_cast<limb_type>(carry);
 #endif
       carry >>= CppInt1::limb_bits;
       ++pr, ++pa;
    }
-   if(carry)
+   if (carry)
    {
       // We overflowed, need to add one more limb:
       result.resize(x + 1, x + 1);
-      if(result.size() > x)
+      if (result.size() > x)
          result.limbs()[x] = static_cast<limb_type>(carry);
    }
    result.normalize();
@@ -94,18 +94,18 @@ inline void add_unsigned(CppInt1& result, const CppInt2& a, const CppInt3& b) BO
 // As above, but for adding a single limb to a non-trivial cpp_int:
 //
 template <class CppInt1, class CppInt2>
-inline void add_unsigned(CppInt1& result, const CppInt2& a, const limb_type& o) BOOST_MP_NOEXCEPT_IF(is_non_throwing_cpp_int<CppInt1>::value)
+inline void add_unsigned(CppInt1 &result, const CppInt2 &a, const limb_type &o) BOOST_MP_NOEXCEPT_IF(is_non_throwing_cpp_int<CppInt1>::value)
 {
    // Addition using modular arithmetic.
    // Nothing fancy, just let uintmax_t take the strain:
-   if(&result != &a)
+   if (&result != &a)
       result.resize(a.size(), a.size());
-   double_limb_type carry = o;
-   typename CppInt1::limb_pointer pr = result.limbs();
-   typename CppInt2::const_limb_pointer pa = a.limbs();
-   unsigned i = 0;
+   double_limb_type                     carry = o;
+   typename CppInt1::limb_pointer       pr    = result.limbs();
+   typename CppInt2::const_limb_pointer pa    = a.limbs();
+   unsigned                             i     = 0;
    // Addition with carry until we either run out of digits or carry is zero:
-   for(; carry && (i < result.size()); ++i)
+   for (; carry && (i < result.size()); ++i)
    {
       carry += static_cast<double_limb_type>(pa[i]);
 #ifdef __MSVC_RUNTIME_CHECKS
@@ -116,17 +116,17 @@ inline void add_unsigned(CppInt1& result, const CppInt2& a, const limb_type& o) 
       carry >>= CppInt1::limb_bits;
    }
    // Just copy any remaining digits:
-   if(&a != &result)
+   if (&a != &result)
    {
-      for(; i < result.size(); ++i)
+      for (; i < result.size(); ++i)
          pr[i] = pa[i];
    }
-   if(carry)
+   if (carry)
    {
       // We overflowed, need to add one more limb:
       unsigned x = result.size();
       result.resize(x + 1, x + 1);
-      if(result.size() > x)
+      if (result.size() > x)
          result.limbs()[x] = static_cast<limb_type>(carry);
    }
    result.normalize();
@@ -136,23 +136,23 @@ inline void add_unsigned(CppInt1& result, const CppInt2& a, const limb_type& o) 
 // Core subtraction routine for all non-trivial cpp_int's:
 //
 template <class CppInt1, class CppInt2, class CppInt3>
-inline void subtract_unsigned(CppInt1& result, const CppInt2& a, const CppInt3& b) BOOST_MP_NOEXCEPT_IF(is_non_throwing_cpp_int<CppInt1>::value)
+inline void subtract_unsigned(CppInt1 &result, const CppInt2 &a, const CppInt3 &b) BOOST_MP_NOEXCEPT_IF(is_non_throwing_cpp_int<CppInt1>::value)
 {
    using std::swap;
 
    // Nothing fancy, just let uintmax_t take the strain:
    double_limb_type borrow = 0;
-   unsigned m, x;
+   unsigned         m, x;
    minmax(a.size(), b.size(), m, x);
    //
    // special cases for small limb counts:
    //
-   if(x == 1)
+   if (x == 1)
    {
-      bool s = a.sign();
+      bool      s  = a.sign();
       limb_type al = *a.limbs();
       limb_type bl = *b.limbs();
-      if(bl > al)
+      if (bl > al)
       {
          std::swap(al, bl);
          s = !s;
@@ -167,42 +167,42 @@ inline void subtract_unsigned(CppInt1& result, const CppInt2& a, const CppInt3& 
    // Set up the result vector:
    result.resize(x, x);
    // Now that a, b, and result are stable, get pointers to their limbs:
-   typename CppInt2::const_limb_pointer pa = a.limbs();
-   typename CppInt3::const_limb_pointer pb = b.limbs();
-   typename CppInt1::limb_pointer pr = result.limbs();
-   bool swapped = false;
-   if(c < 0)
+   typename CppInt2::const_limb_pointer pa      = a.limbs();
+   typename CppInt3::const_limb_pointer pb      = b.limbs();
+   typename CppInt1::limb_pointer       pr      = result.limbs();
+   bool                                 swapped = false;
+   if (c < 0)
    {
       swap(pa, pb);
       swapped = true;
    }
-   else if(c == 0)
+   else if (c == 0)
    {
       result = static_cast<limb_type>(0);
       return;
    }
-   
+
    unsigned i = 0;
    // First where a and b overlap:
-   while(i < m)
+   while (i < m)
    {
       borrow = static_cast<double_limb_type>(pa[i]) - static_cast<double_limb_type>(pb[i]) - borrow;
-      pr[i] = static_cast<limb_type>(borrow);
+      pr[i]  = static_cast<limb_type>(borrow);
       borrow = (borrow >> CppInt1::limb_bits) & 1u;
       ++i;
    }
    // Now where only a has digits, only as long as we've borrowed:
-   while(borrow && (i < x))
+   while (borrow && (i < x))
    {
       borrow = static_cast<double_limb_type>(pa[i]) - borrow;
-      pr[i] = static_cast<limb_type>(borrow);
+      pr[i]  = static_cast<limb_type>(borrow);
       borrow = (borrow >> CppInt1::limb_bits) & 1u;
       ++i;
    }
    // Any remaining digits are the same as those in pa:
-   if((x != i) && (pa != pr))
+   if ((x != i) && (pa != pr))
 #if BOOST_WORKAROUND(BOOST_MSVC, >= 1600)
-      std::copy(pa + i, pa + x, stdext::checked_array_iterator<limb_type*>(pr + i, result.size() - i));
+      std::copy(pa + i, pa + x, stdext::checked_array_iterator<limb_type *>(pr + i, result.size() - i));
 #else
       std::copy(pa + i, pa + x, pr + i);
 #endif
@@ -213,58 +213,58 @@ inline void subtract_unsigned(CppInt1& result, const CppInt2& a, const CppInt3& 
    //
    result.normalize();
    result.sign(a.sign());
-   if(swapped)
+   if (swapped)
       result.negate();
 }
 //
 // And again to subtract a single limb:
 //
 template <class CppInt1, class CppInt2>
-inline void subtract_unsigned(CppInt1& result, const CppInt2& a, const limb_type& b) BOOST_MP_NOEXCEPT_IF(is_non_throwing_cpp_int<CppInt1>::value)
+inline void subtract_unsigned(CppInt1 &result, const CppInt2 &a, const limb_type &b) BOOST_MP_NOEXCEPT_IF(is_non_throwing_cpp_int<CppInt1>::value)
 {
    // Subtract one limb.
    // Nothing fancy, just let uintmax_t take the strain:
    BOOST_STATIC_CONSTANT(double_limb_type, borrow = static_cast<double_limb_type>(CppInt1::max_limb_value) + 1);
    result.resize(a.size(), a.size());
-   typename CppInt1::limb_pointer pr = result.limbs();
+   typename CppInt1::limb_pointer       pr = result.limbs();
    typename CppInt2::const_limb_pointer pa = a.limbs();
-   if(*pa >= b)
+   if (*pa >= b)
    {
       *pr = *pa - b;
-      if(&result != &a)
+      if (&result != &a)
       {
 #if BOOST_WORKAROUND(BOOST_MSVC, >= 1600)
-         std::copy(pa + 1, pa + a.size(), stdext::checked_array_iterator<limb_type*>(pr + 1, result.size() - 1));
+         std::copy(pa + 1, pa + a.size(), stdext::checked_array_iterator<limb_type *>(pr + 1, result.size() - 1));
 #else
          std::copy(pa + 1, pa + a.size(), pr + 1);
 #endif
          result.sign(a.sign());
       }
-      else if((result.size() == 1) && (*pr == 0))
+      else if ((result.size() == 1) && (*pr == 0))
       {
          result.sign(false); // zero is unsigned.
       }
    }
-   else if(result.size() == 1)
+   else if (result.size() == 1)
    {
       *pr = b - *pa;
       result.sign(!a.sign());
    }
    else
    {
-      *pr = static_cast<limb_type>((borrow + *pa) - b);
+      *pr        = static_cast<limb_type>((borrow + *pa) - b);
       unsigned i = 1;
-      while(!pa[i])
+      while (!pa[i])
       {
          pr[i] = CppInt1::max_limb_value;
          ++i;
       }
       pr[i] = pa[i] - 1;
-      if(&result != &a)
+      if (&result != &a)
       {
          ++i;
 #if BOOST_WORKAROUND(BOOST_MSVC, >= 1600)
-         std::copy(pa + i, pa + a.size(), stdext::checked_array_iterator<limb_type*>(pr + i, result.size() - i));
+         std::copy(pa + i, pa + a.size(), stdext::checked_array_iterator<limb_type *>(pr + i, result.size() - i));
 #else
          std::copy(pa + i, pa + a.size(), pr + i);
 #endif
@@ -278,21 +278,21 @@ inline void subtract_unsigned(CppInt1& result, const CppInt2& a, const limb_type
 // Now the actual functions called by the front end, all of which forward to one of the above:
 //
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1, unsigned MinBits2, unsigned MaxBits2, cpp_integer_type SignType2, cpp_int_check_type Checked2, class Allocator2>
-BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value >::type 
-   eval_add(
-      cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, 
-      const cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2>& o) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
+BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value>::type
+eval_add(
+    cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &      result,
+    const cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> &o) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
    eval_add(result, result, o);
 }
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1, unsigned MinBits2, unsigned MaxBits2, cpp_integer_type SignType2, cpp_int_check_type Checked2, class Allocator2, unsigned MinBits3, unsigned MaxBits3, cpp_integer_type SignType3, cpp_int_check_type Checked3, class Allocator3>
-inline typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits3, MaxBits3, SignType3, Checked3, Allocator3> >::value >::type
-   eval_add(
-      cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, 
-      const cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2>& a, 
-      const cpp_int_backend<MinBits3, MaxBits3, SignType3, Checked3, Allocator3>& b) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
+inline typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits3, MaxBits3, SignType3, Checked3, Allocator3> >::value>::type
+eval_add(
+    cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &      result,
+    const cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> &a,
+    const cpp_int_backend<MinBits3, MaxBits3, SignType3, Checked3, Allocator3> &b) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
-   if(a.sign() != b.sign())
+   if (a.sign() != b.sign())
    {
       subtract_unsigned(result, a, b);
       return;
@@ -300,10 +300,10 @@ inline typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBit
    add_unsigned(result, a, b);
 }
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1>
-BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value>::type 
-   eval_add(cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, const limb_type& o) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
+BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value>::type
+eval_add(cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &result, const limb_type &o) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
-   if(result.sign())
+   if (result.sign())
    {
       subtract_unsigned(result, result, o);
    }
@@ -311,13 +311,13 @@ BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<Mi
       add_unsigned(result, result, o);
 }
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1, unsigned MinBits2, unsigned MaxBits2, cpp_integer_type SignType2, cpp_int_check_type Checked2, class Allocator2>
-BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value >::type 
-   eval_add(
-      cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, 
-      const cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2>& a, 
-      const limb_type& o) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
+BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value>::type
+eval_add(
+    cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &      result,
+    const cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> &a,
+    const limb_type &                                                           o) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
-   if(a.sign())
+   if (a.sign())
    {
       subtract_unsigned(result, a, o);
    }
@@ -325,37 +325,37 @@ BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<Mi
       add_unsigned(result, a, o);
 }
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1>
-BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value>::type 
-   eval_add(
-      cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, 
-      const signed_limb_type& o) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
+BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value>::type
+eval_add(
+    cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &result,
+    const signed_limb_type &                                              o) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
-   if(o < 0)
+   if (o < 0)
       eval_subtract(result, static_cast<limb_type>(boost::multiprecision::detail::unsigned_abs(o)));
-   else if(o > 0)
+   else if (o > 0)
       eval_add(result, static_cast<limb_type>(o));
 }
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1, unsigned MinBits2, unsigned MaxBits2, cpp_integer_type SignType2, cpp_int_check_type Checked2, class Allocator2>
-BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value >::type 
-   eval_add(
-      cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, 
-      const cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2>& a, 
-      const signed_limb_type& o) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
+BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value>::type
+eval_add(
+    cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &      result,
+    const cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> &a,
+    const signed_limb_type &                                                    o) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
-   if(o < 0)
+   if (o < 0)
       eval_subtract(result, a, static_cast<limb_type>(boost::multiprecision::detail::unsigned_abs(o)));
-   else if(o > 0)
+   else if (o > 0)
       eval_add(result, a, static_cast<limb_type>(o));
-   else if(&result != &a)
+   else if (&result != &a)
       result = a;
 }
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1>
-BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value>::type 
-   eval_subtract(
-      cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, 
-      const limb_type& o) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
+BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value>::type
+eval_subtract(
+    cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &result,
+    const limb_type &                                                     o) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
-   if(result.sign())
+   if (result.sign())
    {
       add_unsigned(result, result, o);
    }
@@ -363,13 +363,13 @@ BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<Mi
       subtract_unsigned(result, result, o);
 }
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1, unsigned MinBits2, unsigned MaxBits2, cpp_integer_type SignType2, cpp_int_check_type Checked2, class Allocator2>
-BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value >::type 
-   eval_subtract(
-      cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, 
-      const cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2>& a, 
-      const limb_type& o) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
+BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value>::type
+eval_subtract(
+    cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &      result,
+    const cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> &a,
+    const limb_type &                                                           o) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
-   if(a.sign())
+   if (a.sign())
    {
       add_unsigned(result, a, o);
    }
@@ -379,43 +379,43 @@ BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<Mi
    }
 }
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1>
-BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value>::type 
-   eval_subtract(
-      cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, 
-      const signed_limb_type& o) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
+BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value>::type
+eval_subtract(
+    cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &result,
+    const signed_limb_type &                                              o) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
-   if(o)
+   if (o)
    {
-      if(o < 0)
+      if (o < 0)
          eval_add(result, static_cast<limb_type>(boost::multiprecision::detail::unsigned_abs(o)));
       else
          eval_subtract(result, static_cast<limb_type>(o));
    }
 }
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1, unsigned MinBits2, unsigned MaxBits2, cpp_integer_type SignType2, cpp_int_check_type Checked2, class Allocator2>
-BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value >::type 
-   eval_subtract(
-      cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, 
-      const cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2>& a, 
-      const signed_limb_type& o) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
+BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value>::type
+eval_subtract(
+    cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &      result,
+    const cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> &a,
+    const signed_limb_type &                                                    o) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
-   if(o)
+   if (o)
    {
-      if(o < 0)
+      if (o < 0)
          eval_add(result, a, static_cast<limb_type>(boost::multiprecision::detail::unsigned_abs(o)));
       else
          eval_subtract(result, a, static_cast<limb_type>(o));
    }
-   else if(&result != &a)
+   else if (&result != &a)
       result = a;
 }
 
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1>
-BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value>::type 
-   eval_increment(cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
+BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value>::type
+eval_increment(cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &result) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
    static const limb_type one = 1;
-   if(!result.sign() && (result.limbs()[0] < cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::max_limb_value))
+   if (!result.sign() && (result.limbs()[0] < cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::max_limb_value))
       ++result.limbs()[0];
    else if (result.sign() && result.limbs()[0])
    {
@@ -427,11 +427,11 @@ BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<Mi
       eval_add(result, one);
 }
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1>
-BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value>::type 
-   eval_decrement(cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
+BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value>::type
+eval_decrement(cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &result) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
    static const limb_type one = 1;
-   if(!result.sign() && result.limbs()[0])
+   if (!result.sign() && result.limbs()[0])
       --result.limbs()[0];
    else if (result.sign() && (result.limbs()[0] < cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::max_limb_value))
       ++result.limbs()[0];
@@ -439,21 +439,21 @@ BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<Mi
       eval_subtract(result, one);
 }
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1, unsigned MinBits2, unsigned MaxBits2, cpp_integer_type SignType2, cpp_int_check_type Checked2, class Allocator2>
-BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value >::type 
-   eval_subtract(
-      cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, 
-      const cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2>& o) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
+BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value>::type
+eval_subtract(
+    cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &      result,
+    const cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> &o) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
    eval_subtract(result, result, o);
 }
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1, unsigned MinBits2, unsigned MaxBits2, cpp_integer_type SignType2, cpp_int_check_type Checked2, class Allocator2, unsigned MinBits3, unsigned MaxBits3, cpp_integer_type SignType3, cpp_int_check_type Checked3, class Allocator3>
-BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits3, MaxBits3, SignType3, Checked3, Allocator3> >::value >::type
-   eval_subtract(
-      cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, 
-      const cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2>& a, 
-      const cpp_int_backend<MinBits3, MaxBits3, SignType3, Checked3, Allocator3>& b) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
+BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits3, MaxBits3, SignType3, Checked3, Allocator3> >::value>::type
+eval_subtract(
+    cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &      result,
+    const cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> &a,
+    const cpp_int_backend<MinBits3, MaxBits3, SignType3, Checked3, Allocator3> &b) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
-   if(a.sign() != b.sign())
+   if (a.sign() != b.sign())
    {
       add_unsigned(result, a, b);
       return;
@@ -468,17 +468,14 @@ BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<Mi
 //
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1>
 inline typename enable_if_c<
-         is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value 
-         && is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value
-         && (is_signed_number<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value || is_signed_number<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value)
-         >::type 
-   eval_add(
-      cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, 
-      const cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& o) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
+    is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && (is_signed_number<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value || is_signed_number<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value)>::type
+eval_add(
+    cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &      result,
+    const cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &o) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
-   if(result.sign() != o.sign())
+   if (result.sign() != o.sign())
    {
-      if(*o.limbs() > *result.limbs())
+      if (*o.limbs() > *result.limbs())
       {
          *result.limbs() = detail::checked_subtract(*o.limbs(), *result.limbs(), typename cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::checked_type());
          result.negate();
@@ -493,13 +490,9 @@ inline typename enable_if_c<
 // Simple version for two unsigned arguments:
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1>
 BOOST_MP_FORCEINLINE typename enable_if_c<
-         is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value 
-         && is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value
-         && is_unsigned_number<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value 
-         && is_unsigned_number<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value
-         >::type 
-   eval_add(cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, 
-      const cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& o) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
+    is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && is_unsigned_number<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && is_unsigned_number<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value>::type
+eval_add(cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &      result,
+         const cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &o) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
    *result.limbs() = detail::checked_add(*result.limbs(), *o.limbs(), typename cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::checked_type());
    result.normalize();
@@ -508,19 +501,16 @@ BOOST_MP_FORCEINLINE typename enable_if_c<
 // signed subtraction:
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1>
 inline typename enable_if_c<
-         is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value 
-         && is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value
-         && (is_signed_number<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value || is_signed_number<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value)
-         >::type 
-   eval_subtract(
-      cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, 
-      const cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& o) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
+    is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && (is_signed_number<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value || is_signed_number<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value)>::type
+eval_subtract(
+    cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &      result,
+    const cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &o) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
-   if(result.sign() != o.sign())
+   if (result.sign() != o.sign())
    {
       *result.limbs() = detail::checked_add(*result.limbs(), *o.limbs(), typename cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::checked_type());
    }
-   else if(*result.limbs() < *o.limbs())
+   else if (*result.limbs() < *o.limbs())
    {
       *result.limbs() = detail::checked_subtract(*o.limbs(), *result.limbs(), typename cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::checked_type());
       result.negate();
@@ -532,14 +522,10 @@ inline typename enable_if_c<
 
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1>
 BOOST_MP_FORCEINLINE typename enable_if_c<
-         is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value 
-         && is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value
-         && is_unsigned_number<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value 
-         && is_unsigned_number<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value
-         >::type 
-   eval_subtract(
-      cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, 
-      const cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& o) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
+    is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && is_unsigned_number<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && is_unsigned_number<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value>::type
+eval_subtract(
+    cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &      result,
+    const cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &o) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
    *result.limbs() = detail::checked_subtract(*result.limbs(), *o.limbs(), typename cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::checked_type());
    result.normalize();
@@ -549,6 +535,6 @@ BOOST_MP_FORCEINLINE typename enable_if_c<
 #pragma warning(pop)
 #endif
 
-}}} // namespaces
+}}} // namespace boost::multiprecision::backends
 
 #endif

--- a/include/boost/multiprecision/cpp_int/multiply.hpp
+++ b/include/boost/multiprecision/cpp_int/multiply.hpp
@@ -8,32 +8,32 @@
 #ifndef BOOST_MP_CPP_INT_MUL_HPP
 #define BOOST_MP_CPP_INT_MUL_HPP
 
-namespace boost{ namespace multiprecision{ namespace backends{
+namespace boost { namespace multiprecision { namespace backends {
 
 #ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning(disable:4127) // conditional expression is constant
+#pragma warning(disable : 4127) // conditional expression is constant
 #endif
-   
-   template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1, unsigned MinBits2, unsigned MaxBits2, cpp_integer_type SignType2, cpp_int_check_type Checked2, class Allocator2>
-inline typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value >::type 
-   eval_multiply(
-      cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, 
-      const cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2>& a, 
-      const limb_type& val) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
+
+template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1, unsigned MinBits2, unsigned MaxBits2, cpp_integer_type SignType2, cpp_int_check_type Checked2, class Allocator2>
+inline typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value>::type
+eval_multiply(
+    cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &      result,
+    const cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> &a,
+    const limb_type &                                                           val) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
-   if(!val)
+   if (!val)
    {
       result = static_cast<limb_type>(0);
       return;
    }
-   if((void*)&a != (void*)&result)
+   if ((void *)&a != (void *)&result)
       result.resize(a.size(), a.size());
-   double_limb_type carry = 0;
-   typename cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::limb_pointer p = result.limbs();
-   typename cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::limb_pointer pe = result.limbs() + result.size();
-   typename cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2>::const_limb_pointer pa = a.limbs();
-   while(p != pe)
+   double_limb_type                                                                                  carry = 0;
+   typename cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::limb_pointer       p     = result.limbs();
+   typename cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::limb_pointer       pe    = result.limbs() + result.size();
+   typename cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2>::const_limb_pointer pa    = a.limbs();
+   while (p != pe)
    {
       carry += static_cast<double_limb_type>(*pa) * static_cast<double_limb_type>(val);
 #ifdef __MSVC_RUNTIME_CHECKS
@@ -44,15 +44,15 @@ inline typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBit
       carry >>= cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::limb_bits;
       ++p, ++pa;
    }
-   if(carry)
+   if (carry)
    {
       unsigned i = result.size();
       result.resize(i + 1, i + 1);
-      if(result.size() > i)
+      if (result.size() > i)
          result.limbs()[i] = static_cast<limb_type>(carry);
    }
    result.sign(a.sign());
-   if(!cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::variable)
+   if (!cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::variable)
       result.normalize();
 }
 
@@ -62,35 +62,35 @@ inline typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBit
 // This will cause an overflow error inside resize():
 //
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1>
-inline void resize_for_carry(cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& /*result*/, unsigned /*required*/){}
+inline void resize_for_carry(cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> & /*result*/, unsigned /*required*/) {}
 
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, class Allocator1>
-inline void resize_for_carry(cpp_int_backend<MinBits1, MaxBits1, SignType1, checked, Allocator1>& result, unsigned required)
+inline void resize_for_carry(cpp_int_backend<MinBits1, MaxBits1, SignType1, checked, Allocator1> &result, unsigned required)
 {
-   if(result.size() < required)
+   if (result.size() < required)
       result.resize(required, required);
 }
 
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1, unsigned MinBits2, unsigned MaxBits2, cpp_integer_type SignType2, cpp_int_check_type Checked2, class Allocator2, unsigned MinBits3, unsigned MaxBits3, cpp_integer_type SignType3, cpp_int_check_type Checked3, class Allocator3>
-inline typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits3, MaxBits3, SignType3, Checked3, Allocator3> >::value >::type
-   eval_multiply(
-      cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, 
-      const cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2>& a, 
-      const cpp_int_backend<MinBits3, MaxBits3, SignType3, Checked3, Allocator3>& b) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
+inline typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits3, MaxBits3, SignType3, Checked3, Allocator3> >::value>::type
+eval_multiply(
+    cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &      result,
+    const cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> &a,
+    const cpp_int_backend<MinBits3, MaxBits3, SignType3, Checked3, Allocator3> &b) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
    // Very simple long multiplication, only usable for small numbers of limb_type's
    // but that's the typical use case for this type anyway:
    //
    // Special cases first:
    //
-   unsigned as = a.size();
-   unsigned bs = b.size();
+   unsigned                                                                                          as = a.size();
+   unsigned                                                                                          bs = b.size();
    typename cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2>::const_limb_pointer pa = a.limbs();
    typename cpp_int_backend<MinBits3, MaxBits3, SignType3, Checked3, Allocator3>::const_limb_pointer pb = b.limbs();
-   if(as == 1)
+   if (as == 1)
    {
       bool s = b.sign() != a.sign();
-      if(bs == 1)
+      if (bs == 1)
       {
          result = static_cast<double_limb_type>(*pa) * static_cast<double_limb_type>(*pb);
       }
@@ -102,22 +102,22 @@ inline typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBit
       result.sign(s);
       return;
    }
-   if(bs == 1)
+   if (bs == 1)
    {
-      bool s = b.sign() != a.sign();
+      bool      s = b.sign() != a.sign();
       limb_type l = *pb;
       eval_multiply(result, a, l);
       result.sign(s);
       return;
    }
 
-   if((void*)&result == (void*)&a)
+   if ((void *)&result == (void *)&a)
    {
       cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> t(a);
       eval_multiply(result, t, b);
       return;
    }
-   if((void*)&result == (void*)&b)
+   if ((void *)&result == (void *)&b)
    {
       cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> t(b);
       eval_multiply(result, a, t);
@@ -127,27 +127,25 @@ inline typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBit
    result.resize(as + bs, as + bs - 1);
    typename cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::limb_pointer pr = result.limbs();
 
-   static const double_limb_type limb_max = ~static_cast<limb_type>(0u);
+   static const double_limb_type limb_max        = ~static_cast<limb_type>(0u);
    static const double_limb_type double_limb_max = ~static_cast<double_limb_type>(0u);
    BOOST_STATIC_ASSERT(double_limb_max - 2 * limb_max >= limb_max * limb_max);
 
    double_limb_type carry = 0;
    std::memset(pr, 0, result.size() * sizeof(limb_type));
-   for(unsigned i = 0; i < as; ++i)
+   for (unsigned i = 0; i < as; ++i)
    {
       unsigned inner_limit = cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::variable ? bs : (std::min)(result.size() - i, bs);
       unsigned j;
-      for(j = 0; j < inner_limit; ++j)
+      for (j = 0; j < inner_limit; ++j)
       {
-         BOOST_ASSERT(i+j < result.size());
+         BOOST_ASSERT(i + j < result.size());
 #if (!defined(__GLIBCXX__) && !defined(__GLIBCPP__)) || !BOOST_WORKAROUND(BOOST_GCC_VERSION, <= 50100)
-         BOOST_ASSERT(!std::numeric_limits<double_limb_type>::is_specialized 
-            || ((std::numeric_limits<double_limb_type>::max)() - carry 
-                  > 
-                static_cast<double_limb_type>(cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::max_limb_value) * static_cast<double_limb_type>(cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::max_limb_value)));
+         BOOST_ASSERT(!std::numeric_limits<double_limb_type>::is_specialized || ((std::numeric_limits<double_limb_type>::max)() - carry >
+                                                                                 static_cast<double_limb_type>(cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::max_limb_value) * static_cast<double_limb_type>(cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::max_limb_value)));
 #endif
          carry += static_cast<double_limb_type>(pa[i]) * static_cast<double_limb_type>(pb[j]);
-         BOOST_ASSERT(!std::numeric_limits<double_limb_type>::is_specialized || ((std::numeric_limits<double_limb_type>::max)() - carry >= pr[i+j]));
+         BOOST_ASSERT(!std::numeric_limits<double_limb_type>::is_specialized || ((std::numeric_limits<double_limb_type>::max)() - carry >= pr[i + j]));
          carry += pr[i + j];
 #ifdef __MSVC_RUNTIME_CHECKS
          pr[i + j] = static_cast<limb_type>(carry & ~static_cast<limb_type>(0));
@@ -157,10 +155,10 @@ inline typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBit
          carry >>= cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::limb_bits;
          BOOST_ASSERT(carry <= (cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::max_limb_value));
       }
-      if(carry)
+      if (carry)
       {
-         resize_for_carry(result, i + j + 1);  // May throw if checking is enabled
-         if(i + j < result.size())
+         resize_for_carry(result, i + j + 1); // May throw if checking is enabled
+         if (i + j < result.size())
 #ifdef __MSVC_RUNTIME_CHECKS
             pr[i + j] = static_cast<limb_type>(carry & ~static_cast<limb_type>(0));
 #else
@@ -177,29 +175,29 @@ inline typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBit
 }
 
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1, unsigned MinBits2, unsigned MaxBits2, cpp_integer_type SignType2, cpp_int_check_type Checked2, class Allocator2>
-BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value >::type 
-   eval_multiply(
-      cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, 
-      const cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2>& a) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
+BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value>::type
+eval_multiply(
+    cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &      result,
+    const cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> &a) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
-    eval_multiply(result, result, a);
+   eval_multiply(result, result, a);
 }
 
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1>
-BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value>::type 
-   eval_multiply(cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, const limb_type& val) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
+BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value>::type
+eval_multiply(cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &result, const limb_type &val) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
    eval_multiply(result, result, val);
 }
 
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1, unsigned MinBits2, unsigned MaxBits2, cpp_integer_type SignType2, cpp_int_check_type Checked2, class Allocator2>
-BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value >::type 
-   eval_multiply(
-      cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, 
-      const cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2>& a, 
-      const double_limb_type& val) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
+BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value>::type
+eval_multiply(
+    cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &      result,
+    const cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> &a,
+    const double_limb_type &                                                    val) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
-   if(val <= (std::numeric_limits<limb_type>::max)())
+   if (val <= (std::numeric_limits<limb_type>::max)())
    {
       eval_multiply(result, a, static_cast<limb_type>(val));
    }
@@ -216,20 +214,20 @@ BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<Mi
 }
 
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1>
-BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value>::type 
-   eval_multiply(cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, const double_limb_type& val) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
+BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value>::type
+eval_multiply(cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &result, const double_limb_type &val) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
    eval_multiply(result, result, val);
 }
 
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1, unsigned MinBits2, unsigned MaxBits2, cpp_integer_type SignType2, cpp_int_check_type Checked2, class Allocator2>
-BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value >::type 
-   eval_multiply(
-      cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, 
-      const cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2>& a, 
-      const signed_limb_type& val) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
+BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value>::type
+eval_multiply(
+    cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &      result,
+    const cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> &a,
+    const signed_limb_type &                                                    val) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
-   if(val > 0)
+   if (val > 0)
       eval_multiply(result, a, static_cast<limb_type>(val));
    else
    {
@@ -239,28 +237,28 @@ BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<Mi
 }
 
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1>
-BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value>::type 
-   eval_multiply(cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, const signed_limb_type& val) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
+BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value>::type
+eval_multiply(cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &result, const signed_limb_type &val) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
    eval_multiply(result, result, val);
 }
 
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1, unsigned MinBits2, unsigned MaxBits2, cpp_integer_type SignType2, cpp_int_check_type Checked2, class Allocator2>
-inline typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value >::type 
-   eval_multiply(
-      cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, 
-      const cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2>& a, 
-      const signed_double_limb_type& val) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
+inline typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value>::type
+eval_multiply(
+    cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &      result,
+    const cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> &a,
+    const signed_double_limb_type &                                             val) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
-   if(val > 0)
+   if (val > 0)
    {
-      if(val <= (std::numeric_limits<limb_type>::max)())
+      if (val <= (std::numeric_limits<limb_type>::max)())
       {
          eval_multiply(result, a, static_cast<limb_type>(val));
          return;
       }
    }
-   else if(val >= -static_cast<signed_double_limb_type>((std::numeric_limits<limb_type>::max)()))
+   else if (val >= -static_cast<signed_double_limb_type>((std::numeric_limits<limb_type>::max)()))
    {
       eval_multiply(result, a, static_cast<limb_type>(boost::multiprecision::detail::unsigned_abs(val)));
       result.negate();
@@ -276,8 +274,8 @@ inline typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBit
 }
 
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1>
-BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value>::type 
-   eval_multiply(cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, const signed_double_limb_type& val) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
+BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value>::type
+eval_multiply(cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &result, const signed_double_limb_type &val) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
    eval_multiply(result, result, val);
 }
@@ -287,14 +285,10 @@ BOOST_MP_FORCEINLINE typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<Mi
 //
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1>
 BOOST_MP_FORCEINLINE typename enable_if_c<
-         is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value 
-         && is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value
-         && (is_signed_number<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value 
-            || is_signed_number<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value)
-         >::type 
-   eval_multiply(
-      cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, 
-      const cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& o) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
+    is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && (is_signed_number<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value || is_signed_number<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value)>::type
+eval_multiply(
+    cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &      result,
+    const cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &o) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
    *result.limbs() = detail::checked_multiply(*result.limbs(), *o.limbs(), typename cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::checked_type());
    result.sign(result.sign() != o.sign());
@@ -303,12 +297,10 @@ BOOST_MP_FORCEINLINE typename enable_if_c<
 
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1>
 BOOST_MP_FORCEINLINE typename enable_if_c<
-         is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value 
-         && is_unsigned_number<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value 
-         >::type 
-   eval_multiply(
-      cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, 
-      const cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& o) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
+    is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && is_unsigned_number<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value>::type
+eval_multiply(
+    cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &      result,
+    const cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &o) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
    *result.limbs() = detail::checked_multiply(*result.limbs(), *o.limbs(), typename cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::checked_type());
    result.normalize();
@@ -316,15 +308,11 @@ BOOST_MP_FORCEINLINE typename enable_if_c<
 
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1>
 BOOST_MP_FORCEINLINE typename enable_if_c<
-         is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value 
-         && is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value
-         && (is_signed_number<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value 
-            || is_signed_number<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value)
-         >::type 
-   eval_multiply(
-      cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, 
-      const cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& a,
-      const cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& b) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
+    is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && (is_signed_number<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value || is_signed_number<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value)>::type
+eval_multiply(
+    cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &      result,
+    const cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &a,
+    const cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &b) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
    *result.limbs() = detail::checked_multiply(*a.limbs(), *b.limbs(), typename cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::checked_type());
    result.sign(a.sign() != b.sign());
@@ -333,13 +321,11 @@ BOOST_MP_FORCEINLINE typename enable_if_c<
 
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1>
 BOOST_MP_FORCEINLINE typename enable_if_c<
-         is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value 
-         && is_unsigned_number<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value 
-         >::type 
-   eval_multiply(
-      cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, 
-      const cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& a,
-      const cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& b) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
+    is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && is_unsigned_number<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value>::type
+eval_multiply(
+    cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &      result,
+    const cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &a,
+    const cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &b) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
    *result.limbs() = detail::checked_multiply(*a.limbs(), *b.limbs(), typename cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::checked_type());
    result.normalize();
@@ -350,22 +336,21 @@ BOOST_MP_FORCEINLINE typename enable_if_c<
 //
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1>
 BOOST_MP_FORCEINLINE typename enable_if_c<
-            !is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value 
-         >::type 
-   eval_multiply(
-      cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, 
-      signed_double_limb_type a, signed_double_limb_type b)
+    !is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value>::type
+eval_multiply(
+    cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &result,
+    signed_double_limb_type a, signed_double_limb_type b)
 {
-   static const signed_double_limb_type mask = ~static_cast<limb_type>(0);
-   static const unsigned limb_bits = sizeof(limb_type) * CHAR_BIT;
-   bool s = false;
-   double_limb_type w, x, y, z;
-   if(a < 0)
+   static const signed_double_limb_type mask      = ~static_cast<limb_type>(0);
+   static const unsigned                limb_bits = sizeof(limb_type) * CHAR_BIT;
+   bool                                 s         = false;
+   double_limb_type                     w, x, y, z;
+   if (a < 0)
    {
       a = -a;
       s = true;
    }
-   if(b < 0)
+   if (b < 0)
    {
       b = -b;
       s = !s;
@@ -376,7 +361,7 @@ BOOST_MP_FORCEINLINE typename enable_if_c<
    z = b >> limb_bits;
 
    result.resize(4, 4);
-   limb_type* pr = result.limbs();
+   limb_type *pr = result.limbs();
 
    double_limb_type carry = w * y;
 #ifdef __MSVC_RUNTIME_CHECKS
@@ -404,14 +389,13 @@ BOOST_MP_FORCEINLINE typename enable_if_c<
 
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1>
 BOOST_MP_FORCEINLINE typename enable_if_c<
-            !is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value 
-         >::type 
-   eval_multiply(
-      cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, 
-      double_limb_type a, double_limb_type b)
+    !is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value>::type
+eval_multiply(
+    cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &result,
+    double_limb_type a, double_limb_type b)
 {
-   static const signed_double_limb_type mask = ~static_cast<limb_type>(0);
-   static const unsigned limb_bits = sizeof(limb_type) * CHAR_BIT;
+   static const signed_double_limb_type mask      = ~static_cast<limb_type>(0);
+   static const unsigned                limb_bits = sizeof(limb_type) * CHAR_BIT;
 
    double_limb_type w, x, y, z;
    w = a & mask;
@@ -420,7 +404,7 @@ BOOST_MP_FORCEINLINE typename enable_if_c<
    z = b >> limb_bits;
 
    result.resize(4, 4);
-   limb_type* pr = result.limbs();
+   limb_type *pr = result.limbs();
 
    double_limb_type carry = w * y;
 #ifdef __MSVC_RUNTIME_CHECKS
@@ -457,14 +441,11 @@ BOOST_MP_FORCEINLINE typename enable_if_c<
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1,
           unsigned MinBits2, unsigned MaxBits2, cpp_integer_type SignType2, cpp_int_check_type Checked2, class Allocator2>
 BOOST_MP_FORCEINLINE typename enable_if_c<
-            !is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value
-            && is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value
-            && is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value
-         >::type 
-   eval_multiply(
-      cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, 
-      cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> const& a, 
-      cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> const& b)
+    !is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value && is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value>::type
+eval_multiply(
+    cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &      result,
+    cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> const &a,
+    cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> const &b)
 {
    typedef typename boost::multiprecision::detail::canonical<typename cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2>::local_limb_type, cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::type canonical_type;
    eval_multiply(result, static_cast<canonical_type>(*a.limbs()), static_cast<canonical_type>(*b.limbs()));
@@ -473,18 +454,18 @@ BOOST_MP_FORCEINLINE typename enable_if_c<
 
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1, class SI>
 BOOST_MP_FORCEINLINE typename enable_if_c<is_signed<SI>::value && (sizeof(SI) <= sizeof(signed_double_limb_type) / 2)>::type
-   eval_multiply(
-      cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, 
-      SI a, SI b)
+eval_multiply(
+    cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &result,
+    SI a, SI b)
 {
    result = static_cast<signed_double_limb_type>(a) * static_cast<signed_double_limb_type>(b);
 }
 
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1, class UI>
 BOOST_MP_FORCEINLINE typename enable_if_c<is_unsigned<UI>::value && (sizeof(UI) <= sizeof(signed_double_limb_type) / 2)>::type
-   eval_multiply(
-      cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, 
-      UI a, UI b)
+eval_multiply(
+    cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> &result,
+    UI a, UI b)
 {
    result = static_cast<double_limb_type>(a) * static_cast<double_limb_type>(b);
 }
@@ -493,6 +474,6 @@ BOOST_MP_FORCEINLINE typename enable_if_c<is_unsigned<UI>::value && (sizeof(UI) 
 #pragma warning(pop)
 #endif
 
-}}} // namespaces
+}}} // namespace boost::multiprecision::backends
 
 #endif

--- a/include/boost/multiprecision/detail/functions/trig.hpp
+++ b/include/boost/multiprecision/detail/functions/trig.hpp
@@ -10,17 +10,17 @@
 // in ACM TOMS, {VOL 37, ISSUE 4, (February 2011)} (C) ACM, 2011. http://doi.acm.org/10.1145/1916461.1916469
 //
 // This file has no include guards or namespaces - it's expanded inline inside default_ops.hpp
-// 
+//
 
 #ifdef BOOST_MSVC
 #pragma warning(push)
-#pragma warning(disable:6326)  // comparison of two constants
+#pragma warning(disable : 6326) // comparison of two constants
 #endif
 
 template <class T>
-void hyp0F1(T& result, const T& b, const T& x)
+void hyp0F1(T &result, const T &b, const T &x)
 {
-   typedef typename boost::multiprecision::detail::canonical<boost::int32_t, T>::type si_type;
+   typedef typename boost::multiprecision::detail::canonical<boost::int32_t, T>::type  si_type;
    typedef typename boost::multiprecision::detail::canonical<boost::uint32_t, T>::type ui_type;
 
    // Compute the series representation of Hypergeometric0F1 taken from
@@ -28,8 +28,8 @@ void hyp0F1(T& result, const T& b, const T& x)
    // There are no checks on input range or parameter boundaries.
 
    T x_pow_n_div_n_fact(x);
-   T pochham_b         (b);
-   T bp                (b);
+   T pochham_b(b);
+   T bp(b);
 
    eval_divide(result, x_pow_n_div_n_fact, pochham_b);
    eval_add(result, ui_type(1));
@@ -40,15 +40,16 @@ void hyp0F1(T& result, const T& b, const T& x)
    tol = ui_type(1);
    eval_ldexp(tol, tol, 1 - boost::multiprecision::detail::digits2<number<T, et_on> >::value());
    eval_multiply(tol, result);
-   if(eval_get_sign(tol) < 0)
+   if (eval_get_sign(tol) < 0)
       tol.negate();
    T term;
 
-   const int series_limit = 
-      boost::multiprecision::detail::digits2<number<T, et_on> >::value() < 100
-      ? 100 : boost::multiprecision::detail::digits2<number<T, et_on> >::value();
+   const int series_limit =
+       boost::multiprecision::detail::digits2<number<T, et_on> >::value() < 100
+           ? 100
+           : boost::multiprecision::detail::digits2<number<T, et_on> >::value();
    // Series expansion of hyperg_0f1(; b; x).
-   for(n = 2; n < series_limit; ++n)
+   for (n = 2; n < series_limit; ++n)
    {
       eval_multiply(x_pow_n_div_n_fact, x);
       eval_divide(x_pow_n_div_n_fact, n);
@@ -59,22 +60,21 @@ void hyp0F1(T& result, const T& b, const T& x)
       eval_add(result, term);
 
       bool neg_term = eval_get_sign(term) < 0;
-      if(neg_term)
+      if (neg_term)
          term.negate();
-      if(term.compare(tol) <= 0)
+      if (term.compare(tol) <= 0)
          break;
    }
 
-   if(n >= series_limit)
+   if (n >= series_limit)
       BOOST_THROW_EXCEPTION(std::runtime_error("H0F1 Failed to Converge"));
 }
 
-
 template <class T>
-void eval_sin(T& result, const T& x)
+void eval_sin(T &result, const T &x)
 {
    BOOST_STATIC_ASSERT_MSG(number_category<T>::value == number_kind_floating_point, "The sin function is only valid for floating point types.");
-   if(&result == &x)
+   if (&result == &x)
    {
       T temp;
       eval_sin(temp, x);
@@ -82,18 +82,18 @@ void eval_sin(T& result, const T& x)
       return;
    }
 
-   typedef typename boost::multiprecision::detail::canonical<boost::int32_t, T>::type si_type;
+   typedef typename boost::multiprecision::detail::canonical<boost::int32_t, T>::type  si_type;
    typedef typename boost::multiprecision::detail::canonical<boost::uint32_t, T>::type ui_type;
-   typedef typename mpl::front<typename T::float_types>::type fp_type;
+   typedef typename mpl::front<typename T::float_types>::type                          fp_type;
 
-   switch(eval_fpclassify(x))
+   switch (eval_fpclassify(x))
    {
    case FP_INFINITE:
    case FP_NAN:
-      if(std::numeric_limits<number<T, et_on> >::has_quiet_NaN)
+      if (std::numeric_limits<number<T, et_on> >::has_quiet_NaN)
       {
          result = std::numeric_limits<number<T, et_on> >::quiet_NaN().backend();
-         errno = EDOM;
+         errno  = EDOM;
       }
       else
          BOOST_THROW_EXCEPTION(std::domain_error("Result is undefined or complex and there is no NaN for this number type."));
@@ -101,7 +101,7 @@ void eval_sin(T& result, const T& x)
    case FP_ZERO:
       result = x;
       return;
-   default: ;
+   default:;
    }
 
    // Local copy of the argument
@@ -112,7 +112,7 @@ void eval_sin(T& result, const T& x)
    // The argument xx will be reduced to 0 <= xx <= pi/2.
    bool b_negate_sin = false;
 
-   if(eval_get_sign(x) < 0)
+   if (eval_get_sign(x) < 0)
    {
       xx.negate();
       b_negate_sin = !b_negate_sin;
@@ -120,7 +120,7 @@ void eval_sin(T& result, const T& x)
 
    T n_pi, t;
    // Remove even multiples of pi.
-   if(xx.compare(get_constant_pi<T>()) > 0)
+   if (xx.compare(get_constant_pi<T>()) > 0)
    {
       eval_divide(n_pi, xx, get_constant_pi<T>());
       eval_trunc(n_pi, n_pi);
@@ -140,7 +140,7 @@ void eval_sin(T& result, const T& x)
       BOOST_MATH_INSTRUMENT_CODE(n_pi.str(0, std::ios_base::scientific));
 
       // Adjust signs if the multiple of pi is not even.
-      if(!b_n_pi_is_even)
+      if (!b_n_pi_is_even)
       {
          b_negate_sin = !b_negate_sin;
       }
@@ -148,7 +148,7 @@ void eval_sin(T& result, const T& x)
 
    // Reduce the argument to 0 <= xx <= pi/2.
    eval_ldexp(t, get_constant_pi<T>(), -1);
-   if(xx.compare(t) > 0)
+   if (xx.compare(t) > 0)
    {
       eval_subtract(xx, get_constant_pi<T>(), xx);
       BOOST_MATH_INSTRUMENT_CODE(xx.str(0, std::ios_base::scientific));
@@ -159,18 +159,19 @@ void eval_sin(T& result, const T& x)
    const bool b_pi_half = eval_get_sign(t) == 0;
 
    // Check if the reduced argument is very close to 0 or pi/2.
-   const bool    b_near_zero    = xx.compare(fp_type(1e-1)) < 0;
-   const bool    b_near_pi_half = t.compare(fp_type(1e-1)) < 0;;
+   const bool b_near_zero    = xx.compare(fp_type(1e-1)) < 0;
+   const bool b_near_pi_half = t.compare(fp_type(1e-1)) < 0;
+   ;
 
-   if(b_zero)
+   if (b_zero)
    {
       result = ui_type(0);
    }
-   else if(b_pi_half)
+   else if (b_pi_half)
    {
       result = ui_type(1);
    }
-   else if(b_near_zero)
+   else if (b_near_zero)
    {
       eval_multiply(t, xx, xx);
       eval_divide(t, si_type(-4));
@@ -180,7 +181,7 @@ void eval_sin(T& result, const T& x)
       BOOST_MATH_INSTRUMENT_CODE(result.str(0, std::ios_base::scientific));
       eval_multiply(result, xx);
    }
-   else if(b_near_pi_half)
+   else if (b_near_pi_half)
    {
       eval_multiply(t, t);
       eval_divide(t, si_type(-4));
@@ -196,7 +197,7 @@ void eval_sin(T& result, const T& x)
       // divide by three identity a certain number of times.
       // Here we use division by 3^9 --> (19683 = 3^9).
 
-      static const si_type n_scale = 9;
+      static const si_type n_scale           = 9;
       static const si_type n_three_pow_scale = static_cast<si_type>(19683L);
 
       eval_divide(xx, n_three_pow_scale);
@@ -211,7 +212,7 @@ void eval_sin(T& result, const T& x)
       eval_multiply(result, xx);
 
       // Convert back using multiple angle identity.
-      for(boost::int32_t k = static_cast<boost::int32_t>(0); k < n_scale; k++)
+      for (boost::int32_t k = static_cast<boost::int32_t>(0); k < n_scale; k++)
       {
          // Rescale the cosine value using the multiple angle identity.
          eval_multiply(t2, result, ui_type(3));
@@ -222,15 +223,15 @@ void eval_sin(T& result, const T& x)
       }
    }
 
-   if(b_negate_sin)
+   if (b_negate_sin)
       result.negate();
 }
 
 template <class T>
-void eval_cos(T& result, const T& x)
+void eval_cos(T &result, const T &x)
 {
    BOOST_STATIC_ASSERT_MSG(number_category<T>::value == number_kind_floating_point, "The cos function is only valid for floating point types.");
-   if(&result == &x)
+   if (&result == &x)
    {
       T temp;
       eval_cos(temp, x);
@@ -238,18 +239,18 @@ void eval_cos(T& result, const T& x)
       return;
    }
 
-   typedef typename boost::multiprecision::detail::canonical<boost::int32_t, T>::type si_type;
+   typedef typename boost::multiprecision::detail::canonical<boost::int32_t, T>::type  si_type;
    typedef typename boost::multiprecision::detail::canonical<boost::uint32_t, T>::type ui_type;
-   typedef typename mpl::front<typename T::float_types>::type fp_type;
+   typedef typename mpl::front<typename T::float_types>::type                          fp_type;
 
-   switch(eval_fpclassify(x))
+   switch (eval_fpclassify(x))
    {
    case FP_INFINITE:
    case FP_NAN:
-      if(std::numeric_limits<number<T, et_on> >::has_quiet_NaN)
+      if (std::numeric_limits<number<T, et_on> >::has_quiet_NaN)
       {
          result = std::numeric_limits<number<T, et_on> >::quiet_NaN().backend();
-         errno = EDOM;
+         errno  = EDOM;
       }
       else
          BOOST_THROW_EXCEPTION(std::domain_error("Result is undefined or complex and there is no NaN for this number type."));
@@ -257,7 +258,7 @@ void eval_cos(T& result, const T& x)
    case FP_ZERO:
       result = ui_type(1);
       return;
-   default: ;
+   default:;
    }
 
    // Local copy of the argument
@@ -268,14 +269,14 @@ void eval_cos(T& result, const T& x)
    // The argument xx will be reduced to 0 <= xx <= pi/2.
    bool b_negate_cos = false;
 
-   if(eval_get_sign(x) < 0)
+   if (eval_get_sign(x) < 0)
    {
       xx.negate();
    }
 
    T n_pi, t;
    // Remove even multiples of pi.
-   if(xx.compare(get_constant_pi<T>()) > 0)
+   if (xx.compare(get_constant_pi<T>()) > 0)
    {
       eval_divide(t, xx, get_constant_pi<T>());
       eval_trunc(n_pi, t);
@@ -303,7 +304,7 @@ void eval_cos(T& result, const T& x)
       eval_fmod(t, n_pi, t);
       const bool b_n_pi_is_even = eval_get_sign(t) == 0;
 
-      if(!b_n_pi_is_even)
+      if (!b_n_pi_is_even)
       {
          b_negate_cos = !b_negate_cos;
       }
@@ -312,7 +313,7 @@ void eval_cos(T& result, const T& x)
    // Reduce the argument to 0 <= xx <= pi/2.
    eval_ldexp(t, get_constant_pi<T>(), -1);
    int com = xx.compare(t);
-   if(com > 0)
+   if (com > 0)
    {
       eval_subtract(xx, get_constant_pi<T>(), xx);
       b_negate_cos = !b_negate_cos;
@@ -323,17 +324,17 @@ void eval_cos(T& result, const T& x)
    const bool b_pi_half = com == 0;
 
    // Check if the reduced argument is very close to 0.
-   const bool    b_near_zero    = xx.compare(fp_type(1e-1)) < 0;
+   const bool b_near_zero = xx.compare(fp_type(1e-1)) < 0;
 
-   if(b_zero)
+   if (b_zero)
    {
       result = si_type(1);
    }
-   else if(b_pi_half)
+   else if (b_pi_half)
    {
       result = si_type(0);
    }
-   else if(b_near_zero)
+   else if (b_near_zero)
    {
       eval_multiply(t, xx, xx);
       eval_divide(t, si_type(-4));
@@ -346,15 +347,15 @@ void eval_cos(T& result, const T& x)
       eval_subtract(t, xx);
       eval_sin(result, t);
    }
-   if(b_negate_cos)
+   if (b_negate_cos)
       result.negate();
 }
 
 template <class T>
-void eval_tan(T& result, const T& x)
+void eval_tan(T &result, const T &x)
 {
    BOOST_STATIC_ASSERT_MSG(number_category<T>::value == number_kind_floating_point, "The tan function is only valid for floating point types.");
-   if(&result == &x)
+   if (&result == &x)
    {
       T temp;
       eval_tan(temp, x);
@@ -368,21 +369,21 @@ void eval_tan(T& result, const T& x)
 }
 
 template <class T>
-void hyp2F1(T& result, const T& a, const T& b, const T& c, const T& x)
+void hyp2F1(T &result, const T &a, const T &b, const T &c, const T &x)
 {
-  // Compute the series representation of hyperg_2f1 taken from
-  // Abramowitz and Stegun 15.1.1.
-  // There are no checks on input range or parameter boundaries.
+   // Compute the series representation of hyperg_2f1 taken from
+   // Abramowitz and Stegun 15.1.1.
+   // There are no checks on input range or parameter boundaries.
 
    typedef typename boost::multiprecision::detail::canonical<boost::uint32_t, T>::type ui_type;
 
    T x_pow_n_div_n_fact(x);
-   T pochham_a         (a);
-   T pochham_b         (b);
-   T pochham_c         (c);
-   T ap                (a);
-   T bp                (b);
-   T cp                (c);
+   T pochham_a(a);
+   T pochham_b(b);
+   T pochham_c(c);
+   T ap(a);
+   T bp(b);
+   T cp(c);
 
    eval_multiply(result, pochham_a, pochham_b);
    eval_divide(result, pochham_c);
@@ -392,17 +393,18 @@ void hyp2F1(T& result, const T& a, const T& b, const T& c, const T& x)
    T lim;
    eval_ldexp(lim, result, 1 - boost::multiprecision::detail::digits2<number<T, et_on> >::value());
 
-   if(eval_get_sign(lim) < 0)
+   if (eval_get_sign(lim) < 0)
       lim.negate();
 
    ui_type n;
-   T term;
+   T       term;
 
-   const unsigned series_limit = 
-      boost::multiprecision::detail::digits2<number<T, et_on> >::value() < 100
-      ? 100 : boost::multiprecision::detail::digits2<number<T, et_on> >::value();
+   const unsigned series_limit =
+       boost::multiprecision::detail::digits2<number<T, et_on> >::value() < 100
+           ? 100
+           : boost::multiprecision::detail::digits2<number<T, et_on> >::value();
    // Series expansion of hyperg_2f1(a, b; c; x).
-   for(n = 2; n < series_limit; ++n)
+   for (n = 2; n < series_limit; ++n)
    {
       eval_multiply(x_pow_n_div_n_fact, x);
       eval_divide(x_pow_n_div_n_fact, n);
@@ -419,37 +421,37 @@ void hyp2F1(T& result, const T& a, const T& b, const T& c, const T& x)
       eval_multiply(term, x_pow_n_div_n_fact);
       eval_add(result, term);
 
-      if(eval_get_sign(term) < 0)
+      if (eval_get_sign(term) < 0)
          term.negate();
-      if(lim.compare(term) >= 0)
+      if (lim.compare(term) >= 0)
          break;
    }
-   if(n > series_limit)
+   if (n > series_limit)
       BOOST_THROW_EXCEPTION(std::runtime_error("H2F1 failed to converge."));
 }
 
 template <class T>
-void eval_asin(T& result, const T& x)
+void eval_asin(T &result, const T &x)
 {
    BOOST_STATIC_ASSERT_MSG(number_category<T>::value == number_kind_floating_point, "The asin function is only valid for floating point types.");
    typedef typename boost::multiprecision::detail::canonical<boost::uint32_t, T>::type ui_type;
-   typedef typename mpl::front<typename T::float_types>::type fp_type;
+   typedef typename mpl::front<typename T::float_types>::type                          fp_type;
 
-   if(&result == &x)
+   if (&result == &x)
    {
       T t(x);
       eval_asin(result, t);
       return;
    }
 
-   switch(eval_fpclassify(x))
+   switch (eval_fpclassify(x))
    {
    case FP_NAN:
    case FP_INFINITE:
-      if(std::numeric_limits<number<T, et_on> >::has_quiet_NaN)
+      if (std::numeric_limits<number<T, et_on> >::has_quiet_NaN)
       {
          result = std::numeric_limits<number<T, et_on> >::quiet_NaN().backend();
-         errno = EDOM;
+         errno  = EDOM;
       }
       else
          BOOST_THROW_EXCEPTION(std::domain_error("Result is undefined or complex and there is no NaN for this number type."));
@@ -457,37 +459,37 @@ void eval_asin(T& result, const T& x)
    case FP_ZERO:
       result = x;
       return;
-   default: ;
+   default:;
    }
 
    const bool b_neg = eval_get_sign(x) < 0;
 
    T xx(x);
-   if(b_neg)
+   if (b_neg)
       xx.negate();
 
    int c = xx.compare(ui_type(1));
-   if(c > 0)
+   if (c > 0)
    {
-      if(std::numeric_limits<number<T, et_on> >::has_quiet_NaN)
+      if (std::numeric_limits<number<T, et_on> >::has_quiet_NaN)
       {
          result = std::numeric_limits<number<T, et_on> >::quiet_NaN().backend();
-         errno = EDOM;
+         errno  = EDOM;
       }
       else
          BOOST_THROW_EXCEPTION(std::domain_error("Result is undefined or complex and there is no NaN for this number type."));
       return;
    }
-   else if(c == 0)
+   else if (c == 0)
    {
       result = get_constant_pi<T>();
       eval_ldexp(result, result, -1);
-      if(b_neg)
+      if (b_neg)
          result.negate();
       return;
    }
 
-   if(xx.compare(fp_type(1e-4)) < 0)
+   if (xx.compare(fp_type(1e-4)) < 0)
    {
       // http://functions.wolfram.com/ElementaryFunctions/ArcSin/26/01/01/
       eval_multiply(xx, xx);
@@ -498,7 +500,7 @@ void eval_asin(T& result, const T& x)
       eval_multiply(result, x);
       return;
    }
-   else if(xx.compare(fp_type(1 - 1e-4f)) > 0)
+   else if (xx.compare(fp_type(1 - 1e-4f)) > 0)
    {
       T dx1;
       T t1, t2;
@@ -513,7 +515,7 @@ void eval_asin(T& result, const T& x)
       eval_ldexp(t1, get_constant_pi<T>(), -1);
       result.negate();
       eval_add(result, t1);
-      if(b_neg)
+      if (b_neg)
          result.negate();
       return;
    }
@@ -528,16 +530,16 @@ void eval_asin(T& result, const T& x)
 
    result = (guess_type)(std::asin(dd));
 
-   // Newton-Raphson iteration, we should double our precision with each iteration, 
+   // Newton-Raphson iteration, we should double our precision with each iteration,
    // in practice this seems to not quite work in all cases... so terminate when we
-   // have at least 2/3 of the digits correct on the assumption that the correction 
+   // have at least 2/3 of the digits correct on the assumption that the correction
    // we've just added will finish the job...
 
    boost::intmax_t current_precision = eval_ilogb(result);
-   boost::intmax_t target_precision = current_precision - 1 - (std::numeric_limits<number<T> >::digits * 2) / 3;
+   boost::intmax_t target_precision  = current_precision - 1 - (std::numeric_limits<number<T> >::digits * 2) / 3;
 
    // Newton-Raphson iteration
-   while(current_precision > target_precision)
+   while (current_precision > target_precision)
    {
       T sine, cosine;
       eval_sin(sine, result);
@@ -546,27 +548,27 @@ void eval_asin(T& result, const T& x)
       eval_divide(sine, cosine);
       eval_subtract(result, sine);
       current_precision = eval_ilogb(sine);
-      if(current_precision <= (std::numeric_limits<typename T::exponent_type>::min)() + 1)
+      if (current_precision <= (std::numeric_limits<typename T::exponent_type>::min)() + 1)
          break;
    }
-   if(b_neg)
+   if (b_neg)
       result.negate();
 }
 
 template <class T>
-inline void eval_acos(T& result, const T& x)
+inline void eval_acos(T &result, const T &x)
 {
    BOOST_STATIC_ASSERT_MSG(number_category<T>::value == number_kind_floating_point, "The acos function is only valid for floating point types.");
    typedef typename boost::multiprecision::detail::canonical<boost::uint32_t, T>::type ui_type;
 
-   switch(eval_fpclassify(x))
+   switch (eval_fpclassify(x))
    {
    case FP_NAN:
    case FP_INFINITE:
-      if(std::numeric_limits<number<T, et_on> >::has_quiet_NaN)
+      if (std::numeric_limits<number<T, et_on> >::has_quiet_NaN)
       {
          result = std::numeric_limits<number<T, et_on> >::quiet_NaN().backend();
-         errno = EDOM;
+         errno  = EDOM;
       }
       else
          BOOST_THROW_EXCEPTION(std::domain_error("Result is undefined or complex and there is no NaN for this number type."));
@@ -580,20 +582,20 @@ inline void eval_acos(T& result, const T& x)
    eval_abs(result, x);
    int c = result.compare(ui_type(1));
 
-   if(c > 0)
+   if (c > 0)
    {
-      if(std::numeric_limits<number<T, et_on> >::has_quiet_NaN)
+      if (std::numeric_limits<number<T, et_on> >::has_quiet_NaN)
       {
          result = std::numeric_limits<number<T, et_on> >::quiet_NaN().backend();
-         errno = EDOM;
+         errno  = EDOM;
       }
       else
          BOOST_THROW_EXCEPTION(std::domain_error("Result is undefined or complex and there is no NaN for this number type."));
       return;
    }
-   else if(c == 0)
+   else if (c == 0)
    {
-      if(eval_get_sign(x) < 0)
+      if (eval_get_sign(x) < 0)
          result = get_constant_pi<T>();
       else
          result = ui_type(0);
@@ -608,24 +610,24 @@ inline void eval_acos(T& result, const T& x)
 }
 
 template <class T>
-void eval_atan(T& result, const T& x)
+void eval_atan(T &result, const T &x)
 {
    BOOST_STATIC_ASSERT_MSG(number_category<T>::value == number_kind_floating_point, "The atan function is only valid for floating point types.");
-   typedef typename boost::multiprecision::detail::canonical<boost::int32_t, T>::type si_type;
+   typedef typename boost::multiprecision::detail::canonical<boost::int32_t, T>::type  si_type;
    typedef typename boost::multiprecision::detail::canonical<boost::uint32_t, T>::type ui_type;
-   typedef typename mpl::front<typename T::float_types>::type fp_type;
+   typedef typename mpl::front<typename T::float_types>::type                          fp_type;
 
-   switch(eval_fpclassify(x))
+   switch (eval_fpclassify(x))
    {
    case FP_NAN:
       result = x;
-      errno = EDOM;
+      errno  = EDOM;
       return;
    case FP_ZERO:
       result = x;
       return;
    case FP_INFINITE:
-      if(eval_get_sign(x) < 0)
+      if (eval_get_sign(x) < 0)
       {
          eval_ldexp(result, get_constant_pi<T>(), -1);
          result.negate();
@@ -633,16 +635,16 @@ void eval_atan(T& result, const T& x)
       else
          eval_ldexp(result, get_constant_pi<T>(), -1);
       return;
-   default: ;
+   default:;
    }
 
    const bool b_neg = eval_get_sign(x) < 0;
 
    T xx(x);
-   if(b_neg)
+   if (b_neg)
       xx.negate();
 
-   if(xx.compare(fp_type(0.1)) < 0)
+   if (xx.compare(fp_type(0.1)) < 0)
    {
       T t1, t2, t3;
       t1 = ui_type(1);
@@ -655,7 +657,7 @@ void eval_atan(T& result, const T& x)
       return;
    }
 
-   if(xx.compare(fp_type(10)) > 0)
+   if (xx.compare(fp_type(10)) > 0)
    {
       T t1, t2, t3;
       t1 = fp_type(0.5f);
@@ -665,31 +667,30 @@ void eval_atan(T& result, const T& x)
       eval_divide(xx, si_type(-1), xx);
       hyp2F1(result, t1, t2, t3, xx);
       eval_divide(result, x);
-      if(!b_neg)
+      if (!b_neg)
          result.negate();
       eval_ldexp(t1, get_constant_pi<T>(), -1);
       eval_add(result, t1);
-      if(b_neg)
+      if (b_neg)
          result.negate();
       return;
    }
-
 
    // Get initial estimate using standard math function atan.
    fp_type d;
    eval_convert_to(&d, xx);
    result = fp_type(std::atan(d));
 
-   // Newton-Raphson iteration, we should double our precision with each iteration, 
+   // Newton-Raphson iteration, we should double our precision with each iteration,
    // in practice this seems to not quite work in all cases... so terminate when we
-   // have at least 2/3 of the digits correct on the assumption that the correction 
+   // have at least 2/3 of the digits correct on the assumption that the correction
    // we've just added will finish the job...
 
    boost::intmax_t current_precision = eval_ilogb(result);
-   boost::intmax_t target_precision = current_precision - 1 - (std::numeric_limits<number<T> >::digits * 2) / 3;
+   boost::intmax_t target_precision  = current_precision - 1 - (std::numeric_limits<number<T> >::digits * 2) / 3;
 
    T s, c, t;
-   while(current_precision > target_precision)
+   while (current_precision > target_precision)
    {
       eval_sin(s, result);
       eval_cos(c, result);
@@ -698,24 +699,24 @@ void eval_atan(T& result, const T& x)
       eval_multiply(s, t, c);
       eval_add(result, s);
       current_precision = eval_ilogb(s);
-      if(current_precision <= (std::numeric_limits<typename T::exponent_type>::min)() + 1)
+      if (current_precision <= (std::numeric_limits<typename T::exponent_type>::min)() + 1)
          break;
    }
-   if(b_neg)
+   if (b_neg)
       result.negate();
 }
 
 template <class T>
-void eval_atan2(T& result, const T& y, const T& x)
+void eval_atan2(T &result, const T &y, const T &x)
 {
    BOOST_STATIC_ASSERT_MSG(number_category<T>::value == number_kind_floating_point, "The atan2 function is only valid for floating point types.");
-   if(&result == &y)
+   if (&result == &y)
    {
       T temp(y);
       eval_atan2(result, temp, x);
       return;
    }
-   else if(&result == &x)
+   else if (&result == &x)
    {
       T temp(x);
       eval_atan2(result, y, temp);
@@ -724,82 +725,82 @@ void eval_atan2(T& result, const T& y, const T& x)
 
    typedef typename boost::multiprecision::detail::canonical<boost::uint32_t, T>::type ui_type;
 
-   switch(eval_fpclassify(y))
+   switch (eval_fpclassify(y))
    {
    case FP_NAN:
       result = y;
-      errno = EDOM;
+      errno  = EDOM;
       return;
    case FP_ZERO:
+   {
+      if (eval_signbit(x))
       {
-         if(eval_signbit(x))
-         {
-            result = get_constant_pi<T>();
-            if(eval_signbit(y))
-               result.negate();
-         }
-         else
-         {
-            result = y; // Note we allow atan2(0,0) to be +-zero, even though it's mathematically undefined
-         }
-         return;
+         result = get_constant_pi<T>();
+         if (eval_signbit(y))
+            result.negate();
       }
+      else
+      {
+         result = y; // Note we allow atan2(0,0) to be +-zero, even though it's mathematically undefined
+      }
+      return;
+   }
    case FP_INFINITE:
+   {
+      if (eval_fpclassify(x) == FP_INFINITE)
       {
-         if(eval_fpclassify(x) == FP_INFINITE)
+         if (eval_signbit(x))
          {
-            if(eval_signbit(x))
-            {
-               // 3Pi/4
-               eval_ldexp(result, get_constant_pi<T>(), -2);
-               eval_subtract(result, get_constant_pi<T>());
-               if(eval_get_sign(y) >= 0)
-                  result.negate();
-            }
-            else
-            {
-               // Pi/4
-               eval_ldexp(result, get_constant_pi<T>(), -2);
-               if(eval_get_sign(y) < 0)
-                  result.negate();
-            }
+            // 3Pi/4
+            eval_ldexp(result, get_constant_pi<T>(), -2);
+            eval_subtract(result, get_constant_pi<T>());
+            if (eval_get_sign(y) >= 0)
+               result.negate();
          }
          else
          {
-            eval_ldexp(result, get_constant_pi<T>(), -1);
-            if(eval_get_sign(y) < 0)
+            // Pi/4
+            eval_ldexp(result, get_constant_pi<T>(), -2);
+            if (eval_get_sign(y) < 0)
                result.negate();
          }
-         return;
       }
+      else
+      {
+         eval_ldexp(result, get_constant_pi<T>(), -1);
+         if (eval_get_sign(y) < 0)
+            result.negate();
+      }
+      return;
+   }
    }
 
-   switch(eval_fpclassify(x))
+   switch (eval_fpclassify(x))
    {
    case FP_NAN:
       result = x;
-      errno = EDOM;
+      errno  = EDOM;
       return;
    case FP_ZERO:
-      {
-         eval_ldexp(result, get_constant_pi<T>(), -1);
-         if(eval_get_sign(y) < 0)
-            result.negate();
-         return;
-      }
+   {
+      eval_ldexp(result, get_constant_pi<T>(), -1);
+      if (eval_get_sign(y) < 0)
+         result.negate();
+      return;
+   }
    case FP_INFINITE:
-      if(eval_get_sign(x) > 0)
+      if (eval_get_sign(x) > 0)
          result = ui_type(0);
       else
          result = get_constant_pi<T>();
-      if(eval_get_sign(y) < 0)
+      if (eval_get_sign(y) < 0)
          result.negate();
       return;
    }
 
    T xx;
    eval_divide(xx, y, x);
-   if(eval_get_sign(xx) < 0)
+   if (eval_get_sign(xx) < 0)
       xx.negate();
 
    eval_atan(result, xx);
@@ -808,33 +809,33 @@ void eval_atan2(T& result, const T& y, const T& x)
    const bool y_neg = eval_get_sign(y) < 0;
    const bool x_neg = eval_get_sign(x) < 0;
 
-   if(y_neg != x_neg)
+   if (y_neg != x_neg)
       result.negate();
 
-   if(x_neg)
+   if (x_neg)
    {
-      if(y_neg)
+      if (y_neg)
          eval_subtract(result, get_constant_pi<T>());
       else
          eval_add(result, get_constant_pi<T>());
    }
 }
-template<class T, class A> 
-inline typename enable_if<is_arithmetic<A>, void>::type eval_atan2(T& result, const T& x, const A& a)
+template <class T, class A>
+inline typename enable_if<is_arithmetic<A>, void>::type eval_atan2(T &result, const T &x, const A &a)
 {
-   typedef typename boost::multiprecision::detail::canonical<A, T>::type canonical_type;
+   typedef typename boost::multiprecision::detail::canonical<A, T>::type          canonical_type;
    typedef typename mpl::if_<is_same<A, canonical_type>, T, canonical_type>::type cast_type;
-   cast_type c;
+   cast_type                                                                      c;
    c = a;
    eval_atan2(result, x, c);
 }
 
-template<class T, class A> 
-inline typename enable_if<is_arithmetic<A>, void>::type eval_atan2(T& result, const A& x, const T& a)
+template <class T, class A>
+inline typename enable_if<is_arithmetic<A>, void>::type eval_atan2(T &result, const A &x, const T &a)
 {
-   typedef typename boost::multiprecision::detail::canonical<A, T>::type canonical_type;
+   typedef typename boost::multiprecision::detail::canonical<A, T>::type          canonical_type;
    typedef typename mpl::if_<is_same<A, canonical_type>, T, canonical_type>::type cast_type;
-   cast_type c;
+   cast_type                                                                      c;
    c = x;
    eval_atan2(result, c, a);
 }

--- a/include/boost/multiprecision/detail/integer_ops.hpp
+++ b/include/boost/multiprecision/detail/integer_ops.hpp
@@ -8,26 +8,25 @@
 
 #include <boost/multiprecision/number.hpp>
 
-namespace boost{ namespace multiprecision{
+namespace boost { namespace multiprecision {
 
-namespace default_ops
-{
+namespace default_ops {
 
 template <class Backend>
-inline void eval_qr(const Backend& x, const Backend& y, Backend& q, Backend& r)
+inline void eval_qr(const Backend &x, const Backend &y, Backend &q, Backend &r)
 {
    eval_divide(q, x, y);
    eval_modulus(r, x, y);
 }
 
 template <class Backend, class Integer>
-inline Integer eval_integer_modulus(const Backend& x, Integer val)
+inline Integer eval_integer_modulus(const Backend &x, Integer val)
 {
    BOOST_MP_USING_ABS
-   using default_ops::eval_modulus;
    using default_ops::eval_convert_to;
+   using default_ops::eval_modulus;
    typedef typename boost::multiprecision::detail::canonical<Integer, Backend>::type int_type;
-   Backend t;
+   Backend                                                                           t;
    eval_modulus(t, x, static_cast<int_type>(val));
    Integer result;
    eval_convert_to(&result, t);
@@ -36,15 +35,15 @@ inline Integer eval_integer_modulus(const Backend& x, Integer val)
 
 #ifdef BOOST_MSVC
 #pragma warning(push)
-#pragma warning(disable:4127)
+#pragma warning(disable : 4127)
 #endif
 
 template <class B>
-inline void eval_gcd(B& result, const B& a, const B& b)
+inline void eval_gcd(B &result, const B &a, const B &b)
 {
-   using default_ops::eval_lsb;
-   using default_ops::eval_is_zero;
    using default_ops::eval_get_sign;
+   using default_ops::eval_is_zero;
+   using default_ops::eval_lsb;
 
    int shift;
 
@@ -53,21 +52,21 @@ inline void eval_gcd(B& result, const B& a, const B& b)
    int s = eval_get_sign(u);
 
    /* GCD(0,x) := x */
-   if(s < 0)
+   if (s < 0)
    {
       u.negate();
    }
-   else if(s == 0)
+   else if (s == 0)
    {
       result = v;
       return;
    }
    s = eval_get_sign(v);
-   if(s < 0)
+   if (s < 0)
    {
       v.negate();
    }
-   else if(s == 0)
+   else if (s == 0)
    {
       result = u;
       return;
@@ -78,24 +77,23 @@ inline void eval_gcd(B& result, const B& a, const B& b)
 
    unsigned us = eval_lsb(u);
    unsigned vs = eval_lsb(v);
-   shift = (std::min)(us, vs);
+   shift       = (std::min)(us, vs);
    eval_right_shift(u, us);
    eval_right_shift(v, vs);
 
-   do 
+   do
    {
       /* Now u and v are both odd, so diff(u, v) is even.
       Let u = min(u, v), v = diff(u, v)/2. */
       s = u.compare(v);
-      if(s > 0)
+      if (s > 0)
          u.swap(v);
-      if(s == 0)
+      if (s == 0)
          break;
       eval_subtract(v, u);
       vs = eval_lsb(v);
       eval_right_shift(v, vs);
-   } 
-   while(true);
+   } while (true);
 
    result = u;
    eval_left_shift(result, shift);
@@ -106,13 +104,13 @@ inline void eval_gcd(B& result, const B& a, const B& b)
 #endif
 
 template <class B>
-inline void eval_lcm(B& result, const B& a, const B& b)
+inline void eval_lcm(B &result, const B &a, const B &b)
 {
    typedef typename mpl::front<typename B::unsigned_types>::type ui_type;
-   B t;
+   B                                                             t;
    eval_gcd(t, a, b);
 
-   if(eval_is_zero(t))
+   if (eval_is_zero(t))
    {
       result = static_cast<ui_type>(0);
    }
@@ -121,118 +119,118 @@ inline void eval_lcm(B& result, const B& a, const B& b)
       eval_divide(result, a, t);
       eval_multiply(result, b);
    }
-   if(eval_get_sign(result) < 0)
+   if (eval_get_sign(result) < 0)
       result.negate();
 }
 
-}
+} // namespace default_ops
 
 template <class Backend, expression_template_option ExpressionTemplates>
-inline typename enable_if_c<number_category<Backend>::value == number_kind_integer>::type 
-   divide_qr(const number<Backend, ExpressionTemplates>& x, const number<Backend, ExpressionTemplates>& y,
-   number<Backend, ExpressionTemplates>& q, number<Backend, ExpressionTemplates>& r)
+inline typename enable_if_c<number_category<Backend>::value == number_kind_integer>::type
+divide_qr(const number<Backend, ExpressionTemplates> &x, const number<Backend, ExpressionTemplates> &y,
+          number<Backend, ExpressionTemplates> &q, number<Backend, ExpressionTemplates> &r)
 {
    using default_ops::eval_qr;
    eval_qr(x.backend(), y.backend(), q.backend(), r.backend());
 }
 
 template <class Backend, expression_template_option ExpressionTemplates, class tag, class A1, class A2, class A3, class A4>
-inline typename enable_if_c<number_category<Backend>::value == number_kind_integer>::type 
-   divide_qr(const number<Backend, ExpressionTemplates>& x, const multiprecision::detail::expression<tag, A1, A2, A3, A4>& y,
-   number<Backend, ExpressionTemplates>& q, number<Backend, ExpressionTemplates>& r)
+inline typename enable_if_c<number_category<Backend>::value == number_kind_integer>::type
+divide_qr(const number<Backend, ExpressionTemplates> &x, const multiprecision::detail::expression<tag, A1, A2, A3, A4> &y,
+          number<Backend, ExpressionTemplates> &q, number<Backend, ExpressionTemplates> &r)
 {
    divide_qr(x, number<Backend, ExpressionTemplates>(y), q, r);
 }
 
 template <class tag, class A1, class A2, class A3, class A4, class Backend, expression_template_option ExpressionTemplates>
-inline typename enable_if_c<number_category<Backend>::value == number_kind_integer>::type 
-   divide_qr(const multiprecision::detail::expression<tag, A1, A2, A3, A4>& x, const number<Backend, ExpressionTemplates>& y,
-   number<Backend, ExpressionTemplates>& q, number<Backend, ExpressionTemplates>& r)
+inline typename enable_if_c<number_category<Backend>::value == number_kind_integer>::type
+divide_qr(const multiprecision::detail::expression<tag, A1, A2, A3, A4> &x, const number<Backend, ExpressionTemplates> &y,
+          number<Backend, ExpressionTemplates> &q, number<Backend, ExpressionTemplates> &r)
 {
    divide_qr(number<Backend, ExpressionTemplates>(x), y, q, r);
 }
 
 template <class tag, class A1, class A2, class A3, class A4, class tagb, class A1b, class A2b, class A3b, class A4b, class Backend, expression_template_option ExpressionTemplates>
-inline typename enable_if_c<number_category<Backend>::value == number_kind_integer>::type 
-   divide_qr(const multiprecision::detail::expression<tag, A1, A2, A3, A4>& x, const multiprecision::detail::expression<tagb, A1b, A2b, A3b, A4b>& y,
-   number<Backend, ExpressionTemplates>& q, number<Backend, ExpressionTemplates>& r)
+inline typename enable_if_c<number_category<Backend>::value == number_kind_integer>::type
+divide_qr(const multiprecision::detail::expression<tag, A1, A2, A3, A4> &x, const multiprecision::detail::expression<tagb, A1b, A2b, A3b, A4b> &y,
+          number<Backend, ExpressionTemplates> &q, number<Backend, ExpressionTemplates> &r)
 {
    divide_qr(number<Backend, ExpressionTemplates>(x), number<Backend, ExpressionTemplates>(y), q, r);
 }
 
 template <class Backend, expression_template_option ExpressionTemplates, class Integer>
-inline typename enable_if<mpl::and_<is_integral<Integer>, mpl::bool_<number_category<Backend>::value == number_kind_integer> >, Integer>::type 
-   integer_modulus(const number<Backend, ExpressionTemplates>& x, Integer val)
+inline typename enable_if<mpl::and_<is_integral<Integer>, mpl::bool_<number_category<Backend>::value == number_kind_integer> >, Integer>::type
+integer_modulus(const number<Backend, ExpressionTemplates> &x, Integer val)
 {
    using default_ops::eval_integer_modulus;
    return eval_integer_modulus(x.backend(), val);
 }
 
 template <class tag, class A1, class A2, class A3, class A4, class Integer>
-inline typename enable_if<mpl::and_<is_integral<Integer>, mpl::bool_<number_category<typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type>::value == number_kind_integer> >, Integer>::type 
-   integer_modulus(const multiprecision::detail::expression<tag, A1, A2, A3, A4>& x, Integer val)
+inline typename enable_if<mpl::and_<is_integral<Integer>, mpl::bool_<number_category<typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type>::value == number_kind_integer> >, Integer>::type
+integer_modulus(const multiprecision::detail::expression<tag, A1, A2, A3, A4> &x, Integer val)
 {
    typedef typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type result_type;
    return integer_modulus(result_type(x), val);
 }
 
 template <class Backend, expression_template_option ExpressionTemplates>
-inline typename enable_if_c<number_category<Backend>::value == number_kind_integer, unsigned>::type 
-   lsb(const number<Backend, ExpressionTemplates>& x)
+inline typename enable_if_c<number_category<Backend>::value == number_kind_integer, unsigned>::type
+lsb(const number<Backend, ExpressionTemplates> &x)
 {
    using default_ops::eval_lsb;
    return eval_lsb(x.backend());
 }
 
 template <class tag, class A1, class A2, class A3, class A4>
-inline typename enable_if_c<number_category<typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type>::value == number_kind_integer, unsigned>::type 
-   lsb(const multiprecision::detail::expression<tag, A1, A2, A3, A4>& x)
+inline typename enable_if_c<number_category<typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type>::value == number_kind_integer, unsigned>::type
+lsb(const multiprecision::detail::expression<tag, A1, A2, A3, A4> &x)
 {
    typedef typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type number_type;
-   number_type n(x);
+   number_type                                                                           n(x);
    using default_ops::eval_lsb;
    return eval_lsb(n.backend());
 }
 
 template <class Backend, expression_template_option ExpressionTemplates>
-inline typename enable_if_c<number_category<Backend>::value == number_kind_integer, unsigned>::type 
-   msb(const number<Backend, ExpressionTemplates>& x)
+inline typename enable_if_c<number_category<Backend>::value == number_kind_integer, unsigned>::type
+msb(const number<Backend, ExpressionTemplates> &x)
 {
    using default_ops::eval_msb;
    return eval_msb(x.backend());
 }
 
 template <class tag, class A1, class A2, class A3, class A4>
-inline typename enable_if_c<number_category<typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type>::value == number_kind_integer, unsigned>::type 
-   msb(const multiprecision::detail::expression<tag, A1, A2, A3, A4>& x)
+inline typename enable_if_c<number_category<typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type>::value == number_kind_integer, unsigned>::type
+msb(const multiprecision::detail::expression<tag, A1, A2, A3, A4> &x)
 {
    typedef typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type number_type;
-   number_type n(x);
+   number_type                                                                           n(x);
    using default_ops::eval_msb;
    return eval_msb(n.backend());
 }
 
 template <class Backend, expression_template_option ExpressionTemplates>
-inline typename enable_if_c<number_category<Backend>::value == number_kind_integer, bool>::type 
-   bit_test(const number<Backend, ExpressionTemplates>& x, unsigned index)
+inline typename enable_if_c<number_category<Backend>::value == number_kind_integer, bool>::type
+bit_test(const number<Backend, ExpressionTemplates> &x, unsigned index)
 {
    using default_ops::eval_bit_test;
    return eval_bit_test(x.backend(), index);
 }
 
 template <class tag, class A1, class A2, class A3, class A4>
-inline typename enable_if_c<number_category<typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type>::value == number_kind_integer, bool>::type 
-   bit_test(const multiprecision::detail::expression<tag, A1, A2, A3, A4>& x, unsigned index)
+inline typename enable_if_c<number_category<typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type>::value == number_kind_integer, bool>::type
+bit_test(const multiprecision::detail::expression<tag, A1, A2, A3, A4> &x, unsigned index)
 {
    typedef typename multiprecision::detail::expression<tag, A1, A2, A3, A4>::result_type number_type;
-   number_type n(x);
+   number_type                                                                           n(x);
    using default_ops::eval_bit_test;
    return eval_bit_test(n.backend(), index);
 }
 
 template <class Backend, expression_template_option ExpressionTemplates>
-inline typename enable_if_c<number_category<Backend>::value == number_kind_integer, number<Backend, ExpressionTemplates>&>::type 
-   bit_set(number<Backend, ExpressionTemplates>& x, unsigned index)
+inline typename enable_if_c<number_category<Backend>::value == number_kind_integer, number<Backend, ExpressionTemplates> &>::type
+bit_set(number<Backend, ExpressionTemplates> &x, unsigned index)
 {
    using default_ops::eval_bit_set;
    eval_bit_set(x.backend(), index);
@@ -240,8 +238,8 @@ inline typename enable_if_c<number_category<Backend>::value == number_kind_integ
 }
 
 template <class Backend, expression_template_option ExpressionTemplates>
-inline typename enable_if_c<number_category<Backend>::value == number_kind_integer, number<Backend, ExpressionTemplates>&>::type 
-   bit_unset(number<Backend, ExpressionTemplates>& x, unsigned index)
+inline typename enable_if_c<number_category<Backend>::value == number_kind_integer, number<Backend, ExpressionTemplates> &>::type
+bit_unset(number<Backend, ExpressionTemplates> &x, unsigned index)
 {
    using default_ops::eval_bit_unset;
    eval_bit_unset(x.backend(), index);
@@ -249,15 +247,15 @@ inline typename enable_if_c<number_category<Backend>::value == number_kind_integ
 }
 
 template <class Backend, expression_template_option ExpressionTemplates>
-inline typename enable_if_c<number_category<Backend>::value == number_kind_integer, number<Backend, ExpressionTemplates>&>::type 
-   bit_flip(number<Backend, ExpressionTemplates>& x, unsigned index)
+inline typename enable_if_c<number_category<Backend>::value == number_kind_integer, number<Backend, ExpressionTemplates> &>::type
+bit_flip(number<Backend, ExpressionTemplates> &x, unsigned index)
 {
    using default_ops::eval_bit_flip;
    eval_bit_flip(x.backend(), index);
    return x;
 }
 
-namespace default_ops{
+namespace default_ops {
 
 //
 // Within powm, we need a type with twice as many digits as the argument type, define
@@ -274,38 +272,38 @@ struct double_precision_type
 // check the value is positive:
 //
 template <class Backend>
-inline void check_sign_of_backend(const Backend& v, const mpl::true_)
+inline void check_sign_of_backend(const Backend &v, const mpl::true_)
 {
-   if(eval_get_sign(v) < 0)
+   if (eval_get_sign(v) < 0)
    {
       BOOST_THROW_EXCEPTION(std::runtime_error("powm requires a positive exponent."));
    }
 }
 template <class Backend>
-inline void check_sign_of_backend(const Backend&, const mpl::false_){}
+inline void check_sign_of_backend(const Backend &, const mpl::false_) {}
 //
 // Calculate (a^p)%c:
 //
 template <class Backend>
-void eval_powm(Backend& result, const Backend& a, const Backend& p, const Backend& c)
+void eval_powm(Backend &result, const Backend &a, const Backend &p, const Backend &c)
 {
    using default_ops::eval_bit_test;
    using default_ops::eval_get_sign;
-   using default_ops::eval_multiply;
    using default_ops::eval_modulus;
+   using default_ops::eval_multiply;
    using default_ops::eval_right_shift;
 
-   typedef typename double_precision_type<Backend>::type double_type;
+   typedef typename double_precision_type<Backend>::type                                       double_type;
    typedef typename boost::multiprecision::detail::canonical<unsigned char, double_type>::type ui_type;
 
    check_sign_of_backend(p, mpl::bool_<std::numeric_limits<number<Backend> >::is_signed>());
-   
+
    double_type x, y(a), b(p), t;
    x = ui_type(1u);
 
-   while(eval_get_sign(b) > 0)
+   while (eval_get_sign(b) > 0)
    {
-      if(eval_bit_test(b, 0))
+      if (eval_bit_test(b, 0))
       {
          eval_multiply(t, x, y);
          eval_modulus(x, t, c);
@@ -319,22 +317,22 @@ void eval_powm(Backend& result, const Backend& a, const Backend& p, const Backen
 }
 
 template <class Backend, class Integer>
-void eval_powm(Backend& result, const Backend& a, const Backend& p, Integer c)
+void eval_powm(Backend &result, const Backend &a, const Backend &p, Integer c)
 {
-   typedef typename double_precision_type<Backend>::type double_type;
+   typedef typename double_precision_type<Backend>::type                                       double_type;
    typedef typename boost::multiprecision::detail::canonical<unsigned char, double_type>::type ui_type;
-   typedef typename boost::multiprecision::detail::canonical<Integer, double_type>::type i1_type;
-   typedef typename boost::multiprecision::detail::canonical<Integer, Backend>::type i2_type;
+   typedef typename boost::multiprecision::detail::canonical<Integer, double_type>::type       i1_type;
+   typedef typename boost::multiprecision::detail::canonical<Integer, Backend>::type           i2_type;
 
    using default_ops::eval_bit_test;
    using default_ops::eval_get_sign;
-   using default_ops::eval_multiply;
    using default_ops::eval_modulus;
+   using default_ops::eval_multiply;
    using default_ops::eval_right_shift;
 
    check_sign_of_backend(p, mpl::bool_<std::numeric_limits<number<Backend> >::is_signed>());
 
-   if(eval_get_sign(p) < 0)
+   if (eval_get_sign(p) < 0)
    {
       BOOST_THROW_EXCEPTION(std::runtime_error("powm requires a positive exponent."));
    }
@@ -342,9 +340,9 @@ void eval_powm(Backend& result, const Backend& a, const Backend& p, Integer c)
    double_type x, y(a), b(p), t;
    x = ui_type(1u);
 
-   while(eval_get_sign(b) > 0)
+   while (eval_get_sign(b) > 0)
    {
-      if(eval_bit_test(b, 0))
+      if (eval_bit_test(b, 0))
       {
          eval_multiply(t, x, y);
          eval_modulus(x, t, static_cast<i1_type>(c));
@@ -358,23 +356,23 @@ void eval_powm(Backend& result, const Backend& a, const Backend& p, Integer c)
 }
 
 template <class Backend, class Integer>
-typename enable_if<is_unsigned<Integer> >::type eval_powm(Backend& result, const Backend& a, Integer b, const Backend& c)
+typename enable_if<is_unsigned<Integer> >::type eval_powm(Backend &result, const Backend &a, Integer b, const Backend &c)
 {
-   typedef typename double_precision_type<Backend>::type double_type;
+   typedef typename double_precision_type<Backend>::type                                       double_type;
    typedef typename boost::multiprecision::detail::canonical<unsigned char, double_type>::type ui_type;
 
    using default_ops::eval_bit_test;
    using default_ops::eval_get_sign;
-   using default_ops::eval_multiply;
    using default_ops::eval_modulus;
+   using default_ops::eval_multiply;
    using default_ops::eval_right_shift;
 
    double_type x, y(a), t;
    x = ui_type(1u);
 
-   while(b > 0)
+   while (b > 0)
    {
-      if(b & 1)
+      if (b & 1)
       {
          eval_multiply(t, x, y);
          eval_modulus(x, t, c);
@@ -388,9 +386,9 @@ typename enable_if<is_unsigned<Integer> >::type eval_powm(Backend& result, const
 }
 
 template <class Backend, class Integer>
-typename enable_if<is_signed<Integer> >::type eval_powm(Backend& result, const Backend& a, Integer b, const Backend& c)
+typename enable_if<is_signed<Integer> >::type eval_powm(Backend &result, const Backend &a, Integer b, const Backend &c)
 {
-   if(b < 0)
+   if (b < 0)
    {
       BOOST_THROW_EXCEPTION(std::runtime_error("powm requires a positive exponent."));
    }
@@ -398,25 +396,25 @@ typename enable_if<is_signed<Integer> >::type eval_powm(Backend& result, const B
 }
 
 template <class Backend, class Integer1, class Integer2>
-typename enable_if<is_unsigned<Integer1> >::type eval_powm(Backend& result, const Backend& a, Integer1 b, Integer2 c)
+typename enable_if<is_unsigned<Integer1> >::type eval_powm(Backend &result, const Backend &a, Integer1 b, Integer2 c)
 {
-   typedef typename double_precision_type<Backend>::type double_type;
+   typedef typename double_precision_type<Backend>::type                                       double_type;
    typedef typename boost::multiprecision::detail::canonical<unsigned char, double_type>::type ui_type;
-   typedef typename boost::multiprecision::detail::canonical<Integer1, double_type>::type i1_type;
-   typedef typename boost::multiprecision::detail::canonical<Integer2, Backend>::type i2_type;
+   typedef typename boost::multiprecision::detail::canonical<Integer1, double_type>::type      i1_type;
+   typedef typename boost::multiprecision::detail::canonical<Integer2, Backend>::type          i2_type;
 
    using default_ops::eval_bit_test;
    using default_ops::eval_get_sign;
-   using default_ops::eval_multiply;
    using default_ops::eval_modulus;
+   using default_ops::eval_multiply;
    using default_ops::eval_right_shift;
 
    double_type x, y(a), t;
    x = ui_type(1u);
 
-   while(b > 0)
+   while (b > 0)
    {
-      if(b & 1)
+      if (b & 1)
       {
          eval_multiply(t, x, y);
          eval_modulus(x, t, static_cast<i1_type>(c));
@@ -430,9 +428,9 @@ typename enable_if<is_unsigned<Integer1> >::type eval_powm(Backend& result, cons
 }
 
 template <class Backend, class Integer1, class Integer2>
-typename enable_if<is_signed<Integer1> >::type eval_powm(Backend& result, const Backend& a, Integer1 b, Integer2 c)
+typename enable_if<is_signed<Integer1> >::type eval_powm(Backend &result, const Backend &a, Integer1 b, Integer2 c)
 {
-   if(b < 0)
+   if (b < 0)
    {
       BOOST_THROW_EXCEPTION(std::runtime_error("powm requires a positive exponent."));
    }
@@ -442,54 +440,45 @@ typename enable_if<is_signed<Integer1> >::type eval_powm(Backend& result, const 
 struct powm_func
 {
    template <class T, class U, class V>
-   void operator()(T& result, const T& b, const U& p, const V& m)const
+   void operator()(T &result, const T &b, const U &p, const V &m) const
    {
       eval_powm(result, b, p, m);
    }
 };
 
-}
+} // namespace default_ops
 
 template <class T, class U, class V>
 inline typename enable_if<
-   mpl::and_<
-      mpl::bool_<number_category<T>::value == number_kind_integer>, 
-      mpl::or_<
-         is_number<T>,
-         is_number_expression<T>
-      >,
-      mpl::or_<
-         is_number<U>,
-         is_number_expression<U>,
-         is_integral<U>
-      >,
-      mpl::or_<
-         is_number<V>,
-         is_number_expression<V>,
-         is_integral<V>
-      >
-   >,
-   typename mpl::if_<
-      is_no_et_number<T>, 
-      T,
-      typename mpl::if_<
-         is_no_et_number<U>,
-         U,
-         typename mpl::if_<
-            is_no_et_number<V>,
-            V,
-            detail::expression<detail::function, default_ops::powm_func, T, U, V> >::type
-         >::type
-      >::type
-   >::type
-   powm(const T& b, const U& p, const V& mod)
+    mpl::and_<
+        mpl::bool_<number_category<T>::value == number_kind_integer>,
+        mpl::or_<
+            is_number<T>,
+            is_number_expression<T> >,
+        mpl::or_<
+            is_number<U>,
+            is_number_expression<U>,
+            is_integral<U> >,
+        mpl::or_<
+            is_number<V>,
+            is_number_expression<V>,
+            is_integral<V> > >,
+    typename mpl::if_<
+        is_no_et_number<T>,
+        T,
+        typename mpl::if_<
+            is_no_et_number<U>,
+            U,
+            typename mpl::if_<
+                is_no_et_number<V>,
+                V,
+                detail::expression<detail::function, default_ops::powm_func, T, U, V> >::type>::type>::type>::type
+powm(const T &b, const U &p, const V &mod)
 {
    return detail::expression<detail::function, default_ops::powm_func, T, U, V>(
-      default_ops::powm_func(), b, p, mod);
+       default_ops::powm_func(), b, p, mod);
 }
 
-}} //namespaces
+}} // namespace boost::multiprecision
 
 #endif
-
-

--- a/include/boost/multiprecision/gmp.hpp
+++ b/include/boost/multiprecision/gmp.hpp
@@ -6,52 +6,52 @@
 #ifndef BOOST_MATH_ER_GMP_BACKEND_HPP
 #define BOOST_MATH_ER_GMP_BACKEND_HPP
 
-#include <boost/multiprecision/number.hpp>
-#include <boost/multiprecision/debug_adaptor.hpp>
-#include <boost/multiprecision/detail/integer_ops.hpp>
-#include <boost/multiprecision/detail/big_lanczos.hpp>
-#include <boost/multiprecision/detail/digits.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/cstdint.hpp>
 #include <boost/functional/hash_fwd.hpp>
+#include <boost/math/special_functions/fpclassify.hpp>
+#include <boost/multiprecision/debug_adaptor.hpp>
+#include <boost/multiprecision/detail/big_lanczos.hpp>
+#include <boost/multiprecision/detail/digits.hpp>
+#include <boost/multiprecision/detail/integer_ops.hpp>
+#include <boost/multiprecision/number.hpp>
 //
 // Some includes we need from Boost.Math, since we rely on that library to provide these functions:
 //
-#include <boost/math/special_functions/asinh.hpp>
 #include <boost/math/special_functions/acosh.hpp>
+#include <boost/math/special_functions/asinh.hpp>
 #include <boost/math/special_functions/atanh.hpp>
 #include <boost/math/special_functions/cbrt.hpp>
 #include <boost/math/special_functions/expm1.hpp>
 #include <boost/math/special_functions/gamma.hpp>
 
 #ifdef BOOST_MSVC
-#  pragma warning(push)
-#  pragma warning(disable:4127)
+#pragma warning(push)
+#pragma warning(disable : 4127)
 #endif
 #include <gmp.h>
 #ifdef BOOST_MSVC
-#  pragma warning(pop)
+#pragma warning(pop)
 #endif
 
 #if defined(__MPIR_VERSION) && defined(__MPIR_VERSION_MINOR) && defined(__MPIR_VERSION_PATCHLEVEL)
-#  define BOOST_MP_MPIR_VERSION (__MPIR_VERSION * 10000 + __MPIR_VERSION_MINOR * 100 + __MPIR_VERSION_PATCHLEVEL)
+#define BOOST_MP_MPIR_VERSION (__MPIR_VERSION * 10000 + __MPIR_VERSION_MINOR * 100 + __MPIR_VERSION_PATCHLEVEL)
 #else
-#  define BOOST_MP_MPIR_VERSION 0
+#define BOOST_MP_MPIR_VERSION 0
 #endif
 
 #include <cctype>
+#include <climits>
 #include <cmath>
 #include <limits>
-#include <climits>
 
-namespace boost{
-namespace multiprecision{
-namespace backends{
+namespace boost {
+namespace multiprecision {
+namespace backends {
 
 #ifdef BOOST_MSVC
 // warning C4127: conditional expression is constant
 #pragma warning(push)
-#pragma warning(disable:4127)
+#pragma warning(disable : 4127)
 #endif
 
 template <unsigned digits10>
@@ -61,40 +61,43 @@ struct gmp_rational;
 
 } // namespace backends
 
-template<>
-struct number_category<backends::gmp_int> : public mpl::int_<number_kind_integer>{};
-template<>
-struct number_category<backends::gmp_rational> : public mpl::int_<number_kind_rational>{};
+template <>
+struct number_category<backends::gmp_int> : public mpl::int_<number_kind_integer>
+{};
+template <>
+struct number_category<backends::gmp_rational> : public mpl::int_<number_kind_rational>
+{};
 template <unsigned digits10>
-struct number_category<backends::gmp_float<digits10> > : public mpl::int_<number_kind_floating_point>{};
+struct number_category<backends::gmp_float<digits10> > : public mpl::int_<number_kind_floating_point>
+{};
 
-namespace backends{
+namespace backends {
 //
 // Within this file, the only functions we mark as noexcept are those that manipulate
 // (but don't create) an mpf_t.  All other types may allocate at pretty much any time
 // via a user-supplied allocator, and therefore throw.
 //
-namespace detail{
+namespace detail {
 
 template <unsigned digits10>
 struct gmp_float_imp
 {
 #ifdef BOOST_HAS_LONG_LONG
-   typedef mpl::list<long, boost::long_long_type>                     signed_types;
-   typedef mpl::list<unsigned long, boost::ulong_long_type>   unsigned_types;
+   typedef mpl::list<long, boost::long_long_type>           signed_types;
+   typedef mpl::list<unsigned long, boost::ulong_long_type> unsigned_types;
 #else
-   typedef mpl::list<long>                                signed_types;
-   typedef mpl::list<unsigned long>                       unsigned_types;
+   typedef mpl::list<long>          signed_types;
+   typedef mpl::list<unsigned long> unsigned_types;
 #endif
-   typedef mpl::list<double, long double>                 float_types;
-   typedef long                                           exponent_type;
+   typedef mpl::list<double, long double> float_types;
+   typedef long                           exponent_type;
 
-   gmp_float_imp() BOOST_NOEXCEPT 
+   gmp_float_imp() BOOST_NOEXCEPT
    {
       m_data[0]._mp_d = 0; // uninitialized m_data
    }
 
-   gmp_float_imp(const gmp_float_imp& o)
+   gmp_float_imp(const gmp_float_imp &o)
    {
       //
       // We have to do an init followed by a set here, otherwise *this may be at
@@ -103,19 +106,19 @@ struct gmp_float_imp
       // things go badly wrong!!
       //
       mpf_init2(m_data, mpf_get_prec(o.data()));
-      if(o.m_data[0]._mp_d)
+      if (o.m_data[0]._mp_d)
          mpf_set(m_data, o.m_data);
    }
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
-   gmp_float_imp(gmp_float_imp&& o) BOOST_NOEXCEPT
+   gmp_float_imp(gmp_float_imp &&o) BOOST_NOEXCEPT
    {
-      m_data[0] = o.m_data[0];
+      m_data[0]         = o.m_data[0];
       o.m_data[0]._mp_d = 0;
    }
 #endif
-   gmp_float_imp& operator = (const gmp_float_imp& o)
+   gmp_float_imp &operator=(const gmp_float_imp &o)
    {
-      if(m_data[0]._mp_d == 0)
+      if (m_data[0]._mp_d == 0)
          mpf_init2(m_data, mpf_get_prec(o.data()));
       if (mpf_get_prec(data()) != mpf_get_prec(o.data()))
       {
@@ -133,7 +136,7 @@ struct gmp_float_imp
       return *this;
    }
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
-   gmp_float_imp& operator = (gmp_float_imp&& o) BOOST_NOEXCEPT
+   gmp_float_imp &operator=(gmp_float_imp &&o) BOOST_NOEXCEPT
    {
       mpf_swap(m_data, o.m_data);
       return *this;
@@ -142,25 +145,25 @@ struct gmp_float_imp
 
 #ifdef BOOST_HAS_LONG_LONG
 #if defined(ULLONG_MAX) && (ULLONG_MAX == ULONG_MAX)
-   gmp_float_imp& operator = (boost::ulong_long_type i)
+   gmp_float_imp &operator=(boost::ulong_long_type i)
    {
       *this = static_cast<unsigned long>(i);
       return *this;
    }
 #else
-   gmp_float_imp& operator = (boost::ulong_long_type i)
+   gmp_float_imp &operator=(boost::ulong_long_type i)
    {
-      if(m_data[0]._mp_d == 0)
+      if (m_data[0]._mp_d == 0)
          mpf_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : get_default_precision()));
-      boost::ulong_long_type mask = ((((1uLL << (std::numeric_limits<unsigned long>::digits - 1)) - 1) << 1) | 1uLL);
-      unsigned shift = 0;
-      mpf_t t;
+      boost::ulong_long_type mask  = ((((1uLL << (std::numeric_limits<unsigned long>::digits - 1)) - 1) << 1) | 1uLL);
+      unsigned               shift = 0;
+      mpf_t                  t;
       mpf_init2(t, multiprecision::detail::digits10_2_2(digits10 ? digits10 : get_default_precision()));
       mpf_set_ui(m_data, 0);
-      while(i)
+      while (i)
       {
          mpf_set_ui(t, static_cast<unsigned long>(i & mask));
-         if(shift)
+         if (shift)
             mpf_mul_2exp(t, t, shift);
          mpf_add(m_data, m_data, t);
          shift += std::numeric_limits<unsigned long>::digits;
@@ -170,53 +173,55 @@ struct gmp_float_imp
       return *this;
    }
 #endif
-   gmp_float_imp& operator = (boost::long_long_type i)
+   gmp_float_imp &operator=(boost::long_long_type i)
    {
-      if(m_data[0]._mp_d == 0)
+      if (m_data[0]._mp_d == 0)
          mpf_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : get_default_precision()));
       bool neg = i < 0;
-      *this = static_cast<boost::ulong_long_type>(boost::multiprecision::detail::unsigned_abs(i));
-      if(neg)
+      *this    = static_cast<boost::ulong_long_type>(boost::multiprecision::detail::unsigned_abs(i));
+      if (neg)
          mpf_neg(m_data, m_data);
       return *this;
    }
 #endif
-   gmp_float_imp& operator = (unsigned long i)
+   gmp_float_imp &operator=(unsigned long i)
    {
-      if(m_data[0]._mp_d == 0)
+      if (m_data[0]._mp_d == 0)
          mpf_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : get_default_precision()));
       mpf_set_ui(m_data, i);
       return *this;
    }
-   gmp_float_imp& operator = (long i)
+   gmp_float_imp &operator=(long i)
    {
-      if(m_data[0]._mp_d == 0)
+      if (m_data[0]._mp_d == 0)
          mpf_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : get_default_precision()));
       mpf_set_si(m_data, i);
       return *this;
    }
-   gmp_float_imp& operator = (double d)
+   gmp_float_imp &operator=(double d)
    {
-      if(m_data[0]._mp_d == 0)
+      if (m_data[0]._mp_d == 0)
          mpf_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : get_default_precision()));
       mpf_set_d(m_data, d);
       return *this;
    }
-   gmp_float_imp& operator = (long double a)
+   gmp_float_imp &operator=(long double a)
    {
+      using std::floor;
       using std::frexp;
       using std::ldexp;
-      using std::floor;
 
-      if(m_data[0]._mp_d == 0)
+      if (m_data[0]._mp_d == 0)
          mpf_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : get_default_precision()));
 
-      if (a == 0) {
+      if (a == 0)
+      {
          mpf_set_si(m_data, 0);
          return *this;
       }
 
-      if (a == 1) {
+      if (a == 1)
+      {
          mpf_set_si(m_data, 1);
          return *this;
       }
@@ -224,7 +229,7 @@ struct gmp_float_imp
       BOOST_ASSERT(!(boost::math::isinf)(a));
       BOOST_ASSERT(!(boost::math::isnan)(a));
 
-      int e;
+      int         e;
       long double f, term;
       mpf_set_ui(m_data, 0u);
 
@@ -232,120 +237,120 @@ struct gmp_float_imp
 
       static const int shift = std::numeric_limits<int>::digits - 1;
 
-      while(f)
+      while (f)
       {
          // extract int sized bits from f:
-         f = ldexp(f, shift);
+         f    = ldexp(f, shift);
          term = floor(f);
          e -= shift;
          mpf_mul_2exp(m_data, m_data, shift);
-         if(term > 0)
+         if (term > 0)
             mpf_add_ui(m_data, m_data, static_cast<unsigned>(term));
          else
             mpf_sub_ui(m_data, m_data, static_cast<unsigned>(-term));
          f -= term;
       }
-      if(e > 0)
+      if (e > 0)
          mpf_mul_2exp(m_data, m_data, e);
-      else if(e < 0)
+      else if (e < 0)
          mpf_div_2exp(m_data, m_data, -e);
       return *this;
    }
-   gmp_float_imp& operator = (const char* s)
+   gmp_float_imp &operator=(const char *s)
    {
-      if(m_data[0]._mp_d == 0)
+      if (m_data[0]._mp_d == 0)
          mpf_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : get_default_precision()));
-      if(0 != mpf_set_str(m_data, s, 10))
+      if (0 != mpf_set_str(m_data, s, 10))
          BOOST_THROW_EXCEPTION(std::runtime_error(std::string("The string \"") + s + std::string("\"could not be interpreted as a valid floating point number.")));
       return *this;
    }
-   void swap(gmp_float_imp& o) BOOST_NOEXCEPT
+   void swap(gmp_float_imp &o) BOOST_NOEXCEPT
    {
       mpf_swap(m_data, o.m_data);
    }
-   std::string str(std::streamsize digits, std::ios_base::fmtflags f)const
+   std::string str(std::streamsize digits, std::ios_base::fmtflags f) const
    {
       BOOST_ASSERT(m_data[0]._mp_d);
 
-      bool scientific = (f & std::ios_base::scientific) == std::ios_base::scientific;
-      bool fixed      = (f & std::ios_base::fixed) == std::ios_base::fixed;
+      bool            scientific = (f & std::ios_base::scientific) == std::ios_base::scientific;
+      bool            fixed      = (f & std::ios_base::fixed) == std::ios_base::fixed;
       std::streamsize org_digits(digits);
 
-      if(scientific && digits)
+      if (scientific && digits)
          ++digits;
 
       std::string result;
-      mp_exp_t e;
-      void *(*alloc_func_ptr) (size_t);
-      void *(*realloc_func_ptr) (void *, size_t, size_t);
-      void (*free_func_ptr) (void *, size_t);
+      mp_exp_t    e;
+      void *(*alloc_func_ptr)(size_t);
+      void *(*realloc_func_ptr)(void *, size_t, size_t);
+      void (*free_func_ptr)(void *, size_t);
       mp_get_memory_functions(&alloc_func_ptr, &realloc_func_ptr, &free_func_ptr);
 
-      if(mpf_sgn(m_data) == 0)
+      if (mpf_sgn(m_data) == 0)
       {
-         e = 0;
+         e      = 0;
          result = "0";
-         if(fixed && digits)
+         if (fixed && digits)
             ++digits;
       }
       else
       {
-         char* ps = mpf_get_str (0, &e, 10, static_cast<std::size_t>(digits), m_data);
-         --e;  // To match with what our formatter expects.
-         if(fixed && e != -1)
+         char *ps = mpf_get_str(0, &e, 10, static_cast<std::size_t>(digits), m_data);
+         --e; // To match with what our formatter expects.
+         if (fixed && e != -1)
          {
             // Oops we actually need a different number of digits to what we asked for:
-            (*free_func_ptr)((void*)ps, std::strlen(ps) + 1);
+            (*free_func_ptr)((void *)ps, std::strlen(ps) + 1);
             digits += e + 1;
-            if(digits == 0)
+            if (digits == 0)
             {
                // We need to get *all* the digits and then possibly round up,
                // we end up with either "0" or "1" as the result.
-               ps = mpf_get_str (0, &e, 10, 0, m_data);
+               ps = mpf_get_str(0, &e, 10, 0, m_data);
                --e;
                unsigned offset = *ps == '-' ? 1 : 0;
-               if(ps[offset] > '5')
+               if (ps[offset] > '5')
                {
                   ++e;
-                  ps[offset] = '1';
+                  ps[offset]     = '1';
                   ps[offset + 1] = 0;
                }
-               else if(ps[offset] == '5')
+               else if (ps[offset] == '5')
                {
-                  unsigned i = offset + 1;
-                  bool round_up = false;
-                  while(ps[i] != 0)
+                  unsigned i        = offset + 1;
+                  bool     round_up = false;
+                  while (ps[i] != 0)
                   {
-                     if(ps[i] != '0')
+                     if (ps[i] != '0')
                      {
                         round_up = true;
                         break;
                      }
                      ++i;
                   }
-                  if(round_up)
+                  if (round_up)
                   {
                      ++e;
-                     ps[offset] = '1';
+                     ps[offset]     = '1';
                      ps[offset + 1] = 0;
                   }
                   else
                   {
-                     ps[offset] = '0';
+                     ps[offset]     = '0';
                      ps[offset + 1] = 0;
                   }
                }
                else
                {
-                  ps[offset] = '0';
+                  ps[offset]     = '0';
                   ps[offset + 1] = 0;
                }
             }
-            else if(digits > 0)
+            else if (digits > 0)
             {
                mp_exp_t old_e = e;
-               ps = mpf_get_str (0, &e, 10, static_cast<std::size_t>(digits), m_data);
-               --e;  // To match with what our formatter expects.
+               ps             = mpf_get_str(0, &e, 10, static_cast<std::size_t>(digits), m_data);
+               --e; // To match with what our formatter expects.
                if (old_e > e)
                {
                   // in some cases, when we ask for more digits of precision, it will
@@ -353,28 +358,28 @@ struct gmp_float_imp
                   // happens, account for it here.
                   // example: cout << fixed << setprecision(3) << mpf_float_50("99.9809")
                   digits -= old_e - e;
-                  ps = mpf_get_str (0, &e, 10, static_cast<std::size_t>(digits), m_data);
-                  --e;  // To match with what our formatter expects.
+                  ps = mpf_get_str(0, &e, 10, static_cast<std::size_t>(digits), m_data);
+                  --e; // To match with what our formatter expects.
                }
             }
             else
             {
-               ps = mpf_get_str (0, &e, 10, 1, m_data);
+               ps = mpf_get_str(0, &e, 10, 1, m_data);
                --e;
                unsigned offset = *ps == '-' ? 1 : 0;
-               ps[offset] = '0';
-               ps[offset + 1] = 0;
+               ps[offset]      = '0';
+               ps[offset + 1]  = 0;
             }
          }
          result = ps;
-         (*free_func_ptr)((void*)ps, std::strlen(ps) + 1);
+         (*free_func_ptr)((void *)ps, std::strlen(ps) + 1);
       }
       boost::multiprecision::detail::format_float_string(result, e, org_digits, f, mpf_sgn(m_data) == 0);
       return result;
    }
    ~gmp_float_imp() BOOST_NOEXCEPT
    {
-      if(m_data[0]._mp_d)
+      if (m_data[0]._mp_d)
          mpf_clear(m_data);
    }
    void negate() BOOST_NOEXCEPT
@@ -382,41 +387,42 @@ struct gmp_float_imp
       BOOST_ASSERT(m_data[0]._mp_d);
       mpf_neg(m_data, m_data);
    }
-   int compare(const gmp_float<digits10>& o)const BOOST_NOEXCEPT
+   int compare(const gmp_float<digits10> &o) const BOOST_NOEXCEPT
    {
       BOOST_ASSERT(m_data[0]._mp_d && o.m_data[0]._mp_d);
       return mpf_cmp(m_data, o.m_data);
    }
-   int compare(long i)const BOOST_NOEXCEPT
+   int compare(long i) const BOOST_NOEXCEPT
    {
       BOOST_ASSERT(m_data[0]._mp_d);
       return mpf_cmp_si(m_data, i);
    }
-   int compare(unsigned long i)const BOOST_NOEXCEPT
+   int compare(unsigned long i) const BOOST_NOEXCEPT
    {
       BOOST_ASSERT(m_data[0]._mp_d);
       return mpf_cmp_ui(m_data, i);
    }
    template <class V>
-   typename enable_if<is_arithmetic<V>, int>::type compare(V v)const
+   typename enable_if<is_arithmetic<V>, int>::type compare(V v) const
    {
       gmp_float<digits10> d;
       d = v;
       return compare(d);
    }
-   mpf_t& data() BOOST_NOEXCEPT
+   mpf_t &data() BOOST_NOEXCEPT
    {
       BOOST_ASSERT(m_data[0]._mp_d);
       return m_data;
    }
-   const mpf_t& data()const BOOST_NOEXCEPT
+   const mpf_t &data() const BOOST_NOEXCEPT
    {
       BOOST_ASSERT(m_data[0]._mp_d);
       return m_data;
    }
-protected:
-   mpf_t m_data;
-   static unsigned& get_default_precision() BOOST_NOEXCEPT
+
+ protected:
+   mpf_t            m_data;
+   static unsigned &get_default_precision() BOOST_NOEXCEPT
    {
       static unsigned val = 50;
       return val;
@@ -435,13 +441,13 @@ struct gmp_float : public detail::gmp_float_imp<digits10>
    {
       mpf_init2(this->m_data, multiprecision::detail::digits10_2_2(digits10));
    }
-   gmp_float(const gmp_float& o) : detail::gmp_float_imp<digits10>(o) {}
+   gmp_float(const gmp_float &o) : detail::gmp_float_imp<digits10>(o) {}
    template <unsigned D>
-   gmp_float(const gmp_float<D>& o, typename enable_if_c<D <= digits10>::type* = 0);
+   gmp_float(const gmp_float<D> &o, typename enable_if_c<D <= digits10>::type * = 0);
    template <unsigned D>
-   explicit gmp_float(const gmp_float<D>& o, typename disable_if_c<D <= digits10>::type* = 0);
-   gmp_float(const gmp_int& o);
-   gmp_float(const gmp_rational& o);
+   explicit gmp_float(const gmp_float<D> &o, typename disable_if_c<D <= digits10>::type * = 0);
+   gmp_float(const gmp_int &o);
+   gmp_float(const gmp_rational &o);
    gmp_float(const mpf_t val)
    {
       mpf_init2(this->m_data, multiprecision::detail::digits10_2_2(digits10));
@@ -458,49 +464,50 @@ struct gmp_float : public detail::gmp_float_imp<digits10>
       mpf_set_q(this->m_data, val);
    }
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
-   gmp_float(gmp_float&& o) BOOST_NOEXCEPT : detail::gmp_float_imp<digits10>(static_cast<detail::gmp_float_imp<digits10>&&>(o)) {}
+   gmp_float(gmp_float &&o) BOOST_NOEXCEPT : detail::gmp_float_imp<digits10>(static_cast<detail::gmp_float_imp<digits10> &&>(o))
+   {}
 #endif
-   gmp_float& operator=(const gmp_float& o)
+   gmp_float &operator=(const gmp_float &o)
    {
-      *static_cast<detail::gmp_float_imp<digits10>*>(this) = static_cast<detail::gmp_float_imp<digits10> const&>(o);
+      *static_cast<detail::gmp_float_imp<digits10> *>(this) = static_cast<detail::gmp_float_imp<digits10> const &>(o);
       return *this;
    }
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
-   gmp_float& operator=(gmp_float&& o) BOOST_NOEXCEPT
+   gmp_float &operator=(gmp_float &&o) BOOST_NOEXCEPT
    {
-      *static_cast<detail::gmp_float_imp<digits10>*>(this) = static_cast<detail::gmp_float_imp<digits10>&&>(o);
+      *static_cast<detail::gmp_float_imp<digits10> *>(this) = static_cast<detail::gmp_float_imp<digits10> &&>(o);
       return *this;
    }
 #endif
    template <unsigned D>
-   gmp_float& operator=(const gmp_float<D>& o);
-   gmp_float& operator=(const gmp_int& o);
-   gmp_float& operator=(const gmp_rational& o);
-   gmp_float& operator=(const mpf_t val)
+   gmp_float &operator=(const gmp_float<D> &o);
+   gmp_float &operator=(const gmp_int &o);
+   gmp_float &operator=(const gmp_rational &o);
+   gmp_float &operator=(const mpf_t val)
    {
-      if(this->m_data[0]._mp_d == 0)
+      if (this->m_data[0]._mp_d == 0)
          mpf_init2(this->m_data, multiprecision::detail::digits10_2_2(digits10));
       mpf_set(this->m_data, val);
       return *this;
    }
-   gmp_float& operator=(const mpz_t val)
+   gmp_float &operator=(const mpz_t val)
    {
-      if(this->m_data[0]._mp_d == 0)
+      if (this->m_data[0]._mp_d == 0)
          mpf_init2(this->m_data, multiprecision::detail::digits10_2_2(digits10));
       mpf_set_z(this->m_data, val);
       return *this;
    }
-   gmp_float& operator=(const mpq_t val)
+   gmp_float &operator=(const mpq_t val)
    {
-      if(this->m_data[0]._mp_d == 0)
+      if (this->m_data[0]._mp_d == 0)
          mpf_init2(this->m_data, multiprecision::detail::digits10_2_2(digits10));
       mpf_set_q(this->m_data, val);
       return *this;
    }
    template <class V>
-   gmp_float& operator=(const V& v)
+   gmp_float &operator=(const V &v)
    {
-      *static_cast<detail::gmp_float_imp<digits10>*>(this) = v;
+      *static_cast<detail::gmp_float_imp<digits10> *>(this) = v;
       return *this;
    }
 };
@@ -527,25 +534,26 @@ struct gmp_float<0> : public detail::gmp_float_imp<0>
       mpf_init2(this->m_data, multiprecision::detail::digits10_2_2(get_default_precision()));
       mpf_set_q(this->m_data, val);
    }
-   gmp_float(const gmp_float& o) : detail::gmp_float_imp<0>(o) {}
+   gmp_float(const gmp_float &o) : detail::gmp_float_imp<0>(o) {}
    template <unsigned D>
-   gmp_float(const gmp_float<D>& o)
+   gmp_float(const gmp_float<D> &o)
    {
       mpf_init2(this->m_data, mpf_get_prec(o.data()));
       mpf_set(this->m_data, o.data());
    }
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
-   gmp_float(gmp_float&& o) BOOST_NOEXCEPT : detail::gmp_float_imp<0>(static_cast<detail::gmp_float_imp<0>&&>(o)) {}
+   gmp_float(gmp_float &&o) BOOST_NOEXCEPT : detail::gmp_float_imp<0>(static_cast<detail::gmp_float_imp<0> &&>(o))
+   {}
 #endif
-   gmp_float(const gmp_int& o);
-   gmp_float(const gmp_rational& o);
-   gmp_float(const gmp_float& o, unsigned digits10)
+   gmp_float(const gmp_int &o);
+   gmp_float(const gmp_rational &o);
+   gmp_float(const gmp_float &o, unsigned digits10)
    {
       mpf_init2(this->m_data, multiprecision::detail::digits10_2_2(digits10));
       mpf_set(this->m_data, o.data());
    }
    template <class V>
-   gmp_float(const V& o, unsigned digits10)
+   gmp_float(const V &o, unsigned digits10)
    {
       mpf_init2(this->m_data, multiprecision::detail::digits10_2_2(digits10));
       *this = o;
@@ -556,29 +564,29 @@ struct gmp_float<0> : public detail::gmp_float_imp<0>
    // Support for new types in C++17
    //
    template <class Traits>
-   gmp_float(const std::basic_string_view<char, Traits>& o, unsigned digits10)
+   gmp_float(const std::basic_string_view<char, Traits> &o, unsigned digits10)
    {
-      using default_ops::assign_from_string_view; 
+      using default_ops::assign_from_string_view;
       mpf_init2(this->m_data, multiprecision::detail::digits10_2_2(digits10));
       assign_from_string_view(*this, o);
    }
 #endif
-   gmp_float& operator=(const gmp_float& o)
+   gmp_float &operator=(const gmp_float &o)
    {
-      *static_cast<detail::gmp_float_imp<0>*>(this) = static_cast<detail::gmp_float_imp<0> const&>(o);
+      *static_cast<detail::gmp_float_imp<0> *>(this) = static_cast<detail::gmp_float_imp<0> const &>(o);
       return *this;
    }
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
-   gmp_float& operator=(gmp_float&& o) BOOST_NOEXCEPT
+   gmp_float &operator=(gmp_float &&o) BOOST_NOEXCEPT
    {
-      *static_cast<detail::gmp_float_imp<0>*>(this) = static_cast<detail::gmp_float_imp<0> &&>(o);
+      *static_cast<detail::gmp_float_imp<0> *>(this) = static_cast<detail::gmp_float_imp<0> &&>(o);
       return *this;
    }
 #endif
    template <unsigned D>
-   gmp_float& operator=(const gmp_float<D>& o)
+   gmp_float &operator=(const gmp_float<D> &o)
    {
-      if(this->m_data[0]._mp_d == 0)
+      if (this->m_data[0]._mp_d == 0)
       {
          mpf_init2(this->m_data, mpf_get_prec(o.data()));
       }
@@ -589,33 +597,33 @@ struct gmp_float<0> : public detail::gmp_float_imp<0>
       mpf_set(this->m_data, o.data());
       return *this;
    }
-   gmp_float& operator=(const gmp_int& o);
-   gmp_float& operator=(const gmp_rational& o);
-   gmp_float& operator=(const mpf_t val)
+   gmp_float &operator=(const gmp_int &o);
+   gmp_float &operator=(const gmp_rational &o);
+   gmp_float &operator=(const mpf_t val)
    {
-      if(this->m_data[0]._mp_d == 0)
+      if (this->m_data[0]._mp_d == 0)
          mpf_init2(this->m_data, multiprecision::detail::digits10_2_2(get_default_precision()));
       mpf_set(this->m_data, val);
       return *this;
    }
-   gmp_float& operator=(const mpz_t val)
+   gmp_float &operator=(const mpz_t val)
    {
-      if(this->m_data[0]._mp_d == 0)
+      if (this->m_data[0]._mp_d == 0)
          mpf_init2(this->m_data, multiprecision::detail::digits10_2_2(get_default_precision()));
       mpf_set_z(this->m_data, val);
       return *this;
    }
-   gmp_float& operator=(const mpq_t val)
+   gmp_float &operator=(const mpq_t val)
    {
-      if(this->m_data[0]._mp_d == 0)
+      if (this->m_data[0]._mp_d == 0)
          mpf_init2(this->m_data, multiprecision::detail::digits10_2_2(get_default_precision()));
       mpf_set_q(this->m_data, val);
       return *this;
    }
    template <class V>
-   gmp_float& operator=(const V& v)
+   gmp_float &operator=(const V &v)
    {
-      *static_cast<detail::gmp_float_imp<0>*>(this) = v;
+      *static_cast<detail::gmp_float_imp<0> *>(this) = v;
       return *this;
    }
    static unsigned default_precision() BOOST_NOEXCEPT
@@ -626,7 +634,7 @@ struct gmp_float<0> : public detail::gmp_float_imp<0>
    {
       get_default_precision() = v;
    }
-   unsigned precision()const BOOST_NOEXCEPT
+   unsigned precision() const BOOST_NOEXCEPT
    {
       return static_cast<unsigned>(multiprecision::detail::digits2_2_10(static_cast<unsigned long>(mpf_get_prec(this->m_data))));
    }
@@ -637,132 +645,132 @@ struct gmp_float<0> : public detail::gmp_float_imp<0>
 };
 
 template <unsigned digits10, class T>
-inline typename enable_if_c<is_arithmetic<T>::value, bool>::type eval_eq(const gmp_float<digits10>& a, const T& b) BOOST_NOEXCEPT
+inline typename enable_if_c<is_arithmetic<T>::value, bool>::type eval_eq(const gmp_float<digits10> &a, const T &b) BOOST_NOEXCEPT
 {
    return a.compare(b) == 0;
 }
 template <unsigned digits10, class T>
-inline typename enable_if_c<is_arithmetic<T>::value, bool>::type eval_lt(const gmp_float<digits10>& a, const T& b) BOOST_NOEXCEPT
+inline typename enable_if_c<is_arithmetic<T>::value, bool>::type eval_lt(const gmp_float<digits10> &a, const T &b) BOOST_NOEXCEPT
 {
    return a.compare(b) < 0;
 }
 template <unsigned digits10, class T>
-inline typename enable_if_c<is_arithmetic<T>::value, bool>::type eval_gt(const gmp_float<digits10>& a, const T& b) BOOST_NOEXCEPT
+inline typename enable_if_c<is_arithmetic<T>::value, bool>::type eval_gt(const gmp_float<digits10> &a, const T &b) BOOST_NOEXCEPT
 {
    return a.compare(b) > 0;
 }
 
 template <unsigned D1, unsigned D2>
-inline void eval_add(gmp_float<D1>& result, const gmp_float<D2>& o)
+inline void eval_add(gmp_float<D1> &result, const gmp_float<D2> &o)
 {
    mpf_add(result.data(), result.data(), o.data());
 }
 template <unsigned D1, unsigned D2>
-inline void eval_subtract(gmp_float<D1>& result, const gmp_float<D2>& o)
+inline void eval_subtract(gmp_float<D1> &result, const gmp_float<D2> &o)
 {
    mpf_sub(result.data(), result.data(), o.data());
 }
 template <unsigned D1, unsigned D2>
-inline void eval_multiply(gmp_float<D1>& result, const gmp_float<D2>& o)
+inline void eval_multiply(gmp_float<D1> &result, const gmp_float<D2> &o)
 {
    mpf_mul(result.data(), result.data(), o.data());
 }
 template <unsigned digits10>
-inline bool eval_is_zero(const gmp_float<digits10>& val) BOOST_NOEXCEPT
+inline bool eval_is_zero(const gmp_float<digits10> &val) BOOST_NOEXCEPT
 {
    return mpf_sgn(val.data()) == 0;
 }
 template <unsigned D1, unsigned D2>
-inline void eval_divide(gmp_float<D1>& result, const gmp_float<D2>& o)
+inline void eval_divide(gmp_float<D1> &result, const gmp_float<D2> &o)
 {
-   if(eval_is_zero(o))
+   if (eval_is_zero(o))
       BOOST_THROW_EXCEPTION(std::overflow_error("Division by zero."));
    mpf_div(result.data(), result.data(), o.data());
 }
 template <unsigned digits10>
-inline void eval_add(gmp_float<digits10>& result, unsigned long i)
+inline void eval_add(gmp_float<digits10> &result, unsigned long i)
 {
    mpf_add_ui(result.data(), result.data(), i);
 }
 template <unsigned digits10>
-inline void eval_subtract(gmp_float<digits10>& result, unsigned long i)
+inline void eval_subtract(gmp_float<digits10> &result, unsigned long i)
 {
    mpf_sub_ui(result.data(), result.data(), i);
 }
 template <unsigned digits10>
-inline void eval_multiply(gmp_float<digits10>& result, unsigned long i)
+inline void eval_multiply(gmp_float<digits10> &result, unsigned long i)
 {
    mpf_mul_ui(result.data(), result.data(), i);
 }
 template <unsigned digits10>
-inline void eval_divide(gmp_float<digits10>& result, unsigned long i)
+inline void eval_divide(gmp_float<digits10> &result, unsigned long i)
 {
-   if(i == 0)
+   if (i == 0)
       BOOST_THROW_EXCEPTION(std::overflow_error("Division by zero."));
    mpf_div_ui(result.data(), result.data(), i);
 }
 template <unsigned digits10>
-inline void eval_add(gmp_float<digits10>& result, long i)
+inline void eval_add(gmp_float<digits10> &result, long i)
 {
-   if(i > 0)
+   if (i > 0)
       mpf_add_ui(result.data(), result.data(), i);
    else
       mpf_sub_ui(result.data(), result.data(), boost::multiprecision::detail::unsigned_abs(i));
 }
 template <unsigned digits10>
-inline void eval_subtract(gmp_float<digits10>& result, long i)
+inline void eval_subtract(gmp_float<digits10> &result, long i)
 {
-   if(i > 0)
+   if (i > 0)
       mpf_sub_ui(result.data(), result.data(), i);
    else
       mpf_add_ui(result.data(), result.data(), boost::multiprecision::detail::unsigned_abs(i));
 }
 template <unsigned digits10>
-inline void eval_multiply(gmp_float<digits10>& result, long i)
+inline void eval_multiply(gmp_float<digits10> &result, long i)
 {
    mpf_mul_ui(result.data(), result.data(), boost::multiprecision::detail::unsigned_abs(i));
-   if(i < 0)
+   if (i < 0)
       mpf_neg(result.data(), result.data());
 }
 template <unsigned digits10>
-inline void eval_divide(gmp_float<digits10>& result, long i)
+inline void eval_divide(gmp_float<digits10> &result, long i)
 {
-   if(i == 0)
+   if (i == 0)
       BOOST_THROW_EXCEPTION(std::overflow_error("Division by zero."));
    mpf_div_ui(result.data(), result.data(), boost::multiprecision::detail::unsigned_abs(i));
-   if(i < 0)
+   if (i < 0)
       mpf_neg(result.data(), result.data());
 }
 //
 // Specialised 3 arg versions of the basic operators:
 //
 template <unsigned D1, unsigned D2, unsigned D3>
-inline void eval_add(gmp_float<D1>& a, const gmp_float<D2>& x, const gmp_float<D3>& y)
+inline void eval_add(gmp_float<D1> &a, const gmp_float<D2> &x, const gmp_float<D3> &y)
 {
    mpf_add(a.data(), x.data(), y.data());
 }
 template <unsigned D1, unsigned D2>
-inline void eval_add(gmp_float<D1>& a, const gmp_float<D2>& x, unsigned long y)
+inline void eval_add(gmp_float<D1> &a, const gmp_float<D2> &x, unsigned long y)
 {
    mpf_add_ui(a.data(), x.data(), y);
 }
 template <unsigned D1, unsigned D2>
-inline void eval_add(gmp_float<D1>& a, const gmp_float<D2>& x, long y)
+inline void eval_add(gmp_float<D1> &a, const gmp_float<D2> &x, long y)
 {
-   if(y < 0)
+   if (y < 0)
       mpf_sub_ui(a.data(), x.data(), boost::multiprecision::detail::unsigned_abs(y));
    else
       mpf_add_ui(a.data(), x.data(), y);
 }
 template <unsigned D1, unsigned D2>
-inline void eval_add(gmp_float<D1>& a, unsigned long x, const gmp_float<D2>& y)
+inline void eval_add(gmp_float<D1> &a, unsigned long x, const gmp_float<D2> &y)
 {
    mpf_add_ui(a.data(), y.data(), x);
 }
 template <unsigned D1, unsigned D2>
-inline void eval_add(gmp_float<D1>& a, long x, const gmp_float<D2>& y)
+inline void eval_add(gmp_float<D1> &a, long x, const gmp_float<D2> &y)
 {
-   if(x < 0)
+   if (x < 0)
    {
       mpf_ui_sub(a.data(), boost::multiprecision::detail::unsigned_abs(x), y.data());
       mpf_neg(a.data(), a.data());
@@ -771,32 +779,32 @@ inline void eval_add(gmp_float<D1>& a, long x, const gmp_float<D2>& y)
       mpf_add_ui(a.data(), y.data(), x);
 }
 template <unsigned D1, unsigned D2, unsigned D3>
-inline void eval_subtract(gmp_float<D1>& a, const gmp_float<D2>& x, const gmp_float<D3>& y)
+inline void eval_subtract(gmp_float<D1> &a, const gmp_float<D2> &x, const gmp_float<D3> &y)
 {
    mpf_sub(a.data(), x.data(), y.data());
 }
 template <unsigned D1, unsigned D2>
-inline void eval_subtract(gmp_float<D1>& a, const gmp_float<D2>& x, unsigned long y)
+inline void eval_subtract(gmp_float<D1> &a, const gmp_float<D2> &x, unsigned long y)
 {
    mpf_sub_ui(a.data(), x.data(), y);
 }
 template <unsigned D1, unsigned D2>
-inline void eval_subtract(gmp_float<D1>& a, const gmp_float<D2>& x, long y)
+inline void eval_subtract(gmp_float<D1> &a, const gmp_float<D2> &x, long y)
 {
-   if(y < 0)
+   if (y < 0)
       mpf_add_ui(a.data(), x.data(), boost::multiprecision::detail::unsigned_abs(y));
    else
       mpf_sub_ui(a.data(), x.data(), y);
 }
 template <unsigned D1, unsigned D2>
-inline void eval_subtract(gmp_float<D1>& a, unsigned long x, const gmp_float<D2>& y)
+inline void eval_subtract(gmp_float<D1> &a, unsigned long x, const gmp_float<D2> &y)
 {
    mpf_ui_sub(a.data(), x, y.data());
 }
 template <unsigned D1, unsigned D2>
-inline void eval_subtract(gmp_float<D1>& a, long x, const gmp_float<D2>& y)
+inline void eval_subtract(gmp_float<D1> &a, long x, const gmp_float<D2> &y)
 {
-   if(x < 0)
+   if (x < 0)
    {
       mpf_add_ui(a.data(), y.data(), boost::multiprecision::detail::unsigned_abs(x));
       mpf_neg(a.data(), a.data());
@@ -806,19 +814,19 @@ inline void eval_subtract(gmp_float<D1>& a, long x, const gmp_float<D2>& y)
 }
 
 template <unsigned D1, unsigned D2, unsigned D3>
-inline void eval_multiply(gmp_float<D1>& a, const gmp_float<D2>& x, const gmp_float<D3>& y)
+inline void eval_multiply(gmp_float<D1> &a, const gmp_float<D2> &x, const gmp_float<D3> &y)
 {
    mpf_mul(a.data(), x.data(), y.data());
 }
 template <unsigned D1, unsigned D2>
-inline void eval_multiply(gmp_float<D1>& a, const gmp_float<D2>& x, unsigned long y)
+inline void eval_multiply(gmp_float<D1> &a, const gmp_float<D2> &x, unsigned long y)
 {
    mpf_mul_ui(a.data(), x.data(), y);
 }
 template <unsigned D1, unsigned D2>
-inline void eval_multiply(gmp_float<D1>& a, const gmp_float<D2>& x, long y)
+inline void eval_multiply(gmp_float<D1> &a, const gmp_float<D2> &x, long y)
 {
-   if(y < 0)
+   if (y < 0)
    {
       mpf_mul_ui(a.data(), x.data(), boost::multiprecision::detail::unsigned_abs(y));
       a.negate();
@@ -827,14 +835,14 @@ inline void eval_multiply(gmp_float<D1>& a, const gmp_float<D2>& x, long y)
       mpf_mul_ui(a.data(), x.data(), y);
 }
 template <unsigned D1, unsigned D2>
-inline void eval_multiply(gmp_float<D1>& a, unsigned long x, const gmp_float<D2>& y)
+inline void eval_multiply(gmp_float<D1> &a, unsigned long x, const gmp_float<D2> &y)
 {
    mpf_mul_ui(a.data(), y.data(), x);
 }
 template <unsigned D1, unsigned D2>
-inline void eval_multiply(gmp_float<D1>& a, long x, const gmp_float<D2>& y)
+inline void eval_multiply(gmp_float<D1> &a, long x, const gmp_float<D2> &y)
 {
-   if(x < 0)
+   if (x < 0)
    {
       mpf_mul_ui(a.data(), y.data(), boost::multiprecision::detail::unsigned_abs(x));
       mpf_neg(a.data(), a.data());
@@ -844,25 +852,25 @@ inline void eval_multiply(gmp_float<D1>& a, long x, const gmp_float<D2>& y)
 }
 
 template <unsigned D1, unsigned D2, unsigned D3>
-inline void eval_divide(gmp_float<D1>& a, const gmp_float<D2>& x, const gmp_float<D3>& y)
+inline void eval_divide(gmp_float<D1> &a, const gmp_float<D2> &x, const gmp_float<D3> &y)
 {
-   if(eval_is_zero(y))
+   if (eval_is_zero(y))
       BOOST_THROW_EXCEPTION(std::overflow_error("Division by zero."));
    mpf_div(a.data(), x.data(), y.data());
 }
 template <unsigned D1, unsigned D2>
-inline void eval_divide(gmp_float<D1>& a, const gmp_float<D2>& x, unsigned long y)
+inline void eval_divide(gmp_float<D1> &a, const gmp_float<D2> &x, unsigned long y)
 {
-   if(y == 0)
+   if (y == 0)
       BOOST_THROW_EXCEPTION(std::overflow_error("Division by zero."));
    mpf_div_ui(a.data(), x.data(), y);
 }
 template <unsigned D1, unsigned D2>
-inline void eval_divide(gmp_float<D1>& a, const gmp_float<D2>& x, long y)
+inline void eval_divide(gmp_float<D1> &a, const gmp_float<D2> &x, long y)
 {
-   if(y == 0)
+   if (y == 0)
       BOOST_THROW_EXCEPTION(std::overflow_error("Division by zero."));
-   if(y < 0)
+   if (y < 0)
    {
       mpf_div_ui(a.data(), x.data(), boost::multiprecision::detail::unsigned_abs(y));
       a.negate();
@@ -871,18 +879,18 @@ inline void eval_divide(gmp_float<D1>& a, const gmp_float<D2>& x, long y)
       mpf_div_ui(a.data(), x.data(), y);
 }
 template <unsigned D1, unsigned D2>
-inline void eval_divide(gmp_float<D1>& a, unsigned long x, const gmp_float<D2>& y)
+inline void eval_divide(gmp_float<D1> &a, unsigned long x, const gmp_float<D2> &y)
 {
-   if(eval_is_zero(y))
+   if (eval_is_zero(y))
       BOOST_THROW_EXCEPTION(std::overflow_error("Division by zero."));
    mpf_ui_div(a.data(), x, y.data());
 }
 template <unsigned D1, unsigned D2>
-inline void eval_divide(gmp_float<D1>& a, long x, const gmp_float<D2>& y)
+inline void eval_divide(gmp_float<D1> &a, long x, const gmp_float<D2> &y)
 {
-   if(eval_is_zero(y))
+   if (eval_is_zero(y))
       BOOST_THROW_EXCEPTION(std::overflow_error("Division by zero."));
-   if(x < 0)
+   if (x < 0)
    {
       mpf_ui_div(a.data(), boost::multiprecision::detail::unsigned_abs(x), y.data());
       mpf_neg(a.data(), a.data());
@@ -892,23 +900,23 @@ inline void eval_divide(gmp_float<D1>& a, long x, const gmp_float<D2>& y)
 }
 
 template <unsigned digits10>
-inline int eval_get_sign(const gmp_float<digits10>& val) BOOST_NOEXCEPT
+inline int eval_get_sign(const gmp_float<digits10> &val) BOOST_NOEXCEPT
 {
    return mpf_sgn(val.data());
 }
 
 template <unsigned digits10>
-inline void eval_convert_to(unsigned long* result, const gmp_float<digits10>& val) BOOST_NOEXCEPT
+inline void eval_convert_to(unsigned long *result, const gmp_float<digits10> &val) BOOST_NOEXCEPT
 {
-   if(0 == mpf_fits_ulong_p(val.data()))
+   if (0 == mpf_fits_ulong_p(val.data()))
       *result = (std::numeric_limits<unsigned long>::max)();
    else
       *result = (unsigned long)mpf_get_ui(val.data());
 }
 template <unsigned digits10>
-inline void eval_convert_to(long* result, const gmp_float<digits10>& val) BOOST_NOEXCEPT
+inline void eval_convert_to(long *result, const gmp_float<digits10> &val) BOOST_NOEXCEPT
 {
-   if(0 == mpf_fits_slong_p(val.data()))
+   if (0 == mpf_fits_slong_p(val.data()))
    {
       *result = (std::numeric_limits<long>::max)();
       *result *= mpf_sgn(val.data());
@@ -917,26 +925,26 @@ inline void eval_convert_to(long* result, const gmp_float<digits10>& val) BOOST_
       *result = (long)mpf_get_si(val.data());
 }
 template <unsigned digits10>
-inline void eval_convert_to(double* result, const gmp_float<digits10>& val) BOOST_NOEXCEPT
+inline void eval_convert_to(double *result, const gmp_float<digits10> &val) BOOST_NOEXCEPT
 {
    *result = mpf_get_d(val.data());
 }
 #ifdef BOOST_HAS_LONG_LONG
 template <unsigned digits10>
-inline void eval_convert_to(boost::long_long_type* result, const gmp_float<digits10>& val)
+inline void eval_convert_to(boost::long_long_type *result, const gmp_float<digits10> &val)
 {
    gmp_float<digits10> t(val);
-   if(eval_get_sign(t) < 0)
+   if (eval_get_sign(t) < 0)
       t.negate();
 
    long digits = std::numeric_limits<boost::long_long_type>::digits - std::numeric_limits<long>::digits;
 
-   if(digits > 0)
+   if (digits > 0)
       mpf_div_2exp(t.data(), t.data(), digits);
 
-   if(!mpf_fits_slong_p(t.data()))
+   if (!mpf_fits_slong_p(t.data()))
    {
-      if(eval_get_sign(val) < 0)
+      if (eval_get_sign(val) < 0)
          *result = (std::numeric_limits<boost::long_long_type>::min)();
       else
          *result = (std::numeric_limits<boost::long_long_type>::max)();
@@ -944,43 +952,43 @@ inline void eval_convert_to(boost::long_long_type* result, const gmp_float<digit
    };
 
    *result = mpf_get_si(t.data());
-   while(digits > 0)
+   while (digits > 0)
    {
       *result <<= digits;
       digits -= std::numeric_limits<unsigned long>::digits;
       mpf_mul_2exp(t.data(), t.data(), digits >= 0 ? std::numeric_limits<unsigned long>::digits : std::numeric_limits<unsigned long>::digits + digits);
       unsigned long l = (unsigned long)mpf_get_ui(t.data());
-      if(digits < 0)
+      if (digits < 0)
          l >>= -digits;
       *result |= l;
    }
-   if(eval_get_sign(val) < 0)
+   if (eval_get_sign(val) < 0)
       *result = -*result;
 }
 template <unsigned digits10>
-inline void eval_convert_to(boost::ulong_long_type* result, const gmp_float<digits10>& val)
+inline void eval_convert_to(boost::ulong_long_type *result, const gmp_float<digits10> &val)
 {
    gmp_float<digits10> t(val);
 
    long digits = std::numeric_limits<boost::long_long_type>::digits - std::numeric_limits<long>::digits;
 
-   if(digits > 0)
+   if (digits > 0)
       mpf_div_2exp(t.data(), t.data(), digits);
 
-   if(!mpf_fits_ulong_p(t.data()))
+   if (!mpf_fits_ulong_p(t.data()))
    {
       *result = (std::numeric_limits<boost::long_long_type>::max)();
       return;
    }
 
    *result = mpf_get_ui(t.data());
-   while(digits > 0)
+   while (digits > 0)
    {
       *result <<= digits;
       digits -= std::numeric_limits<unsigned long>::digits;
       mpf_mul_2exp(t.data(), t.data(), digits >= 0 ? std::numeric_limits<unsigned long>::digits : std::numeric_limits<unsigned long>::digits + digits);
       unsigned long l = (unsigned long)mpf_get_ui(t.data());
-      if(digits < 0)
+      if (digits < 0)
          l >>= -digits;
       *result |= l;
    }
@@ -991,62 +999,62 @@ inline void eval_convert_to(boost::ulong_long_type* result, const gmp_float<digi
 // Native non-member operations:
 //
 template <unsigned Digits10>
-inline void eval_sqrt(gmp_float<Digits10>& result, const gmp_float<Digits10>& val)
+inline void eval_sqrt(gmp_float<Digits10> &result, const gmp_float<Digits10> &val)
 {
    mpf_sqrt(result.data(), val.data());
 }
 
 template <unsigned Digits10>
-inline void eval_abs(gmp_float<Digits10>& result, const gmp_float<Digits10>& val)
+inline void eval_abs(gmp_float<Digits10> &result, const gmp_float<Digits10> &val)
 {
    mpf_abs(result.data(), val.data());
 }
 
 template <unsigned Digits10>
-inline void eval_fabs(gmp_float<Digits10>& result, const gmp_float<Digits10>& val)
+inline void eval_fabs(gmp_float<Digits10> &result, const gmp_float<Digits10> &val)
 {
    mpf_abs(result.data(), val.data());
 }
 template <unsigned Digits10>
-inline void eval_ceil(gmp_float<Digits10>& result, const gmp_float<Digits10>& val)
+inline void eval_ceil(gmp_float<Digits10> &result, const gmp_float<Digits10> &val)
 {
    mpf_ceil(result.data(), val.data());
 }
 template <unsigned Digits10>
-inline void eval_floor(gmp_float<Digits10>& result, const gmp_float<Digits10>& val)
+inline void eval_floor(gmp_float<Digits10> &result, const gmp_float<Digits10> &val)
 {
    mpf_floor(result.data(), val.data());
 }
 template <unsigned Digits10>
-inline void eval_trunc(gmp_float<Digits10>& result, const gmp_float<Digits10>& val)
+inline void eval_trunc(gmp_float<Digits10> &result, const gmp_float<Digits10> &val)
 {
    mpf_trunc(result.data(), val.data());
 }
 template <unsigned Digits10>
-inline void eval_ldexp(gmp_float<Digits10>& result, const gmp_float<Digits10>& val, long e)
+inline void eval_ldexp(gmp_float<Digits10> &result, const gmp_float<Digits10> &val, long e)
 {
-   if(e > 0)
+   if (e > 0)
       mpf_mul_2exp(result.data(), val.data(), e);
-   else if(e < 0)
+   else if (e < 0)
       mpf_div_2exp(result.data(), val.data(), -e);
    else
       result = val;
 }
 template <unsigned Digits10>
-inline void eval_frexp(gmp_float<Digits10>& result, const gmp_float<Digits10>& val, int* e)
+inline void eval_frexp(gmp_float<Digits10> &result, const gmp_float<Digits10> &val, int *e)
 {
 #if (BOOST_MP_MPIR_VERSION >= 20600) && (BOOST_MP_MPIR_VERSION < 30000)
    mpir_si v;
    mpf_get_d_2exp(&v, val.data());
 #else
-   long v;
+   long                             v;
    mpf_get_d_2exp(&v, val.data());
 #endif
    *e = v;
    eval_ldexp(result, val, -v);
 }
 template <unsigned Digits10>
-inline void eval_frexp(gmp_float<Digits10>& result, const gmp_float<Digits10>& val, long* e)
+inline void eval_frexp(gmp_float<Digits10> &result, const gmp_float<Digits10> &val, long *e)
 {
 #if (BOOST_MP_MPIR_VERSION >= 20600) && (BOOST_MP_MPIR_VERSION < 30000)
    mpir_si v;
@@ -1060,10 +1068,10 @@ inline void eval_frexp(gmp_float<Digits10>& result, const gmp_float<Digits10>& v
 }
 
 template <unsigned Digits10>
-inline std::size_t hash_value(const gmp_float<Digits10>& val)
+inline std::size_t hash_value(const gmp_float<Digits10> &val)
 {
    std::size_t result = 0;
-   for(int i = 0; i < std::abs(val.data()[0]._mp_size); ++i)
+   for (int i = 0; i < std::abs(val.data()[0]._mp_size); ++i)
       boost::hash_combine(result, val.data()[0]._mp_d[i]);
    boost::hash_combine(result, val.data()[0]._mp_exp);
    boost::hash_combine(result, val.data()[0]._mp_size);
@@ -1073,29 +1081,29 @@ inline std::size_t hash_value(const gmp_float<Digits10>& val)
 struct gmp_int
 {
 #ifdef BOOST_HAS_LONG_LONG
-   typedef mpl::list<long, boost::long_long_type>                     signed_types;
-   typedef mpl::list<unsigned long, boost::ulong_long_type>   unsigned_types;
+   typedef mpl::list<long, boost::long_long_type>           signed_types;
+   typedef mpl::list<unsigned long, boost::ulong_long_type> unsigned_types;
 #else
-   typedef mpl::list<long>                                signed_types;
-   typedef mpl::list<unsigned long>                       unsigned_types;
+   typedef mpl::list<long>          signed_types;
+   typedef mpl::list<unsigned long> unsigned_types;
 #endif
-   typedef mpl::list<double, long double>                 float_types;
+   typedef mpl::list<double, long double> float_types;
 
    gmp_int()
    {
       mpz_init(this->m_data);
    }
-   gmp_int(const gmp_int& o)
+   gmp_int(const gmp_int &o)
    {
-      if(o.m_data[0]._mp_d)
+      if (o.m_data[0]._mp_d)
          mpz_init_set(m_data, o.m_data);
       else
          mpz_init(this->m_data);
    }
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
-   gmp_int(gmp_int&& o) BOOST_NOEXCEPT
+   gmp_int(gmp_int &&o) BOOST_NOEXCEPT
    {
-      m_data[0] = o.m_data[0];
+      m_data[0]         = o.m_data[0];
       o.m_data[0]._mp_d = 0;
    }
 #endif
@@ -1114,21 +1122,21 @@ struct gmp_int
       mpz_set_q(this->m_data, val);
    }
    template <unsigned Digits10>
-   explicit gmp_int(const gmp_float<Digits10>& o)
+   explicit gmp_int(const gmp_float<Digits10> &o)
    {
       mpz_init(this->m_data);
       mpz_set_f(this->m_data, o.data());
    }
-   explicit gmp_int(const gmp_rational& o);
-   gmp_int& operator = (const gmp_int& o)
+   explicit gmp_int(const gmp_rational &o);
+   gmp_int &operator=(const gmp_int &o)
    {
-      if(m_data[0]._mp_d == 0)
+      if (m_data[0]._mp_d == 0)
          mpz_init(this->m_data);
       mpz_set(m_data, o.m_data);
       return *this;
    }
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
-   gmp_int& operator = (gmp_int&& o) BOOST_NOEXCEPT
+   gmp_int &operator=(gmp_int &&o) BOOST_NOEXCEPT
    {
       mpz_swap(m_data, o.m_data);
       return *this;
@@ -1136,25 +1144,25 @@ struct gmp_int
 #endif
 #ifdef BOOST_HAS_LONG_LONG
 #if defined(ULLONG_MAX) && (ULLONG_MAX == ULONG_MAX)
-   gmp_int& operator = (boost::ulong_long_type i)
+   gmp_int &operator=(boost::ulong_long_type i)
    {
       *this = static_cast<unsigned long>(i);
       return *this;
    }
 #else
-   gmp_int& operator = (boost::ulong_long_type i)
+   gmp_int &operator=(boost::ulong_long_type i)
    {
-      if(m_data[0]._mp_d == 0)
+      if (m_data[0]._mp_d == 0)
          mpz_init(this->m_data);
-      boost::ulong_long_type mask = ((((1uLL << (std::numeric_limits<unsigned long>::digits - 1)) - 1) << 1) | 1uLL);
-      unsigned shift = 0;
-      mpz_t t;
+      boost::ulong_long_type mask  = ((((1uLL << (std::numeric_limits<unsigned long>::digits - 1)) - 1) << 1) | 1uLL);
+      unsigned               shift = 0;
+      mpz_t                  t;
       mpz_set_ui(m_data, 0);
       mpz_init_set_ui(t, 0);
-      while(i)
+      while (i)
       {
          mpz_set_ui(t, static_cast<unsigned long>(i & mask));
-         if(shift)
+         if (shift)
             mpz_mul_2exp(t, t, shift);
          mpz_add(m_data, m_data, t);
          shift += std::numeric_limits<unsigned long>::digits;
@@ -1164,53 +1172,55 @@ struct gmp_int
       return *this;
    }
 #endif
-   gmp_int& operator = (boost::long_long_type i)
+   gmp_int &operator=(boost::long_long_type i)
    {
-      if(m_data[0]._mp_d == 0)
+      if (m_data[0]._mp_d == 0)
          mpz_init(this->m_data);
       bool neg = i < 0;
-      *this = boost::multiprecision::detail::unsigned_abs(i);
-      if(neg)
+      *this    = boost::multiprecision::detail::unsigned_abs(i);
+      if (neg)
          mpz_neg(m_data, m_data);
       return *this;
    }
 #endif
-   gmp_int& operator = (unsigned long i)
+   gmp_int &operator=(unsigned long i)
    {
-      if(m_data[0]._mp_d == 0)
+      if (m_data[0]._mp_d == 0)
          mpz_init(this->m_data);
       mpz_set_ui(m_data, i);
       return *this;
    }
-   gmp_int& operator = (long i)
+   gmp_int &operator=(long i)
    {
-      if(m_data[0]._mp_d == 0)
+      if (m_data[0]._mp_d == 0)
          mpz_init(this->m_data);
       mpz_set_si(m_data, i);
       return *this;
    }
-   gmp_int& operator = (double d)
+   gmp_int &operator=(double d)
    {
-      if(m_data[0]._mp_d == 0)
+      if (m_data[0]._mp_d == 0)
          mpz_init(this->m_data);
       mpz_set_d(m_data, d);
       return *this;
    }
-   gmp_int& operator = (long double a)
+   gmp_int &operator=(long double a)
    {
+      using std::floor;
       using std::frexp;
       using std::ldexp;
-      using std::floor;
 
-      if(m_data[0]._mp_d == 0)
+      if (m_data[0]._mp_d == 0)
          mpz_init(this->m_data);
 
-      if (a == 0) {
+      if (a == 0)
+      {
          mpz_set_si(m_data, 0);
          return *this;
       }
 
-      if (a == 1) {
+      if (a == 1)
+      {
          mpz_set_si(m_data, 1);
          return *this;
       }
@@ -1218,7 +1228,7 @@ struct gmp_int
       BOOST_ASSERT(!(boost::math::isinf)(a));
       BOOST_ASSERT(!(boost::math::isnan)(a));
 
-      int e;
+      int         e;
       long double f, term;
       mpz_set_ui(m_data, 0u);
 
@@ -1226,37 +1236,37 @@ struct gmp_int
 
       static const int shift = std::numeric_limits<int>::digits - 1;
 
-      while(f)
+      while (f)
       {
          // extract int sized bits from f:
-         f = ldexp(f, shift);
+         f    = ldexp(f, shift);
          term = floor(f);
          e -= shift;
          mpz_mul_2exp(m_data, m_data, shift);
-         if(term > 0)
+         if (term > 0)
             mpz_add_ui(m_data, m_data, static_cast<unsigned>(term));
          else
             mpz_sub_ui(m_data, m_data, static_cast<unsigned>(-term));
          f -= term;
       }
-      if(e > 0)
+      if (e > 0)
          mpz_mul_2exp(m_data, m_data, e);
-      else if(e < 0)
+      else if (e < 0)
          mpz_div_2exp(m_data, m_data, -e);
       return *this;
    }
-   gmp_int& operator = (const char* s)
+   gmp_int &operator=(const char *s)
    {
-      if(m_data[0]._mp_d == 0)
+      if (m_data[0]._mp_d == 0)
          mpz_init(this->m_data);
-      std::size_t n = s ? std::strlen(s) : 0;
-      int radix = 10;
-      if(n && (*s == '0'))
+      std::size_t n     = s ? std::strlen(s) : 0;
+      int         radix = 10;
+      if (n && (*s == '0'))
       {
-         if((n > 1) && ((s[1] == 'x') || (s[1] == 'X')))
+         if ((n > 1) && ((s[1] == 'x') || (s[1] == 'X')))
          {
             radix = 16;
-            s +=2;
+            s += 2;
             n -= 2;
          }
          else
@@ -1265,87 +1275,87 @@ struct gmp_int
             n -= 1;
          }
       }
-      if(n)
+      if (n)
       {
-         if(0 != mpz_set_str(m_data, s, radix))
+         if (0 != mpz_set_str(m_data, s, radix))
             BOOST_THROW_EXCEPTION(std::runtime_error(std::string("The string \"") + s + std::string("\"could not be interpreted as a valid integer.")));
       }
       else
          mpz_set_ui(m_data, 0);
       return *this;
    }
-   gmp_int& operator=(const mpf_t val)
+   gmp_int &operator=(const mpf_t val)
    {
-      if(m_data[0]._mp_d == 0)
+      if (m_data[0]._mp_d == 0)
          mpz_init(this->m_data);
       mpz_set_f(this->m_data, val);
       return *this;
    }
-   gmp_int& operator=(const mpz_t val)
+   gmp_int &operator=(const mpz_t val)
    {
-      if(m_data[0]._mp_d == 0)
+      if (m_data[0]._mp_d == 0)
          mpz_init(this->m_data);
       mpz_set(this->m_data, val);
       return *this;
    }
-   gmp_int& operator=(const mpq_t val)
+   gmp_int &operator=(const mpq_t val)
    {
-      if(m_data[0]._mp_d == 0)
+      if (m_data[0]._mp_d == 0)
          mpz_init(this->m_data);
       mpz_set_q(this->m_data, val);
       return *this;
    }
    template <unsigned Digits10>
-   gmp_int& operator=(const gmp_float<Digits10>& o)
+   gmp_int &operator=(const gmp_float<Digits10> &o)
    {
-      if(m_data[0]._mp_d == 0)
+      if (m_data[0]._mp_d == 0)
          mpz_init(this->m_data);
       mpz_set_f(this->m_data, o.data());
       return *this;
    }
-   gmp_int& operator=(const gmp_rational& o);
-   void swap(gmp_int& o)
+   gmp_int &operator=(const gmp_rational &o);
+   void     swap(gmp_int &o)
    {
       mpz_swap(m_data, o.m_data);
    }
-   std::string str(std::streamsize /*digits*/, std::ios_base::fmtflags f)const
+   std::string str(std::streamsize /*digits*/, std::ios_base::fmtflags f) const
    {
       BOOST_ASSERT(m_data[0]._mp_d);
 
       int base = 10;
-      if((f & std::ios_base::oct) == std::ios_base::oct)
+      if ((f & std::ios_base::oct) == std::ios_base::oct)
          base = 8;
-      else if((f & std::ios_base::hex) == std::ios_base::hex)
+      else if ((f & std::ios_base::hex) == std::ios_base::hex)
          base = 16;
       //
       // sanity check, bases 8 and 16 are only available for positive numbers:
       //
-      if((base != 10) && (mpz_sgn(m_data) < 0))
+      if ((base != 10) && (mpz_sgn(m_data) < 0))
          BOOST_THROW_EXCEPTION(std::runtime_error("Formatted output in bases 8 or 16 is only available for positive numbers"));
-      void *(*alloc_func_ptr) (size_t);
-      void *(*realloc_func_ptr) (void *, size_t, size_t);
-      void (*free_func_ptr) (void *, size_t);
-      const char* ps = mpz_get_str (0, base, m_data);
-      std::string s = ps;
+      void *(*alloc_func_ptr)(size_t);
+      void *(*realloc_func_ptr)(void *, size_t, size_t);
+      void (*free_func_ptr)(void *, size_t);
+      const char *ps = mpz_get_str(0, base, m_data);
+      std::string s  = ps;
       mp_get_memory_functions(&alloc_func_ptr, &realloc_func_ptr, &free_func_ptr);
-      (*free_func_ptr)((void*)ps, std::strlen(ps) + 1);
+      (*free_func_ptr)((void *)ps, std::strlen(ps) + 1);
       if (f & std::ios_base::uppercase)
-          for (size_t i = 0; i < s.length(); ++i)
-              s[i] = std::toupper(s[i]);
-      if((base != 10) && (f & std::ios_base::showbase))
+         for (size_t i = 0; i < s.length(); ++i)
+            s[i] = std::toupper(s[i]);
+      if ((base != 10) && (f & std::ios_base::showbase))
       {
-         int pos = s[0] == '-' ? 1 : 0;
-         const char* pp = base == 8 ? "0" : (f & std::ios_base::uppercase) ? "0X" : "0x";
+         int         pos = s[0] == '-' ? 1 : 0;
+         const char *pp  = base == 8 ? "0" : (f & std::ios_base::uppercase) ? "0X" : "0x";
          s.insert(static_cast<std::string::size_type>(pos), pp);
       }
-      if((f & std::ios_base::showpos) && (s[0] != '-'))
+      if ((f & std::ios_base::showpos) && (s[0] != '-'))
          s.insert(static_cast<std::string::size_type>(0), 1, '+');
 
       return s;
    }
    ~gmp_int() BOOST_NOEXCEPT
    {
-      if(m_data[0]._mp_d)
+      if (m_data[0]._mp_d)
          mpz_clear(m_data);
    }
    void negate() BOOST_NOEXCEPT
@@ -1353,306 +1363,307 @@ struct gmp_int
       BOOST_ASSERT(m_data[0]._mp_d);
       mpz_neg(m_data, m_data);
    }
-   int compare(const gmp_int& o)const BOOST_NOEXCEPT
+   int compare(const gmp_int &o) const BOOST_NOEXCEPT
    {
       BOOST_ASSERT(m_data[0]._mp_d && o.m_data[0]._mp_d);
       return mpz_cmp(m_data, o.m_data);
    }
-   int compare(long i)const BOOST_NOEXCEPT
+   int compare(long i) const BOOST_NOEXCEPT
    {
       BOOST_ASSERT(m_data[0]._mp_d);
       return mpz_cmp_si(m_data, i);
    }
-   int compare(unsigned long i)const BOOST_NOEXCEPT
+   int compare(unsigned long i) const BOOST_NOEXCEPT
    {
       BOOST_ASSERT(m_data[0]._mp_d);
       return mpz_cmp_ui(m_data, i);
    }
    template <class V>
-   int compare(V v)const
+   int compare(V v) const
    {
       gmp_int d;
       d = v;
       return compare(d);
    }
-   mpz_t& data() BOOST_NOEXCEPT
+   mpz_t &data() BOOST_NOEXCEPT
    {
       BOOST_ASSERT(m_data[0]._mp_d);
       return m_data;
    }
-   const mpz_t& data()const BOOST_NOEXCEPT
+   const mpz_t &data() const BOOST_NOEXCEPT
    {
       BOOST_ASSERT(m_data[0]._mp_d);
       return m_data;
    }
-protected:
+
+ protected:
    mpz_t m_data;
 };
 
 template <class T>
-inline typename enable_if<is_arithmetic<T>, bool>::type eval_eq(const gmp_int& a, const T& b)
+inline typename enable_if<is_arithmetic<T>, bool>::type eval_eq(const gmp_int &a, const T &b)
 {
    return a.compare(b) == 0;
 }
 template <class T>
-inline typename enable_if<is_arithmetic<T>, bool>::type eval_lt(const gmp_int& a, const T& b)
+inline typename enable_if<is_arithmetic<T>, bool>::type eval_lt(const gmp_int &a, const T &b)
 {
    return a.compare(b) < 0;
 }
 template <class T>
-inline typename enable_if<is_arithmetic<T>, bool>::type eval_gt(const gmp_int& a, const T& b)
+inline typename enable_if<is_arithmetic<T>, bool>::type eval_gt(const gmp_int &a, const T &b)
 {
    return a.compare(b) > 0;
 }
 
-inline bool eval_is_zero(const gmp_int& val)
+inline bool eval_is_zero(const gmp_int &val)
 {
    return mpz_sgn(val.data()) == 0;
 }
-inline void eval_add(gmp_int& t, const gmp_int& o)
+inline void eval_add(gmp_int &t, const gmp_int &o)
 {
    mpz_add(t.data(), t.data(), o.data());
 }
-inline void eval_multiply_add(gmp_int& t, const gmp_int& a, const gmp_int& b)
+inline void eval_multiply_add(gmp_int &t, const gmp_int &a, const gmp_int &b)
 {
    mpz_addmul(t.data(), a.data(), b.data());
 }
-inline void eval_multiply_subtract(gmp_int& t, const gmp_int& a, const gmp_int& b)
+inline void eval_multiply_subtract(gmp_int &t, const gmp_int &a, const gmp_int &b)
 {
    mpz_submul(t.data(), a.data(), b.data());
 }
-inline void eval_subtract(gmp_int& t, const gmp_int& o)
+inline void eval_subtract(gmp_int &t, const gmp_int &o)
 {
    mpz_sub(t.data(), t.data(), o.data());
 }
-inline void eval_multiply(gmp_int& t, const gmp_int& o)
+inline void eval_multiply(gmp_int &t, const gmp_int &o)
 {
    mpz_mul(t.data(), t.data(), o.data());
 }
-inline void eval_divide(gmp_int& t, const gmp_int& o)
+inline void eval_divide(gmp_int &t, const gmp_int &o)
 {
-   if(eval_is_zero(o))
+   if (eval_is_zero(o))
       BOOST_THROW_EXCEPTION(std::overflow_error("Division by zero."));
    mpz_tdiv_q(t.data(), t.data(), o.data());
 }
-inline void eval_modulus(gmp_int& t, const gmp_int& o)
+inline void eval_modulus(gmp_int &t, const gmp_int &o)
 {
    mpz_tdiv_r(t.data(), t.data(), o.data());
 }
-inline void eval_add(gmp_int& t, unsigned long i)
+inline void eval_add(gmp_int &t, unsigned long i)
 {
    mpz_add_ui(t.data(), t.data(), i);
 }
-inline void eval_multiply_add(gmp_int& t, const gmp_int& a, unsigned long i)
+inline void eval_multiply_add(gmp_int &t, const gmp_int &a, unsigned long i)
 {
    mpz_addmul_ui(t.data(), a.data(), i);
 }
-inline void eval_multiply_subtract(gmp_int& t, const gmp_int& a, unsigned long i)
+inline void eval_multiply_subtract(gmp_int &t, const gmp_int &a, unsigned long i)
 {
    mpz_submul_ui(t.data(), a.data(), i);
 }
-inline void eval_subtract(gmp_int& t, unsigned long i)
+inline void eval_subtract(gmp_int &t, unsigned long i)
 {
    mpz_sub_ui(t.data(), t.data(), i);
 }
-inline void eval_multiply(gmp_int& t, unsigned long i)
+inline void eval_multiply(gmp_int &t, unsigned long i)
 {
    mpz_mul_ui(t.data(), t.data(), i);
 }
-inline void eval_modulus(gmp_int& t, unsigned long i)
+inline void eval_modulus(gmp_int &t, unsigned long i)
 {
    mpz_tdiv_r_ui(t.data(), t.data(), i);
 }
-inline void eval_divide(gmp_int& t, unsigned long i)
+inline void eval_divide(gmp_int &t, unsigned long i)
 {
-   if(i == 0)
+   if (i == 0)
       BOOST_THROW_EXCEPTION(std::overflow_error("Division by zero."));
    mpz_tdiv_q_ui(t.data(), t.data(), i);
 }
-inline void eval_add(gmp_int& t, long i)
+inline void eval_add(gmp_int &t, long i)
 {
-   if(i > 0)
+   if (i > 0)
       mpz_add_ui(t.data(), t.data(), i);
    else
       mpz_sub_ui(t.data(), t.data(), boost::multiprecision::detail::unsigned_abs(i));
 }
-inline void eval_multiply_add(gmp_int& t, const gmp_int& a, long i)
+inline void eval_multiply_add(gmp_int &t, const gmp_int &a, long i)
 {
-   if(i > 0)
+   if (i > 0)
       mpz_addmul_ui(t.data(), a.data(), i);
    else
       mpz_submul_ui(t.data(), a.data(), boost::multiprecision::detail::unsigned_abs(i));
 }
-inline void eval_multiply_subtract(gmp_int& t, const gmp_int& a, long i)
+inline void eval_multiply_subtract(gmp_int &t, const gmp_int &a, long i)
 {
-   if(i > 0)
+   if (i > 0)
       mpz_submul_ui(t.data(), a.data(), i);
    else
       mpz_addmul_ui(t.data(), a.data(), boost::multiprecision::detail::unsigned_abs(i));
 }
-inline void eval_subtract(gmp_int& t, long i)
+inline void eval_subtract(gmp_int &t, long i)
 {
-   if(i > 0)
+   if (i > 0)
       mpz_sub_ui(t.data(), t.data(), i);
    else
       mpz_add_ui(t.data(), t.data(), boost::multiprecision::detail::unsigned_abs(i));
 }
-inline void eval_multiply(gmp_int& t, long i)
+inline void eval_multiply(gmp_int &t, long i)
 {
    mpz_mul_ui(t.data(), t.data(), boost::multiprecision::detail::unsigned_abs(i));
-   if(i < 0)
+   if (i < 0)
       mpz_neg(t.data(), t.data());
 }
-inline void eval_modulus(gmp_int& t, long i)
+inline void eval_modulus(gmp_int &t, long i)
 {
    mpz_tdiv_r_ui(t.data(), t.data(), boost::multiprecision::detail::unsigned_abs(i));
 }
-inline void eval_divide(gmp_int& t, long i)
+inline void eval_divide(gmp_int &t, long i)
 {
-   if(i == 0)
+   if (i == 0)
       BOOST_THROW_EXCEPTION(std::overflow_error("Division by zero."));
    mpz_tdiv_q_ui(t.data(), t.data(), boost::multiprecision::detail::unsigned_abs(i));
-   if(i < 0)
+   if (i < 0)
       mpz_neg(t.data(), t.data());
 }
 template <class UI>
-inline void eval_left_shift(gmp_int& t, UI i)
+inline void eval_left_shift(gmp_int &t, UI i)
 {
    mpz_mul_2exp(t.data(), t.data(), static_cast<unsigned long>(i));
 }
 template <class UI>
-inline void eval_right_shift(gmp_int& t, UI i)
+inline void eval_right_shift(gmp_int &t, UI i)
 {
    mpz_fdiv_q_2exp(t.data(), t.data(), static_cast<unsigned long>(i));
 }
 template <class UI>
-inline void eval_left_shift(gmp_int& t, const gmp_int& v, UI i)
+inline void eval_left_shift(gmp_int &t, const gmp_int &v, UI i)
 {
    mpz_mul_2exp(t.data(), v.data(), static_cast<unsigned long>(i));
 }
 template <class UI>
-inline void eval_right_shift(gmp_int& t, const gmp_int& v, UI i)
+inline void eval_right_shift(gmp_int &t, const gmp_int &v, UI i)
 {
    mpz_fdiv_q_2exp(t.data(), v.data(), static_cast<unsigned long>(i));
 }
 
-inline void eval_bitwise_and(gmp_int& result, const gmp_int& v)
+inline void eval_bitwise_and(gmp_int &result, const gmp_int &v)
 {
    mpz_and(result.data(), result.data(), v.data());
 }
 
-inline void eval_bitwise_or(gmp_int& result, const gmp_int& v)
+inline void eval_bitwise_or(gmp_int &result, const gmp_int &v)
 {
    mpz_ior(result.data(), result.data(), v.data());
 }
 
-inline void eval_bitwise_xor(gmp_int& result, const gmp_int& v)
+inline void eval_bitwise_xor(gmp_int &result, const gmp_int &v)
 {
    mpz_xor(result.data(), result.data(), v.data());
 }
 
-inline void eval_add(gmp_int& t, const gmp_int& p, const gmp_int& o)
+inline void eval_add(gmp_int &t, const gmp_int &p, const gmp_int &o)
 {
    mpz_add(t.data(), p.data(), o.data());
 }
-inline void eval_subtract(gmp_int& t, const gmp_int& p, const gmp_int& o)
+inline void eval_subtract(gmp_int &t, const gmp_int &p, const gmp_int &o)
 {
    mpz_sub(t.data(), p.data(), o.data());
 }
-inline void eval_multiply(gmp_int& t, const gmp_int& p, const gmp_int& o)
+inline void eval_multiply(gmp_int &t, const gmp_int &p, const gmp_int &o)
 {
    mpz_mul(t.data(), p.data(), o.data());
 }
-inline void eval_divide(gmp_int& t, const gmp_int& p, const gmp_int& o)
+inline void eval_divide(gmp_int &t, const gmp_int &p, const gmp_int &o)
 {
-   if(eval_is_zero(o))
+   if (eval_is_zero(o))
       BOOST_THROW_EXCEPTION(std::overflow_error("Division by zero."));
    mpz_tdiv_q(t.data(), p.data(), o.data());
 }
-inline void eval_modulus(gmp_int& t, const gmp_int& p, const gmp_int& o)
+inline void eval_modulus(gmp_int &t, const gmp_int &p, const gmp_int &o)
 {
    mpz_tdiv_r(t.data(), p.data(), o.data());
 }
-inline void eval_add(gmp_int& t, const gmp_int& p, unsigned long i)
+inline void eval_add(gmp_int &t, const gmp_int &p, unsigned long i)
 {
    mpz_add_ui(t.data(), p.data(), i);
 }
-inline void eval_subtract(gmp_int& t, const gmp_int& p, unsigned long i)
+inline void eval_subtract(gmp_int &t, const gmp_int &p, unsigned long i)
 {
    mpz_sub_ui(t.data(), p.data(), i);
 }
-inline void eval_multiply(gmp_int& t, const gmp_int& p, unsigned long i)
+inline void eval_multiply(gmp_int &t, const gmp_int &p, unsigned long i)
 {
    mpz_mul_ui(t.data(), p.data(), i);
 }
-inline void eval_modulus(gmp_int& t, const gmp_int& p, unsigned long i)
+inline void eval_modulus(gmp_int &t, const gmp_int &p, unsigned long i)
 {
    mpz_tdiv_r_ui(t.data(), p.data(), i);
 }
-inline void eval_divide(gmp_int& t, const gmp_int& p, unsigned long i)
+inline void eval_divide(gmp_int &t, const gmp_int &p, unsigned long i)
 {
-   if(i == 0)
+   if (i == 0)
       BOOST_THROW_EXCEPTION(std::overflow_error("Division by zero."));
    mpz_tdiv_q_ui(t.data(), p.data(), i);
 }
-inline void eval_add(gmp_int& t, const gmp_int& p, long i)
+inline void eval_add(gmp_int &t, const gmp_int &p, long i)
 {
-   if(i > 0)
+   if (i > 0)
       mpz_add_ui(t.data(), p.data(), i);
    else
       mpz_sub_ui(t.data(), p.data(), boost::multiprecision::detail::unsigned_abs(i));
 }
-inline void eval_subtract(gmp_int& t, const gmp_int& p, long i)
+inline void eval_subtract(gmp_int &t, const gmp_int &p, long i)
 {
-   if(i > 0)
+   if (i > 0)
       mpz_sub_ui(t.data(), p.data(), i);
    else
       mpz_add_ui(t.data(), p.data(), boost::multiprecision::detail::unsigned_abs(i));
 }
-inline void eval_multiply(gmp_int& t, const gmp_int& p, long i)
+inline void eval_multiply(gmp_int &t, const gmp_int &p, long i)
 {
    mpz_mul_ui(t.data(), p.data(), boost::multiprecision::detail::unsigned_abs(i));
-   if(i < 0)
+   if (i < 0)
       mpz_neg(t.data(), t.data());
 }
-inline void eval_modulus(gmp_int& t, const gmp_int& p, long i)
+inline void eval_modulus(gmp_int &t, const gmp_int &p, long i)
 {
    mpz_tdiv_r_ui(t.data(), p.data(), boost::multiprecision::detail::unsigned_abs(i));
 }
-inline void eval_divide(gmp_int& t, const gmp_int& p, long i)
+inline void eval_divide(gmp_int &t, const gmp_int &p, long i)
 {
-   if(i == 0)
+   if (i == 0)
       BOOST_THROW_EXCEPTION(std::overflow_error("Division by zero."));
    mpz_tdiv_q_ui(t.data(), p.data(), boost::multiprecision::detail::unsigned_abs(i));
-   if(i < 0)
+   if (i < 0)
       mpz_neg(t.data(), t.data());
 }
 
-inline void eval_bitwise_and(gmp_int& result, const gmp_int& u, const gmp_int& v)
+inline void eval_bitwise_and(gmp_int &result, const gmp_int &u, const gmp_int &v)
 {
    mpz_and(result.data(), u.data(), v.data());
 }
 
-inline void eval_bitwise_or(gmp_int& result, const gmp_int& u, const gmp_int& v)
+inline void eval_bitwise_or(gmp_int &result, const gmp_int &u, const gmp_int &v)
 {
    mpz_ior(result.data(), u.data(), v.data());
 }
 
-inline void eval_bitwise_xor(gmp_int& result, const gmp_int& u, const gmp_int& v)
+inline void eval_bitwise_xor(gmp_int &result, const gmp_int &u, const gmp_int &v)
 {
    mpz_xor(result.data(), u.data(), v.data());
 }
 
-inline void eval_complement(gmp_int& result, const gmp_int& u)
+inline void eval_complement(gmp_int &result, const gmp_int &u)
 {
    mpz_com(result.data(), u.data());
 }
 
-inline int eval_get_sign(const gmp_int& val)
+inline int eval_get_sign(const gmp_int &val)
 {
    return mpz_sgn(val.data());
 }
-inline void eval_convert_to(unsigned long* result, const gmp_int& val)
+inline void eval_convert_to(unsigned long *result, const gmp_int &val)
 {
    if (mpz_sgn(val.data()) < 0)
    {
@@ -1661,120 +1672,120 @@ inline void eval_convert_to(unsigned long* result, const gmp_int& val)
    else
       *result = (unsigned long)mpz_get_ui(val.data());
 }
-inline void eval_convert_to(long* result, const gmp_int& val)
+inline void eval_convert_to(long *result, const gmp_int &val)
 {
-   if(0 == mpz_fits_slong_p(val.data()))
+   if (0 == mpz_fits_slong_p(val.data()))
    {
-      *result = mpz_sgn(val.data()) < 0 ? (std::numeric_limits<long>::min)()  : (std::numeric_limits<long>::max)();
+      *result = mpz_sgn(val.data()) < 0 ? (std::numeric_limits<long>::min)() : (std::numeric_limits<long>::max)();
    }
    else
       *result = (signed long)mpz_get_si(val.data());
 }
-inline void eval_convert_to(double* result, const gmp_int& val)
+inline void eval_convert_to(double *result, const gmp_int &val)
 {
    *result = mpz_get_d(val.data());
 }
 
-inline void eval_abs(gmp_int& result, const gmp_int& val)
+inline void eval_abs(gmp_int &result, const gmp_int &val)
 {
    mpz_abs(result.data(), val.data());
 }
 
-inline void eval_gcd(gmp_int& result, const gmp_int& a, const gmp_int& b)
+inline void eval_gcd(gmp_int &result, const gmp_int &a, const gmp_int &b)
 {
    mpz_gcd(result.data(), a.data(), b.data());
 }
-inline void eval_lcm(gmp_int& result, const gmp_int& a, const gmp_int& b)
+inline void eval_lcm(gmp_int &result, const gmp_int &a, const gmp_int &b)
 {
    mpz_lcm(result.data(), a.data(), b.data());
 }
 template <class I>
-inline typename enable_if_c<(is_unsigned<I>::value && (sizeof(I) <= sizeof(unsigned long)))>::type eval_gcd(gmp_int& result, const gmp_int& a, const I b)
+inline typename enable_if_c<(is_unsigned<I>::value && (sizeof(I) <= sizeof(unsigned long)))>::type eval_gcd(gmp_int &result, const gmp_int &a, const I b)
 {
    mpz_gcd_ui(result.data(), a.data(), b);
 }
 template <class I>
-inline typename enable_if_c<(is_unsigned<I>::value && (sizeof(I) <= sizeof(unsigned long)))>::type eval_lcm(gmp_int& result, const gmp_int& a, const I b)
+inline typename enable_if_c<(is_unsigned<I>::value && (sizeof(I) <= sizeof(unsigned long)))>::type eval_lcm(gmp_int &result, const gmp_int &a, const I b)
 {
    mpz_lcm_ui(result.data(), a.data(), b);
 }
 template <class I>
-inline typename enable_if_c<(is_signed<I>::value && (sizeof(I) <= sizeof(long)))>::type eval_gcd(gmp_int& result, const gmp_int& a, const I b)
+inline typename enable_if_c<(is_signed<I>::value && (sizeof(I) <= sizeof(long)))>::type eval_gcd(gmp_int &result, const gmp_int &a, const I b)
 {
    mpz_gcd_ui(result.data(), a.data(), boost::multiprecision::detail::unsigned_abs(b));
 }
 template <class I>
-inline typename enable_if_c<is_signed<I>::value && ((sizeof(I) <= sizeof(long)))>::type eval_lcm(gmp_int& result, const gmp_int& a, const I b)
+inline typename enable_if_c<is_signed<I>::value && ((sizeof(I) <= sizeof(long)))>::type eval_lcm(gmp_int &result, const gmp_int &a, const I b)
 {
    mpz_lcm_ui(result.data(), a.data(), boost::multiprecision::detail::unsigned_abs(b));
 }
 
-inline void eval_integer_sqrt(gmp_int& s, gmp_int& r, const gmp_int& x)
+inline void eval_integer_sqrt(gmp_int &s, gmp_int &r, const gmp_int &x)
 {
    mpz_sqrtrem(s.data(), r.data(), x.data());
 }
 
-inline unsigned eval_lsb(const gmp_int& val)
+inline unsigned eval_lsb(const gmp_int &val)
 {
    int c = eval_get_sign(val);
-   if(c == 0)
+   if (c == 0)
    {
       BOOST_THROW_EXCEPTION(std::range_error("No bits were set in the operand."));
    }
-   if(c < 0)
+   if (c < 0)
    {
       BOOST_THROW_EXCEPTION(std::range_error("Testing individual bits in negative values is not supported - results are undefined."));
    }
    return static_cast<unsigned>(mpz_scan1(val.data(), 0));
 }
 
-inline unsigned eval_msb(const gmp_int& val)
+inline unsigned eval_msb(const gmp_int &val)
 {
    int c = eval_get_sign(val);
-   if(c == 0)
+   if (c == 0)
    {
       BOOST_THROW_EXCEPTION(std::range_error("No bits were set in the operand."));
    }
-   if(c < 0)
+   if (c < 0)
    {
       BOOST_THROW_EXCEPTION(std::range_error("Testing individual bits in negative values is not supported - results are undefined."));
    }
    return static_cast<unsigned>(mpz_sizeinbase(val.data(), 2) - 1);
 }
 
-inline bool eval_bit_test(const gmp_int& val, unsigned index)
+inline bool eval_bit_test(const gmp_int &val, unsigned index)
 {
    return mpz_tstbit(val.data(), index) ? true : false;
 }
 
-inline void eval_bit_set(gmp_int& val, unsigned index)
+inline void eval_bit_set(gmp_int &val, unsigned index)
 {
    mpz_setbit(val.data(), index);
 }
 
-inline void eval_bit_unset(gmp_int& val, unsigned index)
+inline void eval_bit_unset(gmp_int &val, unsigned index)
 {
    mpz_clrbit(val.data(), index);
 }
 
-inline void eval_bit_flip(gmp_int& val, unsigned index)
+inline void eval_bit_flip(gmp_int &val, unsigned index)
 {
    mpz_combit(val.data(), index);
 }
 
-inline void eval_qr(const gmp_int& x, const gmp_int& y,
-   gmp_int& q, gmp_int& r)
+inline void eval_qr(const gmp_int &x, const gmp_int &y,
+                    gmp_int &q, gmp_int &r)
 {
    mpz_tdiv_qr(q.data(), r.data(), x.data(), y.data());
 }
 
 template <class Integer>
-inline typename enable_if<is_unsigned<Integer>, Integer>::type eval_integer_modulus(const gmp_int& x, Integer val)
+inline typename enable_if<is_unsigned<Integer>, Integer>::type eval_integer_modulus(const gmp_int &x, Integer val)
 {
 #if defined(__MPIR_VERSION) && (__MPIR_VERSION >= 3)
-   if((sizeof(Integer) <= sizeof(mpir_ui)) || (val <= (std::numeric_limits<mpir_ui>::max)()))
+   if ((sizeof(Integer) <= sizeof(mpir_ui)) || (val <= (std::numeric_limits<mpir_ui>::max)()))
 #else
-   if((sizeof(Integer) <= sizeof(long)) || (val <= (std::numeric_limits<unsigned long>::max)()))
+   if ((sizeof(Integer) <= sizeof(long)) || (val <= (std::numeric_limits<unsigned long>::max)()))
 #endif
    {
       return static_cast<Integer>(mpz_tdiv_ui(x.data(), val));
@@ -1785,13 +1796,13 @@ inline typename enable_if<is_unsigned<Integer>, Integer>::type eval_integer_modu
    }
 }
 template <class Integer>
-inline typename enable_if<is_signed<Integer>, Integer>::type eval_integer_modulus(const gmp_int& x, Integer val)
+inline typename enable_if<is_signed<Integer>, Integer>::type eval_integer_modulus(const gmp_int &x, Integer val)
 {
    return eval_integer_modulus(x, boost::multiprecision::detail::unsigned_abs(val));
 }
-inline void eval_powm(gmp_int& result, const gmp_int& base, const gmp_int& p, const gmp_int& m)
+inline void eval_powm(gmp_int &result, const gmp_int &base, const gmp_int &p, const gmp_int &m)
 {
-   if(eval_get_sign(p) < 0)
+   if (eval_get_sign(p) < 0)
    {
       BOOST_THROW_EXCEPTION(std::runtime_error("powm requires a positive exponent."));
    }
@@ -1800,72 +1811,70 @@ inline void eval_powm(gmp_int& result, const gmp_int& base, const gmp_int& p, co
 
 template <class Integer>
 inline typename enable_if<
-   mpl::and_<
-      is_unsigned<Integer>,
-      mpl::bool_<sizeof(Integer) <= sizeof(unsigned long)>
-   >
->::type eval_powm(gmp_int& result, const gmp_int& base, Integer p, const gmp_int& m)
+    mpl::and_<
+        is_unsigned<Integer>,
+        mpl::bool_<sizeof(Integer) <= sizeof(unsigned long)> > >::type
+eval_powm(gmp_int &result, const gmp_int &base, Integer p, const gmp_int &m)
 {
    mpz_powm_ui(result.data(), base.data(), p, m.data());
 }
 template <class Integer>
 inline typename enable_if<
-   mpl::and_<
-      is_signed<Integer>,
-      mpl::bool_<sizeof(Integer) <= sizeof(unsigned long)>
-   >
->::type eval_powm(gmp_int& result, const gmp_int& base, Integer p, const gmp_int& m)
+    mpl::and_<
+        is_signed<Integer>,
+        mpl::bool_<sizeof(Integer) <= sizeof(unsigned long)> > >::type
+eval_powm(gmp_int &result, const gmp_int &base, Integer p, const gmp_int &m)
 {
-   if(p < 0)
+   if (p < 0)
    {
       BOOST_THROW_EXCEPTION(std::runtime_error("powm requires a positive exponent."));
    }
    mpz_powm_ui(result.data(), base.data(), p, m.data());
 }
 
-inline std::size_t hash_value(const gmp_int& val)
+inline std::size_t hash_value(const gmp_int &val)
 {
    // We should really use mpz_limbs_read here, but that's unsupported on older versions:
    std::size_t result = 0;
-   for(int i = 0; i < std::abs(val.data()[0]._mp_size); ++i)
+   for (int i = 0; i < std::abs(val.data()[0]._mp_size); ++i)
       boost::hash_combine(result, val.data()[0]._mp_d[i]);
    boost::hash_combine(result, val.data()[0]._mp_size);
    return result;
 }
 
 struct gmp_rational;
-void eval_add(gmp_rational& t, const gmp_rational& o);
+void eval_add(gmp_rational &t, const gmp_rational &o);
 
 struct gmp_rational
 {
 #ifdef BOOST_HAS_LONG_LONG
-   typedef mpl::list<long, boost::long_long_type>                     signed_types;
-   typedef mpl::list<unsigned long, boost::ulong_long_type>   unsigned_types;
+   typedef mpl::list<long, boost::long_long_type>           signed_types;
+   typedef mpl::list<unsigned long, boost::ulong_long_type> unsigned_types;
 #else
-   typedef mpl::list<long>                                signed_types;
-   typedef mpl::list<unsigned long>                       unsigned_types;
+   typedef mpl::list<long>          signed_types;
+   typedef mpl::list<unsigned long> unsigned_types;
 #endif
-   typedef mpl::list<double, long double>                 float_types;
+   typedef mpl::list<double, long double> float_types;
 
    gmp_rational()
    {
       mpq_init(this->m_data);
    }
-   gmp_rational(const gmp_rational& o)
+   gmp_rational(const gmp_rational &o)
    {
       mpq_init(m_data);
-      if(o.m_data[0]._mp_num._mp_d)
+      if (o.m_data[0]._mp_num._mp_d)
          mpq_set(m_data, o.m_data);
    }
-   gmp_rational(const gmp_int& o)
+   gmp_rational(const gmp_int &o)
    {
       mpq_init(m_data);
       mpq_set_z(m_data, o.data());
    }
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
-   gmp_rational(gmp_rational&& o) BOOST_NOEXCEPT
+   gmp_rational(gmp_rational &&o) BOOST_NOEXCEPT
    {
-      m_data[0] = o.m_data[0];
+      m_data[0]                 = o.m_data[0];
       o.m_data[0]._mp_num._mp_d = 0;
       o.m_data[0]._mp_den._mp_d = 0;
    }
@@ -1880,15 +1889,15 @@ struct gmp_rational
       mpq_init(m_data);
       mpq_set_z(m_data, o);
    }
-   gmp_rational& operator = (const gmp_rational& o)
+   gmp_rational &operator=(const gmp_rational &o)
    {
-      if(m_data[0]._mp_den._mp_d == 0)
+      if (m_data[0]._mp_den._mp_d == 0)
          mpq_init(m_data);
       mpq_set(m_data, o.m_data);
       return *this;
    }
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
-   gmp_rational& operator = (gmp_rational&& o) BOOST_NOEXCEPT
+   gmp_rational &operator=(gmp_rational &&o) BOOST_NOEXCEPT
    {
       mpq_swap(m_data, o.m_data);
       return *this;
@@ -1896,71 +1905,73 @@ struct gmp_rational
 #endif
 #ifdef BOOST_HAS_LONG_LONG
 #if defined(ULLONG_MAX) && (ULLONG_MAX == ULONG_MAX)
-   gmp_rational& operator = (boost::ulong_long_type i)
+   gmp_rational &operator=(boost::ulong_long_type i)
    {
       *this = static_cast<unsigned long>(i);
       return *this;
    }
 #else
-   gmp_rational& operator = (boost::ulong_long_type i)
+   gmp_rational &operator=(boost::ulong_long_type i)
    {
-      if(m_data[0]._mp_den._mp_d == 0)
+      if (m_data[0]._mp_den._mp_d == 0)
          mpq_init(m_data);
       gmp_int zi;
       zi = i;
       mpq_set_z(m_data, zi.data());
       return *this;
    }
-   gmp_rational& operator = (boost::long_long_type i)
+   gmp_rational &operator=(boost::long_long_type i)
    {
-      if(m_data[0]._mp_den._mp_d == 0)
+      if (m_data[0]._mp_den._mp_d == 0)
          mpq_init(m_data);
       bool neg = i < 0;
-      *this = boost::multiprecision::detail::unsigned_abs(i);
-      if(neg)
+      *this    = boost::multiprecision::detail::unsigned_abs(i);
+      if (neg)
          mpq_neg(m_data, m_data);
       return *this;
    }
 #endif
 #endif
-   gmp_rational& operator = (unsigned long i)
+   gmp_rational &operator=(unsigned long i)
    {
-      if(m_data[0]._mp_den._mp_d == 0)
+      if (m_data[0]._mp_den._mp_d == 0)
          mpq_init(m_data);
       mpq_set_ui(m_data, i, 1);
       return *this;
    }
-   gmp_rational& operator = (long i)
+   gmp_rational &operator=(long i)
    {
-      if(m_data[0]._mp_den._mp_d == 0)
+      if (m_data[0]._mp_den._mp_d == 0)
          mpq_init(m_data);
       mpq_set_si(m_data, i, 1);
       return *this;
    }
-   gmp_rational& operator = (double d)
+   gmp_rational &operator=(double d)
    {
-      if(m_data[0]._mp_den._mp_d == 0)
+      if (m_data[0]._mp_den._mp_d == 0)
          mpq_init(m_data);
       mpq_set_d(m_data, d);
       return *this;
    }
-   gmp_rational& operator = (long double a)
+   gmp_rational &operator=(long double a)
    {
-      using std::frexp;
-      using std::ldexp;
-      using std::floor;
       using default_ops::eval_add;
       using default_ops::eval_subtract;
+      using std::floor;
+      using std::frexp;
+      using std::ldexp;
 
-      if(m_data[0]._mp_den._mp_d == 0)
+      if (m_data[0]._mp_den._mp_d == 0)
          mpq_init(m_data);
 
-      if (a == 0) {
+      if (a == 0)
+      {
          mpq_set_si(m_data, 0, 1);
          return *this;
       }
 
-      if (a == 1) {
+      if (a == 1)
+      {
          mpq_set_si(m_data, 1, 1);
          return *this;
       }
@@ -1968,7 +1979,7 @@ struct gmp_rational
       BOOST_ASSERT(!(boost::math::isinf)(a));
       BOOST_ASSERT(!(boost::math::isnan)(a));
 
-      int e;
+      int         e;
       long double f, term;
       mpq_set_ui(m_data, 0, 1);
       mpq_set_ui(m_data, 0u, 1);
@@ -1978,10 +1989,10 @@ struct gmp_rational
 
       static const int shift = std::numeric_limits<int>::digits - 1;
 
-      while(f)
+      while (f)
       {
          // extract int sized bits from f:
-         f = ldexp(f, shift);
+         f    = ldexp(f, shift);
          term = floor(f);
          e -= shift;
          mpq_mul_2exp(m_data, m_data, shift);
@@ -1989,61 +2000,61 @@ struct gmp_rational
          eval_add(*this, t);
          f -= term;
       }
-      if(e > 0)
+      if (e > 0)
          mpq_mul_2exp(m_data, m_data, e);
-      else if(e < 0)
+      else if (e < 0)
          mpq_div_2exp(m_data, m_data, -e);
       return *this;
    }
-   gmp_rational& operator = (const char* s)
+   gmp_rational &operator=(const char *s)
    {
-      if(m_data[0]._mp_den._mp_d == 0)
+      if (m_data[0]._mp_den._mp_d == 0)
          mpq_init(m_data);
-      if(0 != mpq_set_str(m_data, s, 10))
+      if (0 != mpq_set_str(m_data, s, 10))
          BOOST_THROW_EXCEPTION(std::runtime_error(std::string("The string \"") + s + std::string("\"could not be interpreted as a valid rational number.")));
       return *this;
    }
-   gmp_rational& operator=(const gmp_int& o)
+   gmp_rational &operator=(const gmp_int &o)
    {
-      if(m_data[0]._mp_den._mp_d == 0)
+      if (m_data[0]._mp_den._mp_d == 0)
          mpq_init(m_data);
       mpq_set_z(m_data, o.data());
       return *this;
    }
-   gmp_rational& operator=(const mpq_t o)
+   gmp_rational &operator=(const mpq_t o)
    {
-      if(m_data[0]._mp_den._mp_d == 0)
+      if (m_data[0]._mp_den._mp_d == 0)
          mpq_init(m_data);
       mpq_set(m_data, o);
       return *this;
    }
-   gmp_rational& operator=(const mpz_t o)
+   gmp_rational &operator=(const mpz_t o)
    {
-      if(m_data[0]._mp_den._mp_d == 0)
+      if (m_data[0]._mp_den._mp_d == 0)
          mpq_init(m_data);
       mpq_set_z(m_data, o);
       return *this;
    }
-   void swap(gmp_rational& o)
+   void swap(gmp_rational &o)
    {
       mpq_swap(m_data, o.m_data);
    }
-   std::string str(std::streamsize /*digits*/, std::ios_base::fmtflags /*f*/)const
+   std::string str(std::streamsize /*digits*/, std::ios_base::fmtflags /*f*/) const
    {
       BOOST_ASSERT(m_data[0]._mp_num._mp_d);
       // TODO make a better job of this including handling of f!!
-      void *(*alloc_func_ptr) (size_t);
-      void *(*realloc_func_ptr) (void *, size_t, size_t);
-      void (*free_func_ptr) (void *, size_t);
-      const char* ps = mpq_get_str (0, 10, m_data);
-      std::string s = ps;
+      void *(*alloc_func_ptr)(size_t);
+      void *(*realloc_func_ptr)(void *, size_t, size_t);
+      void (*free_func_ptr)(void *, size_t);
+      const char *ps = mpq_get_str(0, 10, m_data);
+      std::string s  = ps;
       mp_get_memory_functions(&alloc_func_ptr, &realloc_func_ptr, &free_func_ptr);
-      (*free_func_ptr)((void*)ps, std::strlen(ps) + 1);
+      (*free_func_ptr)((void *)ps, std::strlen(ps) + 1);
       return s;
    }
    ~gmp_rational()
    {
-      if(m_data[0]._mp_num._mp_d || m_data[0]._mp_den._mp_d)
+      if (m_data[0]._mp_num._mp_d || m_data[0]._mp_den._mp_d)
          mpq_clear(m_data);
    }
    void negate()
@@ -2051,104 +2062,105 @@ struct gmp_rational
       BOOST_ASSERT(m_data[0]._mp_num._mp_d);
       mpq_neg(m_data, m_data);
    }
-   int compare(const gmp_rational& o)const
+   int compare(const gmp_rational &o) const
    {
       BOOST_ASSERT(m_data[0]._mp_num._mp_d && o.m_data[0]._mp_num._mp_d);
       return mpq_cmp(m_data, o.m_data);
    }
    template <class V>
-   int compare(V v)const
+   int compare(V v) const
    {
       gmp_rational d;
       d = v;
       return compare(d);
    }
-   int compare(unsigned long v)const
+   int compare(unsigned long v) const
    {
       BOOST_ASSERT(m_data[0]._mp_num._mp_d);
       return mpq_cmp_ui(m_data, v, 1);
    }
-   int compare(long v)const
+   int compare(long v) const
    {
       BOOST_ASSERT(m_data[0]._mp_num._mp_d);
       return mpq_cmp_si(m_data, v, 1);
    }
-   mpq_t& data()
+   mpq_t &data()
    {
       BOOST_ASSERT(m_data[0]._mp_num._mp_d);
       return m_data;
    }
-   const mpq_t& data()const
+   const mpq_t &data() const
    {
       BOOST_ASSERT(m_data[0]._mp_num._mp_d);
       return m_data;
    }
-protected:
+
+ protected:
    mpq_t m_data;
 };
 
-inline bool eval_is_zero(const gmp_rational& val)
+inline bool eval_is_zero(const gmp_rational &val)
 {
    return mpq_sgn(val.data()) == 0;
 }
 template <class T>
-inline bool eval_eq(gmp_rational& a, const T& b)
+inline bool eval_eq(gmp_rational &a, const T &b)
 {
    return a.compare(b) == 0;
 }
 template <class T>
-inline bool eval_lt(gmp_rational& a, const T& b)
+inline bool eval_lt(gmp_rational &a, const T &b)
 {
    return a.compare(b) < 0;
 }
 template <class T>
-inline bool eval_gt(gmp_rational& a, const T& b)
+inline bool eval_gt(gmp_rational &a, const T &b)
 {
    return a.compare(b) > 0;
 }
 
-inline void eval_add(gmp_rational& t, const gmp_rational& o)
+inline void eval_add(gmp_rational &t, const gmp_rational &o)
 {
    mpq_add(t.data(), t.data(), o.data());
 }
-inline void eval_subtract(gmp_rational& t, const gmp_rational& o)
+inline void eval_subtract(gmp_rational &t, const gmp_rational &o)
 {
    mpq_sub(t.data(), t.data(), o.data());
 }
-inline void eval_multiply(gmp_rational& t, const gmp_rational& o)
+inline void eval_multiply(gmp_rational &t, const gmp_rational &o)
 {
    mpq_mul(t.data(), t.data(), o.data());
 }
-inline void eval_divide(gmp_rational& t, const gmp_rational& o)
+inline void eval_divide(gmp_rational &t, const gmp_rational &o)
 {
-   if(eval_is_zero(o))
+   if (eval_is_zero(o))
       BOOST_THROW_EXCEPTION(std::overflow_error("Division by zero."));
    mpq_div(t.data(), t.data(), o.data());
 }
-inline void eval_add(gmp_rational& t, const gmp_rational& p, const gmp_rational& o)
+inline void eval_add(gmp_rational &t, const gmp_rational &p, const gmp_rational &o)
 {
    mpq_add(t.data(), p.data(), o.data());
 }
-inline void eval_subtract(gmp_rational& t, const gmp_rational& p, const gmp_rational& o)
+inline void eval_subtract(gmp_rational &t, const gmp_rational &p, const gmp_rational &o)
 {
    mpq_sub(t.data(), p.data(), o.data());
 }
-inline void eval_multiply(gmp_rational& t, const gmp_rational& p, const gmp_rational& o)
+inline void eval_multiply(gmp_rational &t, const gmp_rational &p, const gmp_rational &o)
 {
    mpq_mul(t.data(), p.data(), o.data());
 }
-inline void eval_divide(gmp_rational& t, const gmp_rational& p, const gmp_rational& o)
+inline void eval_divide(gmp_rational &t, const gmp_rational &p, const gmp_rational &o)
 {
-   if(eval_is_zero(o))
+   if (eval_is_zero(o))
       BOOST_THROW_EXCEPTION(std::overflow_error("Division by zero."));
    mpq_div(t.data(), p.data(), o.data());
 }
 
-inline int eval_get_sign(const gmp_rational& val)
+inline int eval_get_sign(const gmp_rational &val)
 {
    return mpq_sgn(val.data());
 }
-inline void eval_convert_to(double* result, const gmp_rational& val)
+inline void eval_convert_to(double *result, const gmp_rational &val)
 {
    //
    // This does not round correctly:
@@ -2160,48 +2172,48 @@ inline void eval_convert_to(double* result, const gmp_rational& val)
    boost::multiprecision::detail::generic_convert_rational_to_float(*result, val);
 }
 
-inline void eval_convert_to(long* result, const gmp_rational& val)
+inline void eval_convert_to(long *result, const gmp_rational &val)
 {
    double r;
    eval_convert_to(&r, val);
    *result = static_cast<long>(r);
 }
 
-inline void eval_convert_to(unsigned long* result, const gmp_rational& val)
+inline void eval_convert_to(unsigned long *result, const gmp_rational &val)
 {
    double r;
    eval_convert_to(&r, val);
    *result = static_cast<long>(r);
 }
 
-inline void eval_abs(gmp_rational& result, const gmp_rational& val)
+inline void eval_abs(gmp_rational &result, const gmp_rational &val)
 {
    mpq_abs(result.data(), val.data());
 }
 
-inline void assign_components(gmp_rational& result, unsigned long v1, unsigned long v2)
+inline void assign_components(gmp_rational &result, unsigned long v1, unsigned long v2)
 {
    mpq_set_ui(result.data(), v1, v2);
    mpq_canonicalize(result.data());
 }
-inline void assign_components(gmp_rational& result, long v1, long v2)
+inline void assign_components(gmp_rational &result, long v1, long v2)
 {
    mpq_set_si(result.data(), v1, v2);
    mpq_canonicalize(result.data());
 }
-inline void assign_components(gmp_rational& result, gmp_int const& v1, gmp_int const& v2)
+inline void assign_components(gmp_rational &result, gmp_int const &v1, gmp_int const &v2)
 {
    mpz_set(mpq_numref(result.data()), v1.data());
    mpz_set(mpq_denref(result.data()), v2.data());
    mpq_canonicalize(result.data());
 }
 
-inline std::size_t hash_value(const gmp_rational& val)
+inline std::size_t hash_value(const gmp_rational &val)
 {
    std::size_t result = 0;
-   for(int i = 0; i < std::abs(val.data()[0]._mp_num._mp_size); ++i)
+   for (int i = 0; i < std::abs(val.data()[0]._mp_num._mp_size); ++i)
       boost::hash_combine(result, val.data()[0]._mp_num._mp_d[i]);
-   for(int i = 0; i < std::abs(val.data()[0]._mp_den._mp_size); ++i)
+   for (int i = 0; i < std::abs(val.data()[0]._mp_den._mp_size); ++i)
       boost::hash_combine(result, val.data()[0]._mp_den._mp_d[i]);
    boost::hash_combine(result, val.data()[0]._mp_num._mp_size);
    return result;
@@ -2212,87 +2224,87 @@ inline std::size_t hash_value(const gmp_rational& val)
 //
 template <unsigned Digits10>
 template <unsigned D>
-inline gmp_float<Digits10>::gmp_float(const gmp_float<D>& o, typename enable_if_c<D <= Digits10>::type*)
+inline gmp_float<Digits10>::gmp_float(const gmp_float<D> &o, typename enable_if_c<D <= Digits10>::type *)
 {
    mpf_init2(this->m_data, multiprecision::detail::digits10_2_2(Digits10 ? Digits10 : this->get_default_precision()));
    mpf_set(this->m_data, o.data());
 }
 template <unsigned Digits10>
 template <unsigned D>
-inline gmp_float<Digits10>::gmp_float(const gmp_float<D>& o, typename disable_if_c<D <= Digits10>::type*)
+inline gmp_float<Digits10>::gmp_float(const gmp_float<D> &o, typename disable_if_c<D <= Digits10>::type *)
 {
    mpf_init2(this->m_data, multiprecision::detail::digits10_2_2(Digits10 ? Digits10 : this->get_default_precision()));
    mpf_set(this->m_data, o.data());
 }
 template <unsigned Digits10>
-inline gmp_float<Digits10>::gmp_float(const gmp_int& o)
+inline gmp_float<Digits10>::gmp_float(const gmp_int &o)
 {
    mpf_init2(this->m_data, multiprecision::detail::digits10_2_2(Digits10 ? Digits10 : this->get_default_precision()));
    mpf_set_z(this->data(), o.data());
 }
 template <unsigned Digits10>
-inline gmp_float<Digits10>::gmp_float(const gmp_rational& o)
+inline gmp_float<Digits10>::gmp_float(const gmp_rational &o)
 {
    mpf_init2(this->m_data, multiprecision::detail::digits10_2_2(Digits10 ? Digits10 : this->get_default_precision()));
    mpf_set_q(this->data(), o.data());
 }
 template <unsigned Digits10>
 template <unsigned D>
-inline gmp_float<Digits10>& gmp_float<Digits10>::operator=(const gmp_float<D>& o)
+inline gmp_float<Digits10> &gmp_float<Digits10>::operator=(const gmp_float<D> &o)
 {
-   if(this->m_data[0]._mp_d == 0)
+   if (this->m_data[0]._mp_d == 0)
       mpf_init2(this->m_data, multiprecision::detail::digits10_2_2(Digits10 ? Digits10 : this->get_default_precision()));
    mpf_set(this->m_data, o.data());
    return *this;
 }
 template <unsigned Digits10>
-inline gmp_float<Digits10>& gmp_float<Digits10>::operator=(const gmp_int& o)
+inline gmp_float<Digits10> &gmp_float<Digits10>::operator=(const gmp_int &o)
 {
-   if(this->m_data[0]._mp_d == 0)
+   if (this->m_data[0]._mp_d == 0)
       mpf_init2(this->m_data, multiprecision::detail::digits10_2_2(Digits10 ? Digits10 : this->get_default_precision()));
    mpf_set_z(this->data(), o.data());
    return *this;
 }
 template <unsigned Digits10>
-inline gmp_float<Digits10>& gmp_float<Digits10>::operator=(const gmp_rational& o)
+inline gmp_float<Digits10> &gmp_float<Digits10>::operator=(const gmp_rational &o)
 {
-   if(this->m_data[0]._mp_d == 0)
+   if (this->m_data[0]._mp_d == 0)
       mpf_init2(this->m_data, multiprecision::detail::digits10_2_2(Digits10 ? Digits10 : this->get_default_precision()));
    mpf_set_q(this->data(), o.data());
    return *this;
 }
-inline gmp_float<0>::gmp_float(const gmp_int& o)
+inline gmp_float<0>::gmp_float(const gmp_int &o)
 {
    mpf_init2(this->m_data, multiprecision::detail::digits10_2_2(get_default_precision()));
    mpf_set_z(this->data(), o.data());
 }
-inline gmp_float<0>::gmp_float(const gmp_rational& o)
+inline gmp_float<0>::gmp_float(const gmp_rational &o)
 {
    mpf_init2(this->m_data, multiprecision::detail::digits10_2_2(get_default_precision()));
    mpf_set_q(this->data(), o.data());
 }
-inline gmp_float<0>& gmp_float<0>::operator=(const gmp_int& o)
+inline gmp_float<0> &gmp_float<0>::operator=(const gmp_int &o)
 {
-   if(this->m_data[0]._mp_d == 0)
+   if (this->m_data[0]._mp_d == 0)
       mpf_init2(this->m_data, multiprecision::detail::digits10_2_2(this->get_default_precision()));
    mpf_set_z(this->data(), o.data());
    return *this;
 }
-inline gmp_float<0>& gmp_float<0>::operator=(const gmp_rational& o)
+inline gmp_float<0> &gmp_float<0>::operator=(const gmp_rational &o)
 {
-   if(this->m_data[0]._mp_d == 0)
+   if (this->m_data[0]._mp_d == 0)
       mpf_init2(this->m_data, multiprecision::detail::digits10_2_2(this->get_default_precision()));
    mpf_set_q(this->data(), o.data());
    return *this;
 }
-inline gmp_int::gmp_int(const gmp_rational& o)
+inline gmp_int::gmp_int(const gmp_rational &o)
 {
    mpz_init(this->m_data);
    mpz_set_q(this->m_data, o.data());
 }
-inline gmp_int& gmp_int::operator=(const gmp_rational& o)
+inline gmp_int &gmp_int::operator=(const gmp_rational &o)
 {
-   if(this->m_data[0]._mp_d == 0)
+   if (this->m_data[0]._mp_d == 0)
       mpz_init(this->m_data);
    mpz_set_q(this->m_data, o.data());
    return *this;
@@ -2300,9 +2312,9 @@ inline gmp_int& gmp_int::operator=(const gmp_rational& o)
 
 } //namespace backends
 
+using boost::multiprecision::backends::gmp_float;
 using boost::multiprecision::backends::gmp_int;
 using boost::multiprecision::backends::gmp_rational;
-using boost::multiprecision::backends::gmp_float;
 
 template <expression_template_option ExpressionTemplates>
 struct component_type<number<gmp_rational, ExpressionTemplates> >
@@ -2311,34 +2323,39 @@ struct component_type<number<gmp_rational, ExpressionTemplates> >
 };
 
 template <expression_template_option ET>
-inline number<gmp_int, ET> numerator(const number<gmp_rational, ET>& val)
+inline number<gmp_int, ET> numerator(const number<gmp_rational, ET> &val)
 {
    number<gmp_int, ET> result;
    mpz_set(result.backend().data(), (mpq_numref(val.backend().data())));
    return result;
 }
 template <expression_template_option ET>
-inline number<gmp_int, ET> denominator(const number<gmp_rational, ET>& val)
+inline number<gmp_int, ET> denominator(const number<gmp_rational, ET> &val)
 {
    number<gmp_int, ET> result;
    mpz_set(result.backend().data(), (mpq_denref(val.backend().data())));
    return result;
 }
 
-namespace detail{
+namespace detail {
 
 #ifdef BOOST_NO_SFINAE_EXPR
 
-template<>
-struct is_explicitly_convertible<canonical<mpf_t, gmp_int>::type, gmp_int> : public mpl::true_ {};
-template<>
-struct is_explicitly_convertible<canonical<mpq_t, gmp_int>::type, gmp_int> : public mpl::true_ {};
-template<unsigned Digits10>
-struct is_explicitly_convertible<gmp_float<Digits10>, gmp_int> : public mpl::true_ {};
-template<>
-struct is_explicitly_convertible<gmp_rational, gmp_int> : public mpl::true_ {};
-template<unsigned D1, unsigned D2>
-struct is_explicitly_convertible<gmp_float<D1>, gmp_float<D2> > : public mpl::true_ {};
+template <>
+struct is_explicitly_convertible<canonical<mpf_t, gmp_int>::type, gmp_int> : public mpl::true_
+{};
+template <>
+struct is_explicitly_convertible<canonical<mpq_t, gmp_int>::type, gmp_int> : public mpl::true_
+{};
+template <unsigned Digits10>
+struct is_explicitly_convertible<gmp_float<Digits10>, gmp_int> : public mpl::true_
+{};
+template <>
+struct is_explicitly_convertible<gmp_rational, gmp_int> : public mpl::true_
+{};
+template <unsigned D1, unsigned D2>
+struct is_explicitly_convertible<gmp_float<D1>, gmp_float<D2> > : public mpl::true_
+{};
 
 #endif
 
@@ -2347,7 +2364,7 @@ struct digits2<number<gmp_float<0>, et_on> >
 {
    static long value()
    {
-      return  multiprecision::detail::digits10_2_2(gmp_float<0>::default_precision());
+      return multiprecision::detail::digits10_2_2(gmp_float<0>::default_precision());
    }
 };
 
@@ -2356,7 +2373,7 @@ struct digits2<number<gmp_float<0>, et_off> >
 {
    static long value()
    {
-      return  multiprecision::detail::digits10_2_2(gmp_float<0>::default_precision());
+      return multiprecision::detail::digits10_2_2(gmp_float<0>::default_precision());
    }
 };
 
@@ -2365,7 +2382,7 @@ struct digits2<number<debug_adaptor<gmp_float<0> >, et_on> >
 {
    static long value()
    {
-      return  multiprecision::detail::digits10_2_2(gmp_float<0>::default_precision());
+      return multiprecision::detail::digits10_2_2(gmp_float<0>::default_precision());
    }
 };
 
@@ -2374,177 +2391,178 @@ struct digits2<number<debug_adaptor<gmp_float<0> >, et_off> >
 {
    static long value()
    {
-      return  multiprecision::detail::digits10_2_2(gmp_float<0>::default_precision());
+      return multiprecision::detail::digits10_2_2(gmp_float<0>::default_precision());
    }
 };
 
-}
+} // namespace detail
 
-template<>
-struct number_category<detail::canonical<mpz_t, gmp_int>::type> : public mpl::int_<number_kind_integer>{};
-template<>
-struct number_category<detail::canonical<mpq_t, gmp_rational>::type> : public mpl::int_<number_kind_rational>{};
-template<>
-struct number_category<detail::canonical<mpf_t, gmp_float<0> >::type> : public mpl::int_<number_kind_floating_point>{};
+template <>
+struct number_category<detail::canonical<mpz_t, gmp_int>::type> : public mpl::int_<number_kind_integer>
+{};
+template <>
+struct number_category<detail::canonical<mpq_t, gmp_rational>::type> : public mpl::int_<number_kind_rational>
+{};
+template <>
+struct number_category<detail::canonical<mpf_t, gmp_float<0> >::type> : public mpl::int_<number_kind_floating_point>
+{};
 
-namespace detail
+namespace detail {
+template <>
+struct is_variable_precision<backends::gmp_float<0> > : public true_type
+{};
+} // namespace detail
+
+typedef number<gmp_float<50> >   mpf_float_50;
+typedef number<gmp_float<100> >  mpf_float_100;
+typedef number<gmp_float<500> >  mpf_float_500;
+typedef number<gmp_float<1000> > mpf_float_1000;
+typedef number<gmp_float<0> >    mpf_float;
+typedef number<gmp_int>          mpz_int;
+typedef number<gmp_rational>     mpq_rational;
+
+} // namespace multiprecision
+
+namespace math { namespace tools {
+
+template <>
+inline int digits<boost::multiprecision::mpf_float>()
+#ifdef BOOST_MATH_NOEXCEPT
+    BOOST_NOEXCEPT
+#endif
 {
-   template<>
-   struct is_variable_precision<backends::gmp_float<0> > : public true_type {};
+   return multiprecision::detail::digits10_2_2(boost::multiprecision::mpf_float::default_precision());
+}
+template <>
+inline int digits<boost::multiprecision::number<boost::multiprecision::gmp_float<0>, boost::multiprecision::et_off> >()
+#ifdef BOOST_MATH_NOEXCEPT
+    BOOST_NOEXCEPT
+#endif
+{
+   return multiprecision::detail::digits10_2_2(boost::multiprecision::mpf_float::default_precision());
 }
 
+template <>
+inline boost::multiprecision::mpf_float
+max_value<boost::multiprecision::mpf_float>()
+{
+   boost::multiprecision::mpf_float result(0.5);
+   mpf_mul_2exp(result.backend().data(), result.backend().data(), (std::numeric_limits<mp_exp_t>::max)() / 64 + 1);
+   return result;
+}
 
-typedef number<gmp_float<50> >    mpf_float_50;
-typedef number<gmp_float<100> >   mpf_float_100;
-typedef number<gmp_float<500> >   mpf_float_500;
-typedef number<gmp_float<1000> >  mpf_float_1000;
-typedef number<gmp_float<0> >     mpf_float;
-typedef number<gmp_int >         mpz_int;
-typedef number<gmp_rational >    mpq_rational;
+template <>
+inline boost::multiprecision::mpf_float
+min_value<boost::multiprecision::mpf_float>()
+{
+   boost::multiprecision::mpf_float result(0.5);
+   mpf_div_2exp(result.backend().data(), result.backend().data(), (std::numeric_limits<mp_exp_t>::min)() / 64 + 1);
+   return result;
+}
 
-}  // namespace multiprecision
+template <>
+inline boost::multiprecision::number<boost::multiprecision::gmp_float<0>, boost::multiprecision::et_off>
+max_value<boost::multiprecision::number<boost::multiprecision::gmp_float<0>, boost::multiprecision::et_off> >()
+{
+   boost::multiprecision::number<boost::multiprecision::gmp_float<0>, boost::multiprecision::et_off> result(0.5);
+   mpf_mul_2exp(result.backend().data(), result.backend().data(), (std::numeric_limits<mp_exp_t>::max)() / 64 + 1);
+   return result;
+}
 
-namespace math { namespace tools{
+template <>
+inline boost::multiprecision::number<boost::multiprecision::gmp_float<0>, boost::multiprecision::et_off>
+min_value<boost::multiprecision::number<boost::multiprecision::gmp_float<0>, boost::multiprecision::et_off> >()
+{
+   boost::multiprecision::number<boost::multiprecision::gmp_float<0>, boost::multiprecision::et_off> result(0.5);
+   mpf_div_2exp(result.backend().data(), result.backend().data(), (std::numeric_limits<mp_exp_t>::max)() / 64 + 1);
+   return result;
+}
 
-   template <>
-   inline int digits<boost::multiprecision::mpf_float>()
+template <>
+inline int digits<boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpf_float::backend_type> > >()
 #ifdef BOOST_MATH_NOEXCEPT
-      BOOST_NOEXCEPT
+    BOOST_NOEXCEPT
 #endif
-   {
-      return multiprecision::detail::digits10_2_2(boost::multiprecision::mpf_float::default_precision());
-   }
-   template <>
-   inline int digits<boost::multiprecision::number<boost::multiprecision::gmp_float<0>, boost::multiprecision::et_off> >()
+{
+   return multiprecision::detail::digits10_2_2(boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpf_float::backend_type> >::default_precision());
+}
+template <>
+inline int digits<boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::gmp_float<0> >, boost::multiprecision::et_off> >()
 #ifdef BOOST_MATH_NOEXCEPT
-      BOOST_NOEXCEPT
+    BOOST_NOEXCEPT
 #endif
-   {
-      return multiprecision::detail::digits10_2_2(boost::multiprecision::mpf_float::default_precision());
-   }
+{
+   return multiprecision::detail::digits10_2_2(boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpf_float::backend_type> >::default_precision());
+}
 
-   template <>
-   inline boost::multiprecision::mpf_float
-      max_value<boost::multiprecision::mpf_float>()
-   {
-      boost::multiprecision::mpf_float result(0.5);
-      mpf_mul_2exp(result.backend().data(), result.backend().data(), (std::numeric_limits<mp_exp_t>::max)() / 64 + 1);
-      return result;
-   }
+template <>
+inline boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpf_float::backend_type> >
+max_value<boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpf_float::backend_type> > >()
+{
+   return max_value<boost::multiprecision::mpf_float>().backend();
+}
 
-   template <>
-   inline boost::multiprecision::mpf_float
-      min_value<boost::multiprecision::mpf_float>()
-   {
-      boost::multiprecision::mpf_float result(0.5);
-      mpf_div_2exp(result.backend().data(), result.backend().data(), (std::numeric_limits<mp_exp_t>::min)() / 64 + 1);
-      return result;
-   }
+template <>
+inline boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpf_float::backend_type> >
+min_value<boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpf_float::backend_type> > >()
+{
+   return min_value<boost::multiprecision::mpf_float>().backend();
+}
 
-   template <>
-   inline boost::multiprecision::number<boost::multiprecision::gmp_float<0>, boost::multiprecision::et_off>
-      max_value<boost::multiprecision::number<boost::multiprecision::gmp_float<0>, boost::multiprecision::et_off> >()
-   {
-      boost::multiprecision::number<boost::multiprecision::gmp_float<0>, boost::multiprecision::et_off> result(0.5);
-      mpf_mul_2exp(result.backend().data(), result.backend().data(), (std::numeric_limits<mp_exp_t>::max)() / 64 + 1);
-      return result;
-   }
+template <>
+inline boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::gmp_float<0> >, boost::multiprecision::et_off>
+max_value<boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::gmp_float<0> >, boost::multiprecision::et_off> >()
+{
+   return max_value<boost::multiprecision::mpf_float>().backend();
+}
 
-   template <>
-   inline boost::multiprecision::number<boost::multiprecision::gmp_float<0>, boost::multiprecision::et_off>
-      min_value<boost::multiprecision::number<boost::multiprecision::gmp_float<0>, boost::multiprecision::et_off> >()
-   {
-      boost::multiprecision::number<boost::multiprecision::gmp_float<0>, boost::multiprecision::et_off> result(0.5);
-      mpf_div_2exp(result.backend().data(), result.backend().data(), (std::numeric_limits<mp_exp_t>::max)() / 64 + 1);
-      return result;
-   }
+template <>
+inline boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::gmp_float<0> >, boost::multiprecision::et_off>
+min_value<boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::gmp_float<0> >, boost::multiprecision::et_off> >()
+{
+   return min_value<boost::multiprecision::mpf_float>().backend();
+}
 
-   template <>
-   inline int digits<boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpf_float::backend_type> > >()
-#ifdef BOOST_MATH_NOEXCEPT
-      BOOST_NOEXCEPT
-#endif
-   {
-      return multiprecision::detail::digits10_2_2(boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpf_float::backend_type> >::default_precision());
-   }
-   template <>
-   inline int digits<boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::gmp_float<0> >, boost::multiprecision::et_off> >()
-#ifdef BOOST_MATH_NOEXCEPT
-      BOOST_NOEXCEPT
-#endif
-   {
-      return multiprecision::detail::digits10_2_2(boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpf_float::backend_type> >::default_precision());
-   }
+}} // namespace math::tools
 
-   template <>
-   inline boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpf_float::backend_type> >
-      max_value<boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpf_float::backend_type> > >()
-   {
-      return max_value<boost::multiprecision::mpf_float>().backend();
-   }
+} // namespace boost
 
-   template <>
-   inline boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpf_float::backend_type> >
-      min_value<boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpf_float::backend_type> > >()
-   {
-      return min_value<boost::multiprecision::mpf_float>().backend();
-   }
-
-   template <>
-   inline boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::gmp_float<0> >, boost::multiprecision::et_off>
-      max_value<boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::gmp_float<0> >, boost::multiprecision::et_off> >()
-   {
-      return max_value<boost::multiprecision::mpf_float>().backend();
-   }
-
-   template <>
-   inline boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::gmp_float<0> >, boost::multiprecision::et_off>
-      min_value<boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::gmp_float<0> >, boost::multiprecision::et_off> >()
-   {
-      return min_value<boost::multiprecision::mpf_float>().backend();
-   }
-
-
-}} // namespaces math::tools
-
-
-}  // namespace boost
-
-namespace std{
+namespace std {
 
 //
 // numeric_limits [partial] specializations for the types declared in this header:
 //
-template<unsigned Digits10, boost::multiprecision::expression_template_option ExpressionTemplates>
+template <unsigned Digits10, boost::multiprecision::expression_template_option ExpressionTemplates>
 class numeric_limits<boost::multiprecision::number<boost::multiprecision::gmp_float<Digits10>, ExpressionTemplates> >
 {
    typedef boost::multiprecision::number<boost::multiprecision::gmp_float<Digits10>, ExpressionTemplates> number_type;
-public:
+
+ public:
    BOOST_STATIC_CONSTEXPR bool is_specialized = true;
    //
    // min and max values chosen so as to not cause segfaults when calling
    // mpf_get_str on 64-bit Linux builds.  Possibly we could use larger
    // exponent values elsewhere.
    //
-   static number_type (min)()
+   static number_type(min)()
    {
       initializer.do_nothing();
       static std::pair<bool, number_type> value;
-      if(!value.first)
+      if (!value.first)
       {
-         value.first = true;
+         value.first  = true;
          value.second = 1;
          mpf_div_2exp(value.second.backend().data(), value.second.backend().data(), (std::numeric_limits<mp_exp_t>::max)() / 64 + 1);
       }
       return value.second;
    }
-   static number_type (max)()
+   static number_type(max)()
    {
       initializer.do_nothing();
       static std::pair<bool, number_type> value;
-      if(!value.first)
+      if (!value.first)
       {
-         value.first = true;
+         value.first  = true;
          value.second = 1;
          mpf_mul_2exp(value.second.backend().data(), value.second.backend().data(), (std::numeric_limits<mp_exp_t>::max)() / 64 + 1);
       }
@@ -2554,21 +2572,21 @@ public:
    {
       return -(max)();
    }
-   BOOST_STATIC_CONSTEXPR int digits = static_cast<int>((Digits10 * 1000L) / 301L + ((Digits10 * 1000L) % 301L ? 2 : 1));
+   BOOST_STATIC_CONSTEXPR int digits   = static_cast<int>((Digits10 * 1000L) / 301L + ((Digits10 * 1000L) % 301L ? 2 : 1));
    BOOST_STATIC_CONSTEXPR int digits10 = Digits10;
    // Have to allow for a possible extra limb inside the gmp data structure:
-   BOOST_STATIC_CONSTEXPR int max_digits10 = Digits10 + 3 + ((GMP_LIMB_BITS * 301L) / 1000L);
-   BOOST_STATIC_CONSTEXPR bool is_signed = true;
-   BOOST_STATIC_CONSTEXPR bool is_integer = false;
-   BOOST_STATIC_CONSTEXPR bool is_exact = false;
-   BOOST_STATIC_CONSTEXPR int radix = 2;
-   static number_type epsilon()
+   BOOST_STATIC_CONSTEXPR int  max_digits10 = Digits10 + 3 + ((GMP_LIMB_BITS * 301L) / 1000L);
+   BOOST_STATIC_CONSTEXPR bool is_signed    = true;
+   BOOST_STATIC_CONSTEXPR bool is_integer   = false;
+   BOOST_STATIC_CONSTEXPR bool is_exact     = false;
+   BOOST_STATIC_CONSTEXPR int  radix        = 2;
+   static number_type          epsilon()
    {
       initializer.do_nothing();
       static std::pair<bool, number_type> value;
-      if(!value.first)
+      if (!value.first)
       {
-         value.first = true;
+         value.first  = true;
          value.second = 1;
          mpf_div_2exp(value.second.backend().data(), value.second.backend().data(), std::numeric_limits<number_type>::digits - 1);
       }
@@ -2580,34 +2598,34 @@ public:
       // returns epsilon/2
       initializer.do_nothing();
       static std::pair<bool, number_type> value;
-      if(!value.first)
+      if (!value.first)
       {
-         value.first = true;
+         value.first  = true;
          value.second = 1;
       }
       return value.second;
    }
-   BOOST_STATIC_CONSTEXPR long min_exponent = LONG_MIN;
-   BOOST_STATIC_CONSTEXPR long min_exponent10 = (LONG_MIN / 1000) * 301L;
-   BOOST_STATIC_CONSTEXPR long max_exponent = LONG_MAX;
-   BOOST_STATIC_CONSTEXPR long max_exponent10 = (LONG_MAX / 1000) * 301L;
-   BOOST_STATIC_CONSTEXPR bool has_infinity = false;
-   BOOST_STATIC_CONSTEXPR bool has_quiet_NaN = false;
-   BOOST_STATIC_CONSTEXPR bool has_signaling_NaN = false;
-   BOOST_STATIC_CONSTEXPR float_denorm_style has_denorm = denorm_absent;
-   BOOST_STATIC_CONSTEXPR bool has_denorm_loss = false;
+   BOOST_STATIC_CONSTEXPR long min_exponent                  = LONG_MIN;
+   BOOST_STATIC_CONSTEXPR long min_exponent10                = (LONG_MIN / 1000) * 301L;
+   BOOST_STATIC_CONSTEXPR long max_exponent                  = LONG_MAX;
+   BOOST_STATIC_CONSTEXPR long max_exponent10                = (LONG_MAX / 1000) * 301L;
+   BOOST_STATIC_CONSTEXPR bool has_infinity                  = false;
+   BOOST_STATIC_CONSTEXPR bool has_quiet_NaN                 = false;
+   BOOST_STATIC_CONSTEXPR bool has_signaling_NaN             = false;
+   BOOST_STATIC_CONSTEXPR float_denorm_style has_denorm      = denorm_absent;
+   BOOST_STATIC_CONSTEXPR bool               has_denorm_loss = false;
    BOOST_STATIC_CONSTEXPR number_type infinity() { return number_type(); }
    BOOST_STATIC_CONSTEXPR number_type quiet_NaN() { return number_type(); }
    BOOST_STATIC_CONSTEXPR number_type signaling_NaN() { return number_type(); }
    BOOST_STATIC_CONSTEXPR number_type denorm_min() { return number_type(); }
-   BOOST_STATIC_CONSTEXPR bool is_iec559 = false;
-   BOOST_STATIC_CONSTEXPR bool is_bounded = true;
-   BOOST_STATIC_CONSTEXPR bool is_modulo = false;
-   BOOST_STATIC_CONSTEXPR bool traps = true;
-   BOOST_STATIC_CONSTEXPR bool tinyness_before = false;
+   BOOST_STATIC_CONSTEXPR bool        is_iec559         = false;
+   BOOST_STATIC_CONSTEXPR bool        is_bounded        = true;
+   BOOST_STATIC_CONSTEXPR bool        is_modulo         = false;
+   BOOST_STATIC_CONSTEXPR bool        traps             = true;
+   BOOST_STATIC_CONSTEXPR bool        tinyness_before   = false;
    BOOST_STATIC_CONSTEXPR float_round_style round_style = round_indeterminate;
 
-private:
+ private:
    struct data_initializer
    {
       data_initializer()
@@ -2617,12 +2635,12 @@ private:
          (std::numeric_limits<boost::multiprecision::number<boost::multiprecision::gmp_float<digits10> > >::min)();
          (std::numeric_limits<boost::multiprecision::number<boost::multiprecision::gmp_float<digits10> > >::max)();
       }
-      void do_nothing()const{}
+      void do_nothing() const {}
    };
    static const data_initializer initializer;
 };
 
-template<unsigned Digits10, boost::multiprecision::expression_template_option ExpressionTemplates>
+template <unsigned Digits10, boost::multiprecision::expression_template_option ExpressionTemplates>
 const typename numeric_limits<boost::multiprecision::number<boost::multiprecision::gmp_float<Digits10>, ExpressionTemplates> >::data_initializer numeric_limits<boost::multiprecision::number<boost::multiprecision::gmp_float<Digits10>, ExpressionTemplates> >::initializer;
 
 #ifndef BOOST_NO_INCLASS_MEMBER_INITIALIZATION
@@ -2674,43 +2692,44 @@ BOOST_CONSTEXPR_OR_CONST float_round_style numeric_limits<boost::multiprecision:
 
 #endif
 
-template<boost::multiprecision::expression_template_option ExpressionTemplates>
+template <boost::multiprecision::expression_template_option ExpressionTemplates>
 class numeric_limits<boost::multiprecision::number<boost::multiprecision::gmp_float<0>, ExpressionTemplates> >
 {
    typedef boost::multiprecision::number<boost::multiprecision::gmp_float<0>, ExpressionTemplates> number_type;
-public:
+
+ public:
    BOOST_STATIC_CONSTEXPR bool is_specialized = false;
-   static number_type (min)() { return number_type(); }
-   static number_type (max)() { return number_type(); }
-   static number_type lowest() { return number_type(); }
-   BOOST_STATIC_CONSTEXPR int digits = 0;
-   BOOST_STATIC_CONSTEXPR int digits10 = 0;
-   BOOST_STATIC_CONSTEXPR int max_digits10 = 0;
-   BOOST_STATIC_CONSTEXPR bool is_signed = false;
-   BOOST_STATIC_CONSTEXPR bool is_integer = false;
-   BOOST_STATIC_CONSTEXPR bool is_exact = false;
-   BOOST_STATIC_CONSTEXPR int radix = 0;
-   static number_type epsilon() { return number_type(); }
-   static number_type round_error() { return number_type(); }
-   BOOST_STATIC_CONSTEXPR int min_exponent = 0;
-   BOOST_STATIC_CONSTEXPR int min_exponent10 = 0;
-   BOOST_STATIC_CONSTEXPR int max_exponent = 0;
-   BOOST_STATIC_CONSTEXPR int max_exponent10 = 0;
-   BOOST_STATIC_CONSTEXPR bool has_infinity = false;
-   BOOST_STATIC_CONSTEXPR bool has_quiet_NaN = false;
-   BOOST_STATIC_CONSTEXPR bool has_signaling_NaN = false;
-   BOOST_STATIC_CONSTEXPR float_denorm_style has_denorm = denorm_absent;
-   BOOST_STATIC_CONSTEXPR bool has_denorm_loss = false;
-   static number_type infinity() { return number_type(); }
-   static number_type quiet_NaN() { return number_type(); }
-   static number_type signaling_NaN() { return number_type(); }
-   static number_type denorm_min() { return number_type(); }
-   BOOST_STATIC_CONSTEXPR bool is_iec559 = false;
-   BOOST_STATIC_CONSTEXPR bool is_bounded = false;
-   BOOST_STATIC_CONSTEXPR bool is_modulo = false;
-   BOOST_STATIC_CONSTEXPR bool traps = false;
-   BOOST_STATIC_CONSTEXPR bool tinyness_before = false;
-   BOOST_STATIC_CONSTEXPR float_round_style round_style = round_indeterminate;
+   static number_type(min)() { return number_type(); }
+   static number_type(max)() { return number_type(); }
+   static number_type          lowest() { return number_type(); }
+   BOOST_STATIC_CONSTEXPR int  digits       = 0;
+   BOOST_STATIC_CONSTEXPR int  digits10     = 0;
+   BOOST_STATIC_CONSTEXPR int  max_digits10 = 0;
+   BOOST_STATIC_CONSTEXPR bool is_signed    = false;
+   BOOST_STATIC_CONSTEXPR bool is_integer   = false;
+   BOOST_STATIC_CONSTEXPR bool is_exact     = false;
+   BOOST_STATIC_CONSTEXPR int  radix        = 0;
+   static number_type          epsilon() { return number_type(); }
+   static number_type          round_error() { return number_type(); }
+   BOOST_STATIC_CONSTEXPR int  min_exponent                  = 0;
+   BOOST_STATIC_CONSTEXPR int  min_exponent10                = 0;
+   BOOST_STATIC_CONSTEXPR int  max_exponent                  = 0;
+   BOOST_STATIC_CONSTEXPR int  max_exponent10                = 0;
+   BOOST_STATIC_CONSTEXPR bool has_infinity                  = false;
+   BOOST_STATIC_CONSTEXPR bool has_quiet_NaN                 = false;
+   BOOST_STATIC_CONSTEXPR bool has_signaling_NaN             = false;
+   BOOST_STATIC_CONSTEXPR float_denorm_style has_denorm      = denorm_absent;
+   BOOST_STATIC_CONSTEXPR bool               has_denorm_loss = false;
+   static number_type                        infinity() { return number_type(); }
+   static number_type                        quiet_NaN() { return number_type(); }
+   static number_type                        signaling_NaN() { return number_type(); }
+   static number_type                        denorm_min() { return number_type(); }
+   BOOST_STATIC_CONSTEXPR bool               is_iec559       = false;
+   BOOST_STATIC_CONSTEXPR bool               is_bounded      = false;
+   BOOST_STATIC_CONSTEXPR bool               is_modulo       = false;
+   BOOST_STATIC_CONSTEXPR bool               traps           = false;
+   BOOST_STATIC_CONSTEXPR bool               tinyness_before = false;
+   BOOST_STATIC_CONSTEXPR float_round_style round_style      = round_indeterminate;
 };
 
 #ifndef BOOST_NO_INCLASS_MEMBER_INITIALIZATION
@@ -2762,53 +2781,54 @@ BOOST_CONSTEXPR_OR_CONST float_round_style numeric_limits<boost::multiprecision:
 
 #endif
 
-template<boost::multiprecision::expression_template_option ExpressionTemplates>
+template <boost::multiprecision::expression_template_option ExpressionTemplates>
 class numeric_limits<boost::multiprecision::number<boost::multiprecision::gmp_int, ExpressionTemplates> >
 {
    typedef boost::multiprecision::number<boost::multiprecision::gmp_int, ExpressionTemplates> number_type;
-public:
+
+ public:
    BOOST_STATIC_CONSTEXPR bool is_specialized = true;
    //
    // Largest and smallest numbers are bounded only by available memory, set
    // to zero:
    //
-   static number_type (min)()
+   static number_type(min)()
    {
       return number_type();
    }
-   static number_type (max)()
+   static number_type(max)()
    {
       return number_type();
    }
-   static number_type lowest() { return (min)(); }
-   BOOST_STATIC_CONSTEXPR int digits = INT_MAX;
-   BOOST_STATIC_CONSTEXPR int digits10 = (INT_MAX / 1000) * 301L;
-   BOOST_STATIC_CONSTEXPR int max_digits10 = digits10 + 3;
-   BOOST_STATIC_CONSTEXPR bool is_signed = true;
-   BOOST_STATIC_CONSTEXPR bool is_integer = true;
-   BOOST_STATIC_CONSTEXPR bool is_exact = true;
-   BOOST_STATIC_CONSTEXPR int radix = 2;
-   static number_type epsilon() { return number_type(); }
-   static number_type round_error() { return number_type(); }
-   BOOST_STATIC_CONSTEXPR int min_exponent = 0;
-   BOOST_STATIC_CONSTEXPR int min_exponent10 = 0;
-   BOOST_STATIC_CONSTEXPR int max_exponent = 0;
-   BOOST_STATIC_CONSTEXPR int max_exponent10 = 0;
-   BOOST_STATIC_CONSTEXPR bool has_infinity = false;
-   BOOST_STATIC_CONSTEXPR bool has_quiet_NaN = false;
-   BOOST_STATIC_CONSTEXPR bool has_signaling_NaN = false;
-   BOOST_STATIC_CONSTEXPR float_denorm_style has_denorm = denorm_absent;
-   BOOST_STATIC_CONSTEXPR bool has_denorm_loss = false;
-   static number_type infinity() { return number_type(); }
-   static number_type quiet_NaN() { return number_type(); }
-   static number_type signaling_NaN() { return number_type(); }
-   static number_type denorm_min() { return number_type(); }
-   BOOST_STATIC_CONSTEXPR bool is_iec559 = false;
-   BOOST_STATIC_CONSTEXPR bool is_bounded = false;
-   BOOST_STATIC_CONSTEXPR bool is_modulo = false;
-   BOOST_STATIC_CONSTEXPR bool traps = false;
-   BOOST_STATIC_CONSTEXPR bool tinyness_before = false;
-   BOOST_STATIC_CONSTEXPR float_round_style round_style = round_toward_zero;
+   static number_type          lowest() { return (min)(); }
+   BOOST_STATIC_CONSTEXPR int  digits       = INT_MAX;
+   BOOST_STATIC_CONSTEXPR int  digits10     = (INT_MAX / 1000) * 301L;
+   BOOST_STATIC_CONSTEXPR int  max_digits10 = digits10 + 3;
+   BOOST_STATIC_CONSTEXPR bool is_signed    = true;
+   BOOST_STATIC_CONSTEXPR bool is_integer   = true;
+   BOOST_STATIC_CONSTEXPR bool is_exact     = true;
+   BOOST_STATIC_CONSTEXPR int  radix        = 2;
+   static number_type          epsilon() { return number_type(); }
+   static number_type          round_error() { return number_type(); }
+   BOOST_STATIC_CONSTEXPR int  min_exponent                  = 0;
+   BOOST_STATIC_CONSTEXPR int  min_exponent10                = 0;
+   BOOST_STATIC_CONSTEXPR int  max_exponent                  = 0;
+   BOOST_STATIC_CONSTEXPR int  max_exponent10                = 0;
+   BOOST_STATIC_CONSTEXPR bool has_infinity                  = false;
+   BOOST_STATIC_CONSTEXPR bool has_quiet_NaN                 = false;
+   BOOST_STATIC_CONSTEXPR bool has_signaling_NaN             = false;
+   BOOST_STATIC_CONSTEXPR float_denorm_style has_denorm      = denorm_absent;
+   BOOST_STATIC_CONSTEXPR bool               has_denorm_loss = false;
+   static number_type                        infinity() { return number_type(); }
+   static number_type                        quiet_NaN() { return number_type(); }
+   static number_type                        signaling_NaN() { return number_type(); }
+   static number_type                        denorm_min() { return number_type(); }
+   BOOST_STATIC_CONSTEXPR bool               is_iec559       = false;
+   BOOST_STATIC_CONSTEXPR bool               is_bounded      = false;
+   BOOST_STATIC_CONSTEXPR bool               is_modulo       = false;
+   BOOST_STATIC_CONSTEXPR bool               traps           = false;
+   BOOST_STATIC_CONSTEXPR bool               tinyness_before = false;
+   BOOST_STATIC_CONSTEXPR float_round_style round_style      = round_toward_zero;
 };
 
 #ifndef BOOST_NO_INCLASS_MEMBER_INITIALIZATION
@@ -2860,54 +2880,55 @@ BOOST_CONSTEXPR_OR_CONST float_round_style numeric_limits<boost::multiprecision:
 
 #endif
 
-template<boost::multiprecision::expression_template_option ExpressionTemplates>
+template <boost::multiprecision::expression_template_option ExpressionTemplates>
 class numeric_limits<boost::multiprecision::number<boost::multiprecision::gmp_rational, ExpressionTemplates> >
 {
    typedef boost::multiprecision::number<boost::multiprecision::gmp_rational, ExpressionTemplates> number_type;
-public:
+
+ public:
    BOOST_STATIC_CONSTEXPR bool is_specialized = true;
    //
    // Largest and smallest numbers are bounded only by available memory, set
    // to zero:
    //
-   static number_type (min)()
+   static number_type(min)()
    {
       return number_type();
    }
-   static number_type (max)()
+   static number_type(max)()
    {
       return number_type();
    }
    static number_type lowest() { return (min)(); }
    // Digits are unbounded, use zero for now:
-   BOOST_STATIC_CONSTEXPR int digits = INT_MAX;
-   BOOST_STATIC_CONSTEXPR int digits10 = (INT_MAX / 1000) * 301L;
-   BOOST_STATIC_CONSTEXPR int max_digits10 = digits10 + 3;
-   BOOST_STATIC_CONSTEXPR bool is_signed = true;
-   BOOST_STATIC_CONSTEXPR bool is_integer = false;
-   BOOST_STATIC_CONSTEXPR bool is_exact = true;
-   BOOST_STATIC_CONSTEXPR int radix = 2;
-   static number_type epsilon() { return number_type(); }
-   static number_type round_error() { return number_type(); }
-   BOOST_STATIC_CONSTEXPR int min_exponent = 0;
-   BOOST_STATIC_CONSTEXPR int min_exponent10 = 0;
-   BOOST_STATIC_CONSTEXPR int max_exponent = 0;
-   BOOST_STATIC_CONSTEXPR int max_exponent10 = 0;
-   BOOST_STATIC_CONSTEXPR bool has_infinity = false;
-   BOOST_STATIC_CONSTEXPR bool has_quiet_NaN = false;
-   BOOST_STATIC_CONSTEXPR bool has_signaling_NaN = false;
-   BOOST_STATIC_CONSTEXPR float_denorm_style has_denorm = denorm_absent;
-   BOOST_STATIC_CONSTEXPR bool has_denorm_loss = false;
-   static number_type infinity() { return number_type(); }
-   static number_type quiet_NaN() { return number_type(); }
-   static number_type signaling_NaN() { return number_type(); }
-   static number_type denorm_min() { return number_type(); }
-   BOOST_STATIC_CONSTEXPR bool is_iec559 = false;
-   BOOST_STATIC_CONSTEXPR bool is_bounded = false;
-   BOOST_STATIC_CONSTEXPR bool is_modulo = false;
-   BOOST_STATIC_CONSTEXPR bool traps = false;
-   BOOST_STATIC_CONSTEXPR bool tinyness_before = false;
-   BOOST_STATIC_CONSTEXPR float_round_style round_style = round_toward_zero;
+   BOOST_STATIC_CONSTEXPR int  digits       = INT_MAX;
+   BOOST_STATIC_CONSTEXPR int  digits10     = (INT_MAX / 1000) * 301L;
+   BOOST_STATIC_CONSTEXPR int  max_digits10 = digits10 + 3;
+   BOOST_STATIC_CONSTEXPR bool is_signed    = true;
+   BOOST_STATIC_CONSTEXPR bool is_integer   = false;
+   BOOST_STATIC_CONSTEXPR bool is_exact     = true;
+   BOOST_STATIC_CONSTEXPR int  radix        = 2;
+   static number_type          epsilon() { return number_type(); }
+   static number_type          round_error() { return number_type(); }
+   BOOST_STATIC_CONSTEXPR int  min_exponent                  = 0;
+   BOOST_STATIC_CONSTEXPR int  min_exponent10                = 0;
+   BOOST_STATIC_CONSTEXPR int  max_exponent                  = 0;
+   BOOST_STATIC_CONSTEXPR int  max_exponent10                = 0;
+   BOOST_STATIC_CONSTEXPR bool has_infinity                  = false;
+   BOOST_STATIC_CONSTEXPR bool has_quiet_NaN                 = false;
+   BOOST_STATIC_CONSTEXPR bool has_signaling_NaN             = false;
+   BOOST_STATIC_CONSTEXPR float_denorm_style has_denorm      = denorm_absent;
+   BOOST_STATIC_CONSTEXPR bool               has_denorm_loss = false;
+   static number_type                        infinity() { return number_type(); }
+   static number_type                        quiet_NaN() { return number_type(); }
+   static number_type                        signaling_NaN() { return number_type(); }
+   static number_type                        denorm_min() { return number_type(); }
+   BOOST_STATIC_CONSTEXPR bool               is_iec559       = false;
+   BOOST_STATIC_CONSTEXPR bool               is_bounded      = false;
+   BOOST_STATIC_CONSTEXPR bool               is_modulo       = false;
+   BOOST_STATIC_CONSTEXPR bool               traps           = false;
+   BOOST_STATIC_CONSTEXPR bool               tinyness_before = false;
+   BOOST_STATIC_CONSTEXPR float_round_style round_style      = round_toward_zero;
 };
 
 #ifndef BOOST_NO_INCLASS_MEMBER_INITIALIZATION

--- a/include/boost/multiprecision/mpfr.hpp
+++ b/include/boost/multiprecision/mpfr.hpp
@@ -6,23 +6,23 @@
 #ifndef BOOST_MATH_BN_MPFR_HPP
 #define BOOST_MATH_BN_MPFR_HPP
 
-#include <boost/multiprecision/number.hpp>
-#include <boost/multiprecision/debug_adaptor.hpp>
-#include <boost/multiprecision/gmp.hpp>
-#include <boost/math/special_functions/fpclassify.hpp>
+#include <algorithm>
 #include <boost/cstdint.hpp>
+#include <boost/math/special_functions/fpclassify.hpp>
+#include <boost/multiprecision/debug_adaptor.hpp>
 #include <boost/multiprecision/detail/big_lanczos.hpp>
 #include <boost/multiprecision/detail/digits.hpp>
-#include <mpfr.h>
+#include <boost/multiprecision/gmp.hpp>
+#include <boost/multiprecision/number.hpp>
 #include <cmath>
-#include <algorithm>
+#include <mpfr.h>
 
 #ifndef BOOST_MULTIPRECISION_MPFR_DEFAULT_PRECISION
-#  define BOOST_MULTIPRECISION_MPFR_DEFAULT_PRECISION 20
+#define BOOST_MULTIPRECISION_MPFR_DEFAULT_PRECISION 20
 #endif
 
-namespace boost{
-namespace multiprecision{
+namespace boost {
+namespace multiprecision {
 
 enum mpfr_allocation_type
 {
@@ -30,7 +30,7 @@ enum mpfr_allocation_type
    allocate_dynamic
 };
 
-namespace backends{
+namespace backends {
 
 template <unsigned digits10, mpfr_allocation_type AllocationType = allocate_dynamic>
 struct mpfr_float_backend;
@@ -41,11 +41,12 @@ struct mpfr_float_backend<0, allocate_stack>;
 } // namespace backends
 
 template <unsigned digits10, mpfr_allocation_type AllocationType>
-struct number_category<backends::mpfr_float_backend<digits10, AllocationType> > : public mpl::int_<number_kind_floating_point>{};
+struct number_category<backends::mpfr_float_backend<digits10, AllocationType> > : public mpl::int_<number_kind_floating_point>
+{};
 
-namespace backends{
+namespace backends {
 
-namespace detail{
+namespace detail {
 
 template <bool b>
 struct mpfr_cleanup
@@ -53,11 +54,11 @@ struct mpfr_cleanup
    struct initializer
    {
       initializer() {}
-      ~initializer(){ mpfr_free_cache(); }
-      void force_instantiate()const {}
+      ~initializer() { mpfr_free_cache(); }
+      void force_instantiate() const {}
    };
    static const initializer init;
-   static void force_instantiate() { init.force_instantiate(); }
+   static void              force_instantiate() { init.force_instantiate(); }
 };
 
 template <bool b>
@@ -66,7 +67,7 @@ typename mpfr_cleanup<b>::initializer const mpfr_cleanup<b>::init;
 inline void mpfr_copy_precision(mpfr_t dest, const mpfr_t src)
 {
    mpfr_prec_t p_dest = mpfr_get_prec(dest);
-   mpfr_prec_t p_src = mpfr_get_prec(src);
+   mpfr_prec_t p_src  = mpfr_get_prec(src);
    if (p_dest != p_src)
       mpfr_set_prec(dest, p_src);
 }
@@ -81,7 +82,6 @@ inline void mpfr_copy_precision(mpfr_t dest, const mpfr_t src1, const mpfr_t src
       mpfr_set_prec(dest, p_src1);
 }
 
-
 template <unsigned digits10, mpfr_allocation_type AllocationType>
 struct mpfr_float_imp;
 
@@ -89,14 +89,14 @@ template <unsigned digits10>
 struct mpfr_float_imp<digits10, allocate_dynamic>
 {
 #ifdef BOOST_HAS_LONG_LONG
-   typedef mpl::list<long, boost::long_long_type>                     signed_types;
-   typedef mpl::list<unsigned long, boost::ulong_long_type>   unsigned_types;
+   typedef mpl::list<long, boost::long_long_type>           signed_types;
+   typedef mpl::list<unsigned long, boost::ulong_long_type> unsigned_types;
 #else
-   typedef mpl::list<long>                                signed_types;
-   typedef mpl::list<unsigned long>                       unsigned_types;
+   typedef mpl::list<long>          signed_types;
+   typedef mpl::list<unsigned long> unsigned_types;
 #endif
-   typedef mpl::list<double, long double>                 float_types;
-   typedef long                                           exponent_type;
+   typedef mpl::list<double, long double> float_types;
+   typedef long                           exponent_type;
 
    mpfr_float_imp()
    {
@@ -109,22 +109,22 @@ struct mpfr_float_imp<digits10, allocate_dynamic>
       mpfr_set_ui(m_data, 0u, GMP_RNDN);
    }
 
-   mpfr_float_imp(const mpfr_float_imp& o)
+   mpfr_float_imp(const mpfr_float_imp &o)
    {
       mpfr_init2(m_data, mpfr_get_prec(o.m_data));
-      if(o.m_data[0]._mpfr_d)
+      if (o.m_data[0]._mpfr_d)
          mpfr_set(m_data, o.m_data, GMP_RNDN);
    }
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
-   mpfr_float_imp(mpfr_float_imp&& o) BOOST_NOEXCEPT
+   mpfr_float_imp(mpfr_float_imp &&o) BOOST_NOEXCEPT
    {
-      m_data[0] = o.m_data[0];
+      m_data[0]           = o.m_data[0];
       o.m_data[0]._mpfr_d = 0;
    }
 #endif
-   mpfr_float_imp& operator = (const mpfr_float_imp& o)
+   mpfr_float_imp &operator=(const mpfr_float_imp &o)
    {
-      if( (o.m_data[0]._mpfr_d) && (this != &o) )
+      if ((o.m_data[0]._mpfr_d) && (this != &o))
       {
          if (m_data[0]._mpfr_d == 0)
             mpfr_init2(m_data, mpfr_get_prec(o.m_data));
@@ -133,7 +133,7 @@ struct mpfr_float_imp<digits10, allocate_dynamic>
       return *this;
    }
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
-   mpfr_float_imp& operator = (mpfr_float_imp&& o) BOOST_NOEXCEPT
+   mpfr_float_imp &operator=(mpfr_float_imp &&o) BOOST_NOEXCEPT
    {
       mpfr_swap(m_data, o.m_data);
       return *this;
@@ -141,34 +141,34 @@ struct mpfr_float_imp<digits10, allocate_dynamic>
 #endif
 #ifdef BOOST_HAS_LONG_LONG
 #ifdef _MPFR_H_HAVE_INTMAX_T
-   mpfr_float_imp& operator = (boost::ulong_long_type i)
+   mpfr_float_imp &operator=(boost::ulong_long_type i)
    {
-      if(m_data[0]._mpfr_d == 0)
+      if (m_data[0]._mpfr_d == 0)
          mpfr_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : get_default_precision()));
       mpfr_set_uj(m_data, i, GMP_RNDN);
       return *this;
    }
-   mpfr_float_imp& operator = (boost::long_long_type i)
+   mpfr_float_imp &operator=(boost::long_long_type i)
    {
-      if(m_data[0]._mpfr_d == 0)
+      if (m_data[0]._mpfr_d == 0)
          mpfr_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : get_default_precision()));
       mpfr_set_sj(m_data, i, GMP_RNDN);
       return *this;
    }
 #else
-   mpfr_float_imp& operator = (boost::ulong_long_type i)
+   mpfr_float_imp &operator=(boost::ulong_long_type i)
    {
-      if(m_data[0]._mpfr_d == 0)
+      if (m_data[0]._mpfr_d == 0)
          mpfr_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : get_default_precision()));
-      boost::ulong_long_type mask = ((((1uLL << (std::numeric_limits<unsigned long>::digits - 1)) - 1) << 1) | 1uLL);
-      unsigned shift = 0;
-      mpfr_t t;
+      boost::ulong_long_type mask  = ((((1uLL << (std::numeric_limits<unsigned long>::digits - 1)) - 1) << 1) | 1uLL);
+      unsigned               shift = 0;
+      mpfr_t                 t;
       mpfr_init2(t, (std::max)(static_cast<unsigned long>(std::numeric_limits<boost::ulong_long_type>::digits), mpfr_get_prec(m_data)));
       mpfr_set_ui(m_data, 0, GMP_RNDN);
-      while(i)
+      while (i)
       {
          mpfr_set_ui(t, static_cast<unsigned long>(i & mask), GMP_RNDN);
-         if(shift)
+         if (shift)
             mpfr_mul_2exp(t, t, shift, GMP_RNDN);
          mpfr_add(m_data, m_data, t, GMP_RNDN);
          shift += std::numeric_limits<unsigned long>::digits;
@@ -177,61 +177,61 @@ struct mpfr_float_imp<digits10, allocate_dynamic>
       mpfr_clear(t);
       return *this;
    }
-   mpfr_float_imp& operator = (boost::long_long_type i)
+   mpfr_float_imp &operator=(boost::long_long_type i)
    {
-      if(m_data[0]._mpfr_d == 0)
+      if (m_data[0]._mpfr_d == 0)
          mpfr_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : get_default_precision()));
       bool neg = i < 0;
-      *this = boost::multiprecision::detail::unsigned_abs(i);
-      if(neg)
+      *this    = boost::multiprecision::detail::unsigned_abs(i);
+      if (neg)
          mpfr_neg(m_data, m_data, GMP_RNDN);
       return *this;
    }
 #endif
 #endif
-   mpfr_float_imp& operator = (unsigned long i)
+   mpfr_float_imp &operator=(unsigned long i)
    {
-      if(m_data[0]._mpfr_d == 0)
+      if (m_data[0]._mpfr_d == 0)
          mpfr_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : get_default_precision()));
       mpfr_set_ui(m_data, i, GMP_RNDN);
       return *this;
    }
-   mpfr_float_imp& operator = (long i)
+   mpfr_float_imp &operator=(long i)
    {
-      if(m_data[0]._mpfr_d == 0)
+      if (m_data[0]._mpfr_d == 0)
          mpfr_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : get_default_precision()));
       mpfr_set_si(m_data, i, GMP_RNDN);
       return *this;
    }
-   mpfr_float_imp& operator = (double d)
+   mpfr_float_imp &operator=(double d)
    {
-      if(m_data[0]._mpfr_d == 0)
+      if (m_data[0]._mpfr_d == 0)
          mpfr_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : get_default_precision()));
       mpfr_set_d(m_data, d, GMP_RNDN);
       return *this;
    }
-   mpfr_float_imp& operator = (long double a)
+   mpfr_float_imp &operator=(long double a)
    {
-      if(m_data[0]._mpfr_d == 0)
+      if (m_data[0]._mpfr_d == 0)
          mpfr_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : get_default_precision()));
       mpfr_set_ld(m_data, a, GMP_RNDN);
       return *this;
    }
-   mpfr_float_imp& operator = (const char* s)
+   mpfr_float_imp &operator=(const char *s)
    {
-      if(m_data[0]._mpfr_d == 0)
+      if (m_data[0]._mpfr_d == 0)
          mpfr_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : get_default_precision()));
-      if(mpfr_set_str(m_data, s, 10, GMP_RNDN) != 0)
+      if (mpfr_set_str(m_data, s, 10, GMP_RNDN) != 0)
       {
          BOOST_THROW_EXCEPTION(std::runtime_error(std::string("Unable to parse string \"") + s + std::string("\"as a valid floating point number.")));
       }
       return *this;
    }
-   void swap(mpfr_float_imp& o) BOOST_NOEXCEPT
+   void swap(mpfr_float_imp &o) BOOST_NOEXCEPT
    {
       mpfr_swap(m_data, o.m_data);
    }
-   std::string str(std::streamsize digits, std::ios_base::fmtflags f)const
+   std::string str(std::streamsize digits, std::ios_base::fmtflags f) const
    {
       BOOST_ASSERT(m_data[0]._mpfr_d);
 
@@ -240,89 +240,89 @@ struct mpfr_float_imp<digits10, allocate_dynamic>
 
       std::streamsize org_digits(digits);
 
-      if(scientific && digits)
+      if (scientific && digits)
          ++digits;
 
       std::string result;
-      mp_exp_t e;
-      if(mpfr_inf_p(m_data))
+      mp_exp_t    e;
+      if (mpfr_inf_p(m_data))
       {
-         if(mpfr_sgn(m_data) < 0)
+         if (mpfr_sgn(m_data) < 0)
             result = "-inf";
-         else if(f & std::ios_base::showpos)
+         else if (f & std::ios_base::showpos)
             result = "+inf";
          else
             result = "inf";
          return result;
       }
-      if(mpfr_nan_p(m_data))
+      if (mpfr_nan_p(m_data))
       {
          result = "nan";
          return result;
       }
-      if(mpfr_zero_p(m_data))
+      if (mpfr_zero_p(m_data))
       {
-         e = 0;
+         e      = 0;
          result = "0";
       }
       else
       {
-         char* ps = mpfr_get_str (0, &e, 10, static_cast<std::size_t>(digits), m_data, GMP_RNDN);
-        --e;  // To match with what our formatter expects.
-         if(fixed && e != -1)
+         char *ps = mpfr_get_str(0, &e, 10, static_cast<std::size_t>(digits), m_data, GMP_RNDN);
+         --e; // To match with what our formatter expects.
+         if (fixed && e != -1)
          {
             // Oops we actually need a different number of digits to what we asked for:
             mpfr_free_str(ps);
             digits += e + 1;
-            if(digits == 0)
+            if (digits == 0)
             {
                // We need to get *all* the digits and then possibly round up,
                // we end up with either "0" or "1" as the result.
-               ps = mpfr_get_str (0, &e, 10, 0, m_data, GMP_RNDN);
+               ps = mpfr_get_str(0, &e, 10, 0, m_data, GMP_RNDN);
                --e;
                unsigned offset = *ps == '-' ? 1 : 0;
-               if(ps[offset] > '5')
+               if (ps[offset] > '5')
                {
                   ++e;
-                  ps[offset] = '1';
+                  ps[offset]     = '1';
                   ps[offset + 1] = 0;
                }
-               else if(ps[offset] == '5')
+               else if (ps[offset] == '5')
                {
-                  unsigned i = offset + 1;
-                  bool round_up = false;
-                  while(ps[i] != 0)
+                  unsigned i        = offset + 1;
+                  bool     round_up = false;
+                  while (ps[i] != 0)
                   {
-                     if(ps[i] != '0')
+                     if (ps[i] != '0')
                      {
                         round_up = true;
                         break;
                      }
                      ++i;
                   }
-                  if(round_up)
+                  if (round_up)
                   {
                      ++e;
-                     ps[offset] = '1';
+                     ps[offset]     = '1';
                      ps[offset + 1] = 0;
                   }
                   else
                   {
-                     ps[offset] = '0';
+                     ps[offset]     = '0';
                      ps[offset + 1] = 0;
                   }
                }
                else
                {
-                  ps[offset] = '0';
+                  ps[offset]     = '0';
                   ps[offset + 1] = 0;
                }
             }
-            else if(digits > 0)
+            else if (digits > 0)
             {
                mp_exp_t old_e = e;
-               ps = mpfr_get_str (0, &e, 10, static_cast<std::size_t>(digits), m_data, GMP_RNDN);
-               --e;  // To match with what our formatter expects.
+               ps             = mpfr_get_str(0, &e, 10, static_cast<std::size_t>(digits), m_data, GMP_RNDN);
+               --e; // To match with what our formatter expects.
                if (old_e > e)
                {
                   // in some cases, when we ask for more digits of precision, it will
@@ -331,20 +331,20 @@ struct mpfr_float_imp<digits10, allocate_dynamic>
                   // example: cout << fixed << setprecision(3) << mpf_float_50("99.9809")
                   digits -= old_e - e;
                   ps = mpfr_get_str(0, &e, 10, static_cast<std::size_t>(digits), m_data, GMP_RNDN);
-                  --e;  // To match with what our formatter expects.
+                  --e; // To match with what our formatter expects.
                }
             }
             else
             {
-               ps = mpfr_get_str (0, &e, 10, 1, m_data, GMP_RNDN);
+               ps = mpfr_get_str(0, &e, 10, 1, m_data, GMP_RNDN);
                --e;
                unsigned offset = *ps == '-' ? 1 : 0;
-               ps[offset] = '0';
-               ps[offset + 1] = 0;
+               ps[offset]      = '0';
+               ps[offset + 1]  = 0;
             }
          }
          result = ps ? ps : "0";
-         if(ps)
+         if (ps)
             mpfr_free_str(ps);
       }
       boost::multiprecision::detail::format_float_string(result, e, org_digits, f, 0 != mpfr_zero_p(m_data));
@@ -352,7 +352,7 @@ struct mpfr_float_imp<digits10, allocate_dynamic>
    }
    ~mpfr_float_imp() BOOST_NOEXCEPT
    {
-       if(m_data[0]._mpfr_d)
+      if (m_data[0]._mpfr_d)
          mpfr_clear(m_data);
       detail::mpfr_cleanup<true>::force_instantiate();
    }
@@ -362,41 +362,42 @@ struct mpfr_float_imp<digits10, allocate_dynamic>
       mpfr_neg(m_data, m_data, GMP_RNDN);
    }
    template <mpfr_allocation_type AllocationType>
-   int compare(const mpfr_float_backend<digits10, AllocationType>& o)const BOOST_NOEXCEPT
+   int compare(const mpfr_float_backend<digits10, AllocationType> &o) const BOOST_NOEXCEPT
    {
       BOOST_ASSERT(m_data[0]._mpfr_d && o.m_data[0]._mpfr_d);
       return mpfr_cmp(m_data, o.m_data);
    }
-   int compare(long i)const BOOST_NOEXCEPT
+   int compare(long i) const BOOST_NOEXCEPT
    {
       BOOST_ASSERT(m_data[0]._mpfr_d);
       return mpfr_cmp_si(m_data, i);
    }
-   int compare(unsigned long i)const BOOST_NOEXCEPT
+   int compare(unsigned long i) const BOOST_NOEXCEPT
    {
       BOOST_ASSERT(m_data[0]._mpfr_d);
       return mpfr_cmp_ui(m_data, i);
    }
    template <class V>
-   int compare(V v)const BOOST_NOEXCEPT
+   int compare(V v) const BOOST_NOEXCEPT
    {
       mpfr_float_backend<digits10, allocate_dynamic> d(0uL, mpfr_get_prec(m_data));
       d = v;
       return compare(d);
    }
-   mpfr_t& data() BOOST_NOEXCEPT
+   mpfr_t &data() BOOST_NOEXCEPT
    {
       BOOST_ASSERT(m_data[0]._mpfr_d);
       return m_data;
    }
-   const mpfr_t& data()const BOOST_NOEXCEPT
+   const mpfr_t &data() const BOOST_NOEXCEPT
    {
       BOOST_ASSERT(m_data[0]._mpfr_d);
       return m_data;
    }
-protected:
-   mpfr_t m_data;
-   static unsigned& get_default_precision() BOOST_NOEXCEPT
+
+ protected:
+   mpfr_t           m_data;
+   static unsigned &get_default_precision() BOOST_NOEXCEPT
    {
       static unsigned val = BOOST_MULTIPRECISION_MPFR_DEFAULT_PRECISION;
       return val;
@@ -405,23 +406,23 @@ protected:
 
 #ifdef BOOST_MSVC
 #pragma warning(push)
-#pragma warning(disable:4127)  // Conditional expression is constant
+#pragma warning(disable : 4127) // Conditional expression is constant
 #endif
 
 template <unsigned digits10>
 struct mpfr_float_imp<digits10, allocate_stack>
 {
 #ifdef BOOST_HAS_LONG_LONG
-   typedef mpl::list<long, boost::long_long_type>                     signed_types;
-   typedef mpl::list<unsigned long, boost::ulong_long_type>   unsigned_types;
+   typedef mpl::list<long, boost::long_long_type>           signed_types;
+   typedef mpl::list<unsigned long, boost::ulong_long_type> unsigned_types;
 #else
-   typedef mpl::list<long>                                signed_types;
-   typedef mpl::list<unsigned long>                       unsigned_types;
+   typedef mpl::list<long>          signed_types;
+   typedef mpl::list<unsigned long> unsigned_types;
 #endif
-   typedef mpl::list<double, long double>                 float_types;
-   typedef long                                           exponent_type;
+   typedef mpl::list<double, long double> float_types;
+   typedef long                           exponent_type;
 
-   static const unsigned digits2 = (digits10 * 1000uL) / 301uL + ((digits10 * 1000uL) % 301 ? 2u : 1u);
+   static const unsigned digits2    = (digits10 * 1000uL) / 301uL + ((digits10 * 1000uL) % 301 ? 2u : 1u);
    static const unsigned limb_count = mpfr_custom_get_size(digits2) / sizeof(mp_limb_t);
 
    ~mpfr_float_imp() BOOST_NOEXCEPT
@@ -435,43 +436,43 @@ struct mpfr_float_imp<digits10, allocate_stack>
       mpfr_set_ui(m_data, 0u, GMP_RNDN);
    }
 
-   mpfr_float_imp(const mpfr_float_imp& o)
+   mpfr_float_imp(const mpfr_float_imp &o)
    {
       mpfr_custom_init(m_buffer, digits2);
       mpfr_custom_init_set(m_data, MPFR_NAN_KIND, 0, digits2, m_buffer);
       mpfr_set(m_data, o.m_data, GMP_RNDN);
    }
-   mpfr_float_imp& operator = (const mpfr_float_imp& o)
+   mpfr_float_imp &operator=(const mpfr_float_imp &o)
    {
       mpfr_set(m_data, o.m_data, GMP_RNDN);
       return *this;
    }
 #ifdef BOOST_HAS_LONG_LONG
 #ifdef _MPFR_H_HAVE_INTMAX_T
-   mpfr_float_imp& operator = (boost::ulong_long_type i)
+   mpfr_float_imp &operator=(boost::ulong_long_type i)
    {
       mpfr_set_uj(m_data, i, GMP_RNDN);
       return *this;
    }
-   mpfr_float_imp& operator = (boost::long_long_type i)
+   mpfr_float_imp &operator=(boost::long_long_type i)
    {
       mpfr_set_sj(m_data, i, GMP_RNDN);
       return *this;
    }
 #else
-   mpfr_float_imp& operator = (boost::ulong_long_type i)
+   mpfr_float_imp &operator=(boost::ulong_long_type i)
    {
-      boost::ulong_long_type mask = ((((1uLL << (std::numeric_limits<unsigned long>::digits - 1)) - 1) << 1) | 1uL);
-      unsigned shift = 0;
-      mpfr_t t;
-      mp_limb_t t_limbs[limb_count];
+      boost::ulong_long_type mask  = ((((1uLL << (std::numeric_limits<unsigned long>::digits - 1)) - 1) << 1) | 1uL);
+      unsigned               shift = 0;
+      mpfr_t                 t;
+      mp_limb_t              t_limbs[limb_count];
       mpfr_custom_init(t_limbs, digits2);
       mpfr_custom_init_set(t, MPFR_NAN_KIND, 0, digits2, t_limbs);
       mpfr_set_ui(m_data, 0, GMP_RNDN);
-      while(i)
+      while (i)
       {
          mpfr_set_ui(t, static_cast<unsigned long>(i & mask), GMP_RNDN);
-         if(shift)
+         if (shift)
             mpfr_mul_2exp(t, t, shift, GMP_RNDN);
          mpfr_add(m_data, m_data, t, GMP_RNDN);
          shift += std::numeric_limits<unsigned long>::digits;
@@ -479,52 +480,52 @@ struct mpfr_float_imp<digits10, allocate_stack>
       }
       return *this;
    }
-   mpfr_float_imp& operator = (boost::long_long_type i)
+   mpfr_float_imp &operator=(boost::long_long_type i)
    {
       bool neg = i < 0;
-      *this = boost::multiprecision::detail::unsigned_abs(i);
-      if(neg)
+      *this    = boost::multiprecision::detail::unsigned_abs(i);
+      if (neg)
          mpfr_neg(m_data, m_data, GMP_RNDN);
       return *this;
    }
 #endif
 #endif
-   mpfr_float_imp& operator = (unsigned long i)
+   mpfr_float_imp &operator=(unsigned long i)
    {
       mpfr_set_ui(m_data, i, GMP_RNDN);
       return *this;
    }
-   mpfr_float_imp& operator = (long i)
+   mpfr_float_imp &operator=(long i)
    {
       mpfr_set_si(m_data, i, GMP_RNDN);
       return *this;
    }
-   mpfr_float_imp& operator = (double d)
+   mpfr_float_imp &operator=(double d)
    {
       mpfr_set_d(m_data, d, GMP_RNDN);
       return *this;
    }
-   mpfr_float_imp& operator = (long double a)
+   mpfr_float_imp &operator=(long double a)
    {
       mpfr_set_ld(m_data, a, GMP_RNDN);
       return *this;
    }
-   mpfr_float_imp& operator = (const char* s)
+   mpfr_float_imp &operator=(const char *s)
    {
-      if(mpfr_set_str(m_data, s, 10, GMP_RNDN) != 0)
+      if (mpfr_set_str(m_data, s, 10, GMP_RNDN) != 0)
       {
          BOOST_THROW_EXCEPTION(std::runtime_error(std::string("Unable to parse string \"") + s + std::string("\"as a valid floating point number.")));
       }
       return *this;
    }
-   void swap(mpfr_float_imp& o) BOOST_NOEXCEPT
+   void swap(mpfr_float_imp &o) BOOST_NOEXCEPT
    {
       // We have to swap by copying:
       mpfr_float_imp t(*this);
       *this = o;
-      o = t;
+      o     = t;
    }
-   std::string str(std::streamsize digits, std::ios_base::fmtflags f)const
+   std::string str(std::streamsize digits, std::ios_base::fmtflags f) const
    {
       BOOST_ASSERT(m_data[0]._mpfr_d);
 
@@ -533,99 +534,99 @@ struct mpfr_float_imp<digits10, allocate_stack>
 
       std::streamsize org_digits(digits);
 
-      if(scientific && digits)
+      if (scientific && digits)
          ++digits;
 
       std::string result;
-      mp_exp_t e;
-      if(mpfr_inf_p(m_data))
+      mp_exp_t    e;
+      if (mpfr_inf_p(m_data))
       {
-         if(mpfr_sgn(m_data) < 0)
+         if (mpfr_sgn(m_data) < 0)
             result = "-inf";
-         else if(f & std::ios_base::showpos)
+         else if (f & std::ios_base::showpos)
             result = "+inf";
          else
             result = "inf";
          return result;
       }
-      if(mpfr_nan_p(m_data))
+      if (mpfr_nan_p(m_data))
       {
          result = "nan";
          return result;
       }
-      if(mpfr_zero_p(m_data))
+      if (mpfr_zero_p(m_data))
       {
-         e = 0;
+         e      = 0;
          result = "0";
       }
       else
       {
-         char* ps = mpfr_get_str (0, &e, 10, static_cast<std::size_t>(digits), m_data, GMP_RNDN);
-        --e;  // To match with what our formatter expects.
-         if(fixed && e != -1)
+         char *ps = mpfr_get_str(0, &e, 10, static_cast<std::size_t>(digits), m_data, GMP_RNDN);
+         --e; // To match with what our formatter expects.
+         if (fixed && e != -1)
          {
             // Oops we actually need a different number of digits to what we asked for:
             mpfr_free_str(ps);
             digits += e + 1;
-            if(digits == 0)
+            if (digits == 0)
             {
                // We need to get *all* the digits and then possibly round up,
                // we end up with either "0" or "1" as the result.
-               ps = mpfr_get_str (0, &e, 10, 0, m_data, GMP_RNDN);
+               ps = mpfr_get_str(0, &e, 10, 0, m_data, GMP_RNDN);
                --e;
                unsigned offset = *ps == '-' ? 1 : 0;
-               if(ps[offset] > '5')
+               if (ps[offset] > '5')
                {
                   ++e;
-                  ps[offset] = '1';
+                  ps[offset]     = '1';
                   ps[offset + 1] = 0;
                }
-               else if(ps[offset] == '5')
+               else if (ps[offset] == '5')
                {
-                  unsigned i = offset + 1;
-                  bool round_up = false;
-                  while(ps[i] != 0)
+                  unsigned i        = offset + 1;
+                  bool     round_up = false;
+                  while (ps[i] != 0)
                   {
-                     if(ps[i] != '0')
+                     if (ps[i] != '0')
                      {
                         round_up = true;
                         break;
                      }
                   }
-                  if(round_up)
+                  if (round_up)
                   {
                      ++e;
-                     ps[offset] = '1';
+                     ps[offset]     = '1';
                      ps[offset + 1] = 0;
                   }
                   else
                   {
-                     ps[offset] = '0';
+                     ps[offset]     = '0';
                      ps[offset + 1] = 0;
                   }
                }
                else
                {
-                  ps[offset] = '0';
+                  ps[offset]     = '0';
                   ps[offset + 1] = 0;
                }
             }
-            else if(digits > 0)
+            else if (digits > 0)
             {
-               ps = mpfr_get_str (0, &e, 10, static_cast<std::size_t>(digits), m_data, GMP_RNDN);
-               --e;  // To match with what our formatter expects.
+               ps = mpfr_get_str(0, &e, 10, static_cast<std::size_t>(digits), m_data, GMP_RNDN);
+               --e; // To match with what our formatter expects.
             }
             else
             {
-               ps = mpfr_get_str (0, &e, 10, 1, m_data, GMP_RNDN);
+               ps = mpfr_get_str(0, &e, 10, 1, m_data, GMP_RNDN);
                --e;
                unsigned offset = *ps == '-' ? 1 : 0;
-               ps[offset] = '0';
-               ps[offset + 1] = 0;
+               ps[offset]      = '0';
+               ps[offset + 1]  = 0;
             }
          }
          result = ps ? ps : "0";
-         if(ps)
+         if (ps)
             mpfr_free_str(ps);
       }
       boost::multiprecision::detail::format_float_string(result, e, org_digits, f, 0 != mpfr_zero_p(m_data));
@@ -636,35 +637,36 @@ struct mpfr_float_imp<digits10, allocate_stack>
       mpfr_neg(m_data, m_data, GMP_RNDN);
    }
    template <mpfr_allocation_type AllocationType>
-   int compare(const mpfr_float_backend<digits10, AllocationType>& o)const BOOST_NOEXCEPT
+   int compare(const mpfr_float_backend<digits10, AllocationType> &o) const BOOST_NOEXCEPT
    {
       return mpfr_cmp(m_data, o.m_data);
    }
-   int compare(long i)const BOOST_NOEXCEPT
+   int compare(long i) const BOOST_NOEXCEPT
    {
       return mpfr_cmp_si(m_data, i);
    }
-   int compare(unsigned long i)const BOOST_NOEXCEPT
+   int compare(unsigned long i) const BOOST_NOEXCEPT
    {
       return mpfr_cmp_ui(m_data, i);
    }
    template <class V>
-   int compare(V v)const BOOST_NOEXCEPT
+   int compare(V v) const BOOST_NOEXCEPT
    {
       mpfr_float_backend<digits10, allocate_stack> d;
       d = v;
       return compare(d);
    }
-   mpfr_t& data() BOOST_NOEXCEPT
+   mpfr_t &data() BOOST_NOEXCEPT
    {
       return m_data;
    }
-   const mpfr_t& data()const BOOST_NOEXCEPT
+   const mpfr_t &data() const BOOST_NOEXCEPT
    {
       return m_data;
    }
-protected:
-   mpfr_t m_data;
+
+ protected:
+   mpfr_t    m_data;
    mp_limb_t m_buffer[limb_count];
 };
 
@@ -678,40 +680,41 @@ template <unsigned digits10, mpfr_allocation_type AllocationType>
 struct mpfr_float_backend : public detail::mpfr_float_imp<digits10, AllocationType>
 {
    mpfr_float_backend() : detail::mpfr_float_imp<digits10, AllocationType>() {}
-   mpfr_float_backend(const mpfr_float_backend& o) : detail::mpfr_float_imp<digits10, AllocationType>(o) {}
+   mpfr_float_backend(const mpfr_float_backend &o) : detail::mpfr_float_imp<digits10, AllocationType>(o) {}
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
-   mpfr_float_backend(mpfr_float_backend&& o) BOOST_NOEXCEPT : detail::mpfr_float_imp<digits10, AllocationType>(static_cast<detail::mpfr_float_imp<digits10, AllocationType>&&>(o)) {}
+   mpfr_float_backend(mpfr_float_backend &&o) BOOST_NOEXCEPT : detail::mpfr_float_imp<digits10, AllocationType>(static_cast<detail::mpfr_float_imp<digits10, AllocationType> &&>(o))
+   {}
 #endif
    template <unsigned D, mpfr_allocation_type AT>
-   mpfr_float_backend(const mpfr_float_backend<D, AT>& val, typename enable_if_c<D <= digits10>::type* = 0)
+   mpfr_float_backend(const mpfr_float_backend<D, AT> &val, typename enable_if_c<D <= digits10>::type * = 0)
        : detail::mpfr_float_imp<digits10, AllocationType>()
    {
       mpfr_set(this->m_data, val.data(), GMP_RNDN);
    }
    template <unsigned D, mpfr_allocation_type AT>
-   explicit mpfr_float_backend(const mpfr_float_backend<D, AT>& val, typename disable_if_c<D <= digits10>::type* = 0)
+   explicit mpfr_float_backend(const mpfr_float_backend<D, AT> &val, typename disable_if_c<D <= digits10>::type * = 0)
        : detail::mpfr_float_imp<digits10, AllocationType>()
    {
       mpfr_set(this->m_data, val.data(), GMP_RNDN);
    }
    template <unsigned D>
-   mpfr_float_backend(const gmp_float<D>& val, typename enable_if_c<D <= digits10>::type* = 0)
+   mpfr_float_backend(const gmp_float<D> &val, typename enable_if_c<D <= digits10>::type * = 0)
        : detail::mpfr_float_imp<digits10, AllocationType>()
    {
       mpfr_set_f(this->m_data, val.data(), GMP_RNDN);
    }
    template <unsigned D>
-   mpfr_float_backend(const gmp_float<D>& val, typename disable_if_c<D <= digits10>::type* = 0)
+   mpfr_float_backend(const gmp_float<D> &val, typename disable_if_c<D <= digits10>::type * = 0)
        : detail::mpfr_float_imp<digits10, AllocationType>()
    {
       mpfr_set_f(this->m_data, val.data(), GMP_RNDN);
    }
-   mpfr_float_backend(const gmp_int& val)
+   mpfr_float_backend(const gmp_int &val)
        : detail::mpfr_float_imp<digits10, AllocationType>()
    {
       mpfr_set_z(this->m_data, val.data(), GMP_RNDN);
    }
-   mpfr_float_backend(const gmp_rational& val)
+   mpfr_float_backend(const gmp_rational &val)
        : detail::mpfr_float_imp<digits10, AllocationType>()
    {
       mpfr_set_q(this->m_data, val.data(), GMP_RNDN);
@@ -738,83 +741,83 @@ struct mpfr_float_backend : public detail::mpfr_float_imp<digits10, AllocationTy
    }
    // Construction with precision: we ignore the precision here.
    template <class V>
-   mpfr_float_backend(const V& o, unsigned)
+   mpfr_float_backend(const V &o, unsigned)
    {
       *this = o;
    }
-   mpfr_float_backend& operator=(const mpfr_float_backend& o)
+   mpfr_float_backend &operator=(const mpfr_float_backend &o)
    {
-      *static_cast<detail::mpfr_float_imp<digits10, AllocationType>*>(this) = static_cast<detail::mpfr_float_imp<digits10, AllocationType> const&>(o);
+      *static_cast<detail::mpfr_float_imp<digits10, AllocationType> *>(this) = static_cast<detail::mpfr_float_imp<digits10, AllocationType> const &>(o);
       return *this;
    }
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
-   mpfr_float_backend& operator=(mpfr_float_backend&& o) BOOST_NOEXCEPT
+   mpfr_float_backend &operator=(mpfr_float_backend &&o) BOOST_NOEXCEPT
    {
-      *static_cast<detail::mpfr_float_imp<digits10, AllocationType>*>(this) = static_cast<detail::mpfr_float_imp<digits10, AllocationType>&&>(o);
+      *static_cast<detail::mpfr_float_imp<digits10, AllocationType> *>(this) = static_cast<detail::mpfr_float_imp<digits10, AllocationType> &&>(o);
       return *this;
    }
 #endif
    template <class V>
-   mpfr_float_backend& operator=(const V& v)
+   mpfr_float_backend &operator=(const V &v)
    {
-      *static_cast<detail::mpfr_float_imp<digits10, AllocationType>*>(this) = v;
+      *static_cast<detail::mpfr_float_imp<digits10, AllocationType> *>(this) = v;
       return *this;
    }
-   mpfr_float_backend& operator=(const mpfr_t val)
+   mpfr_float_backend &operator=(const mpfr_t val)
    {
-      if(this->m_data[0]._mpfr_d == 0)
+      if (this->m_data[0]._mpfr_d == 0)
          mpfr_init2(this->m_data, multiprecision::detail::digits10_2_2(digits10));
       mpfr_set(this->m_data, val, GMP_RNDN);
       return *this;
    }
-   mpfr_float_backend& operator=(const mpf_t val)
+   mpfr_float_backend &operator=(const mpf_t val)
    {
-      if(this->m_data[0]._mpfr_d == 0)
+      if (this->m_data[0]._mpfr_d == 0)
          mpfr_init2(this->m_data, multiprecision::detail::digits10_2_2(digits10));
       mpfr_set_f(this->m_data, val, GMP_RNDN);
       return *this;
    }
-   mpfr_float_backend& operator=(const mpz_t val)
+   mpfr_float_backend &operator=(const mpz_t val)
    {
-      if(this->m_data[0]._mpfr_d == 0)
+      if (this->m_data[0]._mpfr_d == 0)
          mpfr_init2(this->m_data, multiprecision::detail::digits10_2_2(digits10));
       mpfr_set_z(this->m_data, val, GMP_RNDN);
       return *this;
    }
-   mpfr_float_backend& operator=(const mpq_t val)
+   mpfr_float_backend &operator=(const mpq_t val)
    {
-      if(this->m_data[0]._mpfr_d == 0)
+      if (this->m_data[0]._mpfr_d == 0)
          mpfr_init2(this->m_data, multiprecision::detail::digits10_2_2(digits10));
       mpfr_set_q(this->m_data, val, GMP_RNDN);
       return *this;
    }
    // We don't change our precision here, this is a fixed precision type:
    template <unsigned D, mpfr_allocation_type AT>
-   mpfr_float_backend& operator=(const mpfr_float_backend<D, AT>& val)
+   mpfr_float_backend &operator=(const mpfr_float_backend<D, AT> &val)
    {
-      if(this->m_data[0]._mpfr_d == 0)
+      if (this->m_data[0]._mpfr_d == 0)
          mpfr_init2(this->m_data, multiprecision::detail::digits10_2_2(digits10));
       mpfr_set(this->m_data, val.data(), GMP_RNDN);
       return *this;
    }
    template <unsigned D>
-   mpfr_float_backend& operator=(const gmp_float<D>& val)
+   mpfr_float_backend &operator=(const gmp_float<D> &val)
    {
-      if(this->m_data[0]._mpfr_d == 0)
+      if (this->m_data[0]._mpfr_d == 0)
          mpfr_init2(this->m_data, multiprecision::detail::digits10_2_2(digits10));
       mpfr_set_f(this->m_data, val.data(), GMP_RNDN);
       return *this;
    }
-   mpfr_float_backend& operator=(const gmp_int& val)
+   mpfr_float_backend &operator=(const gmp_int &val)
    {
-      if(this->m_data[0]._mpfr_d == 0)
+      if (this->m_data[0]._mpfr_d == 0)
          mpfr_init2(this->m_data, multiprecision::detail::digits10_2_2(digits10));
       mpfr_set_z(this->m_data, val.data(), GMP_RNDN);
       return *this;
    }
-   mpfr_float_backend& operator=(const gmp_rational& val)
+   mpfr_float_backend &operator=(const gmp_rational &val)
    {
-      if(this->m_data[0]._mpfr_d == 0)
+      if (this->m_data[0]._mpfr_d == 0)
          mpfr_init2(this->m_data, multiprecision::detail::digits10_2_2(digits10));
       mpfr_set_q(this->m_data, val.data(), GMP_RNDN);
       return *this;
@@ -826,81 +829,82 @@ struct mpfr_float_backend<0, allocate_dynamic> : public detail::mpfr_float_imp<0
 {
    mpfr_float_backend() : detail::mpfr_float_imp<0, allocate_dynamic>() {}
    mpfr_float_backend(const mpfr_t val)
-      : detail::mpfr_float_imp<0, allocate_dynamic>((unsigned)mpfr_get_prec(val))
+       : detail::mpfr_float_imp<0, allocate_dynamic>((unsigned)mpfr_get_prec(val))
    {
       mpfr_set(this->m_data, val, GMP_RNDN);
    }
    mpfr_float_backend(const mpf_t val)
-      : detail::mpfr_float_imp<0, allocate_dynamic>((unsigned)mpf_get_prec(val))
+       : detail::mpfr_float_imp<0, allocate_dynamic>((unsigned)mpf_get_prec(val))
    {
       mpfr_set_f(this->m_data, val, GMP_RNDN);
    }
    mpfr_float_backend(const mpz_t val)
-      : detail::mpfr_float_imp<0, allocate_dynamic>()
+       : detail::mpfr_float_imp<0, allocate_dynamic>()
    {
       mpfr_set_z(this->m_data, val, GMP_RNDN);
    }
    mpfr_float_backend(const mpq_t val)
-      : detail::mpfr_float_imp<0, allocate_dynamic>()
+       : detail::mpfr_float_imp<0, allocate_dynamic>()
    {
       mpfr_set_q(this->m_data, val, GMP_RNDN);
    }
-   mpfr_float_backend(const mpfr_float_backend& o) : detail::mpfr_float_imp<0, allocate_dynamic>(o) {}
+   mpfr_float_backend(const mpfr_float_backend &o) : detail::mpfr_float_imp<0, allocate_dynamic>(o) {}
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
-   mpfr_float_backend(mpfr_float_backend&& o) BOOST_NOEXCEPT : detail::mpfr_float_imp<0, allocate_dynamic>(static_cast<detail::mpfr_float_imp<0, allocate_dynamic>&&>(o)) {}
+   mpfr_float_backend(mpfr_float_backend &&o) BOOST_NOEXCEPT : detail::mpfr_float_imp<0, allocate_dynamic>(static_cast<detail::mpfr_float_imp<0, allocate_dynamic> &&>(o))
+   {}
 #endif
    template <class V>
-   mpfr_float_backend(const V& o, unsigned digits10)
-      : detail::mpfr_float_imp<0, allocate_dynamic>(multiprecision::detail::digits10_2_2(digits10))
+   mpfr_float_backend(const V &o, unsigned digits10)
+       : detail::mpfr_float_imp<0, allocate_dynamic>(multiprecision::detail::digits10_2_2(digits10))
    {
       *this = o;
    }
 #ifndef BOOST_NO_CXX17_HDR_STRING_VIEW
-   mpfr_float_backend(const std::string_view& o, unsigned digits10)
-      : detail::mpfr_float_imp<0, allocate_dynamic>(multiprecision::detail::digits10_2_2(digits10))
+   mpfr_float_backend(const std::string_view &o, unsigned digits10)
+       : detail::mpfr_float_imp<0, allocate_dynamic>(multiprecision::detail::digits10_2_2(digits10))
    {
       std::string s(o);
       *this = s.c_str();
    }
 #endif
    template <unsigned D>
-   mpfr_float_backend(const gmp_float<D>& val, unsigned digits10)
-      : detail::mpfr_float_imp<0, allocate_dynamic>(multiprecision::detail::digits10_2_2(digits10))
+   mpfr_float_backend(const gmp_float<D> &val, unsigned digits10)
+       : detail::mpfr_float_imp<0, allocate_dynamic>(multiprecision::detail::digits10_2_2(digits10))
    {
       mpfr_set_f(this->m_data, val.data(), GMP_RNDN);
    }
    template <unsigned D>
-   mpfr_float_backend(const mpfr_float_backend<D>& val, unsigned digits10)
-      : detail::mpfr_float_imp<0, allocate_dynamic>(multiprecision::detail::digits10_2_2(digits10))
+   mpfr_float_backend(const mpfr_float_backend<D> &val, unsigned digits10)
+       : detail::mpfr_float_imp<0, allocate_dynamic>(multiprecision::detail::digits10_2_2(digits10))
    {
       mpfr_set(this->m_data, val.data(), GMP_RNDN);
    }
    template <unsigned D>
-   mpfr_float_backend(const mpfr_float_backend<D>& val)
-      : detail::mpfr_float_imp<0, allocate_dynamic>(mpfr_get_prec(val.data()))
+   mpfr_float_backend(const mpfr_float_backend<D> &val)
+       : detail::mpfr_float_imp<0, allocate_dynamic>(mpfr_get_prec(val.data()))
    {
       mpfr_set(this->m_data, val.data(), GMP_RNDN);
    }
    template <unsigned D>
-   mpfr_float_backend(const gmp_float<D>& val)
-      : detail::mpfr_float_imp<0, allocate_dynamic>(mpf_get_prec(val.data()))
+   mpfr_float_backend(const gmp_float<D> &val)
+       : detail::mpfr_float_imp<0, allocate_dynamic>(mpf_get_prec(val.data()))
    {
       mpfr_set_f(this->m_data, val.data(), GMP_RNDN);
    }
-   mpfr_float_backend(const gmp_int& val)
-      : detail::mpfr_float_imp<0, allocate_dynamic>()
+   mpfr_float_backend(const gmp_int &val)
+       : detail::mpfr_float_imp<0, allocate_dynamic>()
    {
       mpfr_set_z(this->m_data, val.data(), GMP_RNDN);
    }
-   mpfr_float_backend(const gmp_rational& val)
-      : detail::mpfr_float_imp<0, allocate_dynamic>()
+   mpfr_float_backend(const gmp_rational &val)
+       : detail::mpfr_float_imp<0, allocate_dynamic>()
    {
       mpfr_set_q(this->m_data, val.data(), GMP_RNDN);
    }
 
-   mpfr_float_backend& operator=(const mpfr_float_backend& o)
+   mpfr_float_backend &operator=(const mpfr_float_backend &o)
    {
-      if(this != &o)
+      if (this != &o)
       {
          if (this->m_data[0]._mpfr_d == 0)
             mpfr_init2(this->m_data, mpfr_get_prec(o.data()));
@@ -911,54 +915,54 @@ struct mpfr_float_backend<0, allocate_dynamic> : public detail::mpfr_float_imp<0
       return *this;
    }
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
-   mpfr_float_backend& operator=(mpfr_float_backend&& o) BOOST_NOEXCEPT
+   mpfr_float_backend &operator=(mpfr_float_backend &&o) BOOST_NOEXCEPT
    {
-      *static_cast<detail::mpfr_float_imp<0, allocate_dynamic>*>(this) = static_cast<detail::mpfr_float_imp<0, allocate_dynamic> &&>(o);
+      *static_cast<detail::mpfr_float_imp<0, allocate_dynamic> *>(this) = static_cast<detail::mpfr_float_imp<0, allocate_dynamic> &&>(o);
       return *this;
    }
 #endif
    template <class V>
-   mpfr_float_backend& operator=(const V& v)
+   mpfr_float_backend &operator=(const V &v)
    {
-      *static_cast<detail::mpfr_float_imp<0, allocate_dynamic>*>(this) = v;
+      *static_cast<detail::mpfr_float_imp<0, allocate_dynamic> *>(this) = v;
       return *this;
    }
-   mpfr_float_backend& operator=(const mpfr_t val)
+   mpfr_float_backend &operator=(const mpfr_t val)
    {
-      if(this->m_data[0]._mpfr_d == 0)
+      if (this->m_data[0]._mpfr_d == 0)
          mpfr_init2(this->m_data, mpfr_get_prec(val));
       else
          mpfr_set_prec(this->m_data, mpfr_get_prec(val));
       mpfr_set(this->m_data, val, GMP_RNDN);
       return *this;
    }
-   mpfr_float_backend& operator=(const mpf_t val)
+   mpfr_float_backend &operator=(const mpf_t val)
    {
-      if(this->m_data[0]._mpfr_d == 0)
+      if (this->m_data[0]._mpfr_d == 0)
          mpfr_init2(this->m_data, (mpfr_prec_t)mpf_get_prec(val));
       else
          mpfr_set_prec(this->m_data, (unsigned)mpf_get_prec(val));
       mpfr_set_f(this->m_data, val, GMP_RNDN);
       return *this;
    }
-   mpfr_float_backend& operator=(const mpz_t val)
+   mpfr_float_backend &operator=(const mpz_t val)
    {
-      if(this->m_data[0]._mpfr_d == 0)
+      if (this->m_data[0]._mpfr_d == 0)
          mpfr_init2(this->m_data, multiprecision::detail::digits10_2_2(get_default_precision()));
       mpfr_set_z(this->m_data, val, GMP_RNDN);
       return *this;
    }
-   mpfr_float_backend& operator=(const mpq_t val)
+   mpfr_float_backend &operator=(const mpq_t val)
    {
-      if(this->m_data[0]._mpfr_d == 0)
+      if (this->m_data[0]._mpfr_d == 0)
          mpfr_init2(this->m_data, multiprecision::detail::digits10_2_2(get_default_precision()));
       mpfr_set_q(this->m_data, val, GMP_RNDN);
       return *this;
    }
    template <unsigned D>
-   mpfr_float_backend& operator=(const mpfr_float_backend<D>& val)
+   mpfr_float_backend &operator=(const mpfr_float_backend<D> &val)
    {
-      if(this->m_data[0]._mpfr_d == 0)
+      if (this->m_data[0]._mpfr_d == 0)
          mpfr_init2(this->m_data, mpfr_get_prec(val.data()));
       else
          mpfr_set_prec(this->m_data, mpfr_get_prec(val.data()));
@@ -966,25 +970,25 @@ struct mpfr_float_backend<0, allocate_dynamic> : public detail::mpfr_float_imp<0
       return *this;
    }
    template <unsigned D>
-   mpfr_float_backend& operator=(const gmp_float<D>& val)
+   mpfr_float_backend &operator=(const gmp_float<D> &val)
    {
-      if(this->m_data[0]._mpfr_d == 0)
+      if (this->m_data[0]._mpfr_d == 0)
          mpfr_init2(this->m_data, mpf_get_prec(val.data()));
       else
          mpfr_set_prec(this->m_data, mpf_get_prec(val.data()));
       mpfr_set_f(this->m_data, val.data(), GMP_RNDN);
       return *this;
    }
-   mpfr_float_backend& operator=(const gmp_int& val)
+   mpfr_float_backend &operator=(const gmp_int &val)
    {
-      if(this->m_data[0]._mpfr_d == 0)
+      if (this->m_data[0]._mpfr_d == 0)
          mpfr_init2(this->m_data, multiprecision::detail::digits10_2_2(get_default_precision()));
       mpfr_set_z(this->m_data, val.data(), GMP_RNDN);
       return *this;
    }
-   mpfr_float_backend& operator=(const gmp_rational& val)
+   mpfr_float_backend &operator=(const gmp_rational &val)
    {
-      if(this->m_data[0]._mpfr_d == 0)
+      if (this->m_data[0]._mpfr_d == 0)
          mpfr_init2(this->m_data, multiprecision::detail::digits10_2_2(get_default_precision()));
       mpfr_set_q(this->m_data, val.data(), GMP_RNDN);
       return *this;
@@ -997,7 +1001,7 @@ struct mpfr_float_backend<0, allocate_dynamic> : public detail::mpfr_float_imp<0
    {
       get_default_precision() = v;
    }
-   unsigned precision()const BOOST_NOEXCEPT
+   unsigned precision() const BOOST_NOEXCEPT
    {
       return multiprecision::detail::digits2_2_10(mpfr_get_prec(this->m_data));
    }
@@ -1008,124 +1012,124 @@ struct mpfr_float_backend<0, allocate_dynamic> : public detail::mpfr_float_imp<0
 };
 
 template <unsigned digits10, mpfr_allocation_type AllocationType, class T>
-inline typename enable_if<is_arithmetic<T>, bool>::type eval_eq(const mpfr_float_backend<digits10, AllocationType>& a, const T& b) BOOST_NOEXCEPT
+inline typename enable_if<is_arithmetic<T>, bool>::type eval_eq(const mpfr_float_backend<digits10, AllocationType> &a, const T &b) BOOST_NOEXCEPT
 {
    return a.compare(b) == 0;
 }
 template <unsigned digits10, mpfr_allocation_type AllocationType, class T>
-inline typename enable_if<is_arithmetic<T>, bool>::type eval_lt(const mpfr_float_backend<digits10, AllocationType>& a, const T& b) BOOST_NOEXCEPT
+inline typename enable_if<is_arithmetic<T>, bool>::type eval_lt(const mpfr_float_backend<digits10, AllocationType> &a, const T &b) BOOST_NOEXCEPT
 {
    return a.compare(b) < 0;
 }
 template <unsigned digits10, mpfr_allocation_type AllocationType, class T>
-inline typename enable_if<is_arithmetic<T>, bool>::type eval_gt(const mpfr_float_backend<digits10, AllocationType>& a, const T& b) BOOST_NOEXCEPT
+inline typename enable_if<is_arithmetic<T>, bool>::type eval_gt(const mpfr_float_backend<digits10, AllocationType> &a, const T &b) BOOST_NOEXCEPT
 {
    return a.compare(b) > 0;
 }
 
 template <unsigned D1, unsigned D2, mpfr_allocation_type A1, mpfr_allocation_type A2>
-inline void eval_add(mpfr_float_backend<D1, A1>& result, const mpfr_float_backend<D2, A2>& o)
+inline void eval_add(mpfr_float_backend<D1, A1> &result, const mpfr_float_backend<D2, A2> &o)
 {
    mpfr_add(result.data(), result.data(), o.data(), GMP_RNDN);
 }
 template <unsigned D1, unsigned D2, mpfr_allocation_type A1, mpfr_allocation_type A2>
-inline void eval_subtract(mpfr_float_backend<D1, A1>& result, const mpfr_float_backend<D2, A2>& o)
+inline void eval_subtract(mpfr_float_backend<D1, A1> &result, const mpfr_float_backend<D2, A2> &o)
 {
    mpfr_sub(result.data(), result.data(), o.data(), GMP_RNDN);
 }
 template <unsigned D1, unsigned D2, mpfr_allocation_type A1, mpfr_allocation_type A2>
-inline void eval_multiply(mpfr_float_backend<D1, A1>& result, const mpfr_float_backend<D2, A2>& o)
+inline void eval_multiply(mpfr_float_backend<D1, A1> &result, const mpfr_float_backend<D2, A2> &o)
 {
-   if((void*)&o == (void*)&result)
+   if ((void *)&o == (void *)&result)
       mpfr_sqr(result.data(), o.data(), GMP_RNDN);
    else
       mpfr_mul(result.data(), result.data(), o.data(), GMP_RNDN);
 }
 template <unsigned D1, unsigned D2, mpfr_allocation_type A1, mpfr_allocation_type A2>
-inline void eval_divide(mpfr_float_backend<D1, A1>& result, const mpfr_float_backend<D2, A2>& o)
+inline void eval_divide(mpfr_float_backend<D1, A1> &result, const mpfr_float_backend<D2, A2> &o)
 {
    mpfr_div(result.data(), result.data(), o.data(), GMP_RNDN);
 }
 template <unsigned digits10, mpfr_allocation_type AllocationType>
-inline void eval_add(mpfr_float_backend<digits10, AllocationType>& result, unsigned long i)
+inline void eval_add(mpfr_float_backend<digits10, AllocationType> &result, unsigned long i)
 {
    mpfr_add_ui(result.data(), result.data(), i, GMP_RNDN);
 }
 template <unsigned digits10, mpfr_allocation_type AllocationType>
-inline void eval_subtract(mpfr_float_backend<digits10, AllocationType>& result, unsigned long i)
+inline void eval_subtract(mpfr_float_backend<digits10, AllocationType> &result, unsigned long i)
 {
    mpfr_sub_ui(result.data(), result.data(), i, GMP_RNDN);
 }
 template <unsigned digits10, mpfr_allocation_type AllocationType>
-inline void eval_multiply(mpfr_float_backend<digits10, AllocationType>& result, unsigned long i)
+inline void eval_multiply(mpfr_float_backend<digits10, AllocationType> &result, unsigned long i)
 {
    mpfr_mul_ui(result.data(), result.data(), i, GMP_RNDN);
 }
 template <unsigned digits10, mpfr_allocation_type AllocationType>
-inline void eval_divide(mpfr_float_backend<digits10, AllocationType>& result, unsigned long i)
+inline void eval_divide(mpfr_float_backend<digits10, AllocationType> &result, unsigned long i)
 {
    mpfr_div_ui(result.data(), result.data(), i, GMP_RNDN);
 }
 template <unsigned digits10, mpfr_allocation_type AllocationType>
-inline void eval_add(mpfr_float_backend<digits10, AllocationType>& result, long i)
+inline void eval_add(mpfr_float_backend<digits10, AllocationType> &result, long i)
 {
-   if(i > 0)
+   if (i > 0)
       mpfr_add_ui(result.data(), result.data(), i, GMP_RNDN);
    else
       mpfr_sub_ui(result.data(), result.data(), boost::multiprecision::detail::unsigned_abs(i), GMP_RNDN);
 }
 template <unsigned digits10, mpfr_allocation_type AllocationType>
-inline void eval_subtract(mpfr_float_backend<digits10, AllocationType>& result, long i)
+inline void eval_subtract(mpfr_float_backend<digits10, AllocationType> &result, long i)
 {
-   if(i > 0)
+   if (i > 0)
       mpfr_sub_ui(result.data(), result.data(), i, GMP_RNDN);
    else
       mpfr_add_ui(result.data(), result.data(), boost::multiprecision::detail::unsigned_abs(i), GMP_RNDN);
 }
 template <unsigned digits10, mpfr_allocation_type AllocationType>
-inline void eval_multiply(mpfr_float_backend<digits10, AllocationType>& result, long i)
+inline void eval_multiply(mpfr_float_backend<digits10, AllocationType> &result, long i)
 {
    mpfr_mul_ui(result.data(), result.data(), boost::multiprecision::detail::unsigned_abs(i), GMP_RNDN);
-   if(i < 0)
+   if (i < 0)
       mpfr_neg(result.data(), result.data(), GMP_RNDN);
 }
 template <unsigned digits10, mpfr_allocation_type AllocationType>
-inline void eval_divide(mpfr_float_backend<digits10, AllocationType>& result, long i)
+inline void eval_divide(mpfr_float_backend<digits10, AllocationType> &result, long i)
 {
    mpfr_div_ui(result.data(), result.data(), boost::multiprecision::detail::unsigned_abs(i), GMP_RNDN);
-   if(i < 0)
+   if (i < 0)
       mpfr_neg(result.data(), result.data(), GMP_RNDN);
 }
 //
 // Specialised 3 arg versions of the basic operators:
 //
 template <unsigned D1, unsigned D2, mpfr_allocation_type A1, mpfr_allocation_type A2, unsigned D3>
-inline void eval_add(mpfr_float_backend<D1, A1>& a, const mpfr_float_backend<D2, A2>& x, const mpfr_float_backend<D3>& y)
+inline void eval_add(mpfr_float_backend<D1, A1> &a, const mpfr_float_backend<D2, A2> &x, const mpfr_float_backend<D3> &y)
 {
    mpfr_add(a.data(), x.data(), y.data(), GMP_RNDN);
 }
 template <unsigned D1, unsigned D2, mpfr_allocation_type A1, mpfr_allocation_type A2>
-inline void eval_add(mpfr_float_backend<D1, A1>& a, const mpfr_float_backend<D2, A2>& x, unsigned long y)
+inline void eval_add(mpfr_float_backend<D1, A1> &a, const mpfr_float_backend<D2, A2> &x, unsigned long y)
 {
    mpfr_add_ui(a.data(), x.data(), y, GMP_RNDN);
 }
 template <unsigned D1, unsigned D2, mpfr_allocation_type A1, mpfr_allocation_type A2>
-inline void eval_add(mpfr_float_backend<D1, A1>& a, const mpfr_float_backend<D2, A2>& x, long y)
+inline void eval_add(mpfr_float_backend<D1, A1> &a, const mpfr_float_backend<D2, A2> &x, long y)
 {
-   if(y < 0)
+   if (y < 0)
       mpfr_sub_ui(a.data(), x.data(), boost::multiprecision::detail::unsigned_abs(y), GMP_RNDN);
    else
       mpfr_add_ui(a.data(), x.data(), y, GMP_RNDN);
 }
 template <unsigned D1, unsigned D2, mpfr_allocation_type A1, mpfr_allocation_type A2>
-inline void eval_add(mpfr_float_backend<D1, A1>& a, unsigned long x, const mpfr_float_backend<D2, A2>& y)
+inline void eval_add(mpfr_float_backend<D1, A1> &a, unsigned long x, const mpfr_float_backend<D2, A2> &y)
 {
    mpfr_add_ui(a.data(), y.data(), x, GMP_RNDN);
 }
 template <unsigned D1, unsigned D2, mpfr_allocation_type A1, mpfr_allocation_type A2>
-inline void eval_add(mpfr_float_backend<D1, A1>& a, long x, const mpfr_float_backend<D2, A2>& y)
+inline void eval_add(mpfr_float_backend<D1, A1> &a, long x, const mpfr_float_backend<D2, A2> &y)
 {
-   if(x < 0)
+   if (x < 0)
    {
       mpfr_ui_sub(a.data(), boost::multiprecision::detail::unsigned_abs(x), y.data(), GMP_RNDN);
       mpfr_neg(a.data(), a.data(), GMP_RNDN);
@@ -1134,32 +1138,32 @@ inline void eval_add(mpfr_float_backend<D1, A1>& a, long x, const mpfr_float_bac
       mpfr_add_ui(a.data(), y.data(), x, GMP_RNDN);
 }
 template <unsigned D1, unsigned D2, mpfr_allocation_type A1, mpfr_allocation_type A2, unsigned D3>
-inline void eval_subtract(mpfr_float_backend<D1, A1>& a, const mpfr_float_backend<D2, A2>& x, const mpfr_float_backend<D3>& y)
+inline void eval_subtract(mpfr_float_backend<D1, A1> &a, const mpfr_float_backend<D2, A2> &x, const mpfr_float_backend<D3> &y)
 {
    mpfr_sub(a.data(), x.data(), y.data(), GMP_RNDN);
 }
 template <unsigned D1, unsigned D2, mpfr_allocation_type A1, mpfr_allocation_type A2>
-inline void eval_subtract(mpfr_float_backend<D1, A1>& a, const mpfr_float_backend<D2, A2>& x, unsigned long y)
+inline void eval_subtract(mpfr_float_backend<D1, A1> &a, const mpfr_float_backend<D2, A2> &x, unsigned long y)
 {
    mpfr_sub_ui(a.data(), x.data(), y, GMP_RNDN);
 }
 template <unsigned D1, unsigned D2, mpfr_allocation_type A1, mpfr_allocation_type A2>
-inline void eval_subtract(mpfr_float_backend<D1, A1>& a, const mpfr_float_backend<D2, A2>& x, long y)
+inline void eval_subtract(mpfr_float_backend<D1, A1> &a, const mpfr_float_backend<D2, A2> &x, long y)
 {
-   if(y < 0)
+   if (y < 0)
       mpfr_add_ui(a.data(), x.data(), boost::multiprecision::detail::unsigned_abs(y), GMP_RNDN);
    else
       mpfr_sub_ui(a.data(), x.data(), y, GMP_RNDN);
 }
 template <unsigned D1, unsigned D2, mpfr_allocation_type A1, mpfr_allocation_type A2>
-inline void eval_subtract(mpfr_float_backend<D1, A1>& a, unsigned long x, const mpfr_float_backend<D2, A2>& y)
+inline void eval_subtract(mpfr_float_backend<D1, A1> &a, unsigned long x, const mpfr_float_backend<D2, A2> &y)
 {
    mpfr_ui_sub(a.data(), x, y.data(), GMP_RNDN);
 }
 template <unsigned D1, unsigned D2, mpfr_allocation_type A1, mpfr_allocation_type A2>
-inline void eval_subtract(mpfr_float_backend<D1, A1>& a, long x, const mpfr_float_backend<D2, A2>& y)
+inline void eval_subtract(mpfr_float_backend<D1, A1> &a, long x, const mpfr_float_backend<D2, A2> &y)
 {
-   if(x < 0)
+   if (x < 0)
    {
       mpfr_add_ui(a.data(), y.data(), boost::multiprecision::detail::unsigned_abs(x), GMP_RNDN);
       mpfr_neg(a.data(), a.data(), GMP_RNDN);
@@ -1169,22 +1173,22 @@ inline void eval_subtract(mpfr_float_backend<D1, A1>& a, long x, const mpfr_floa
 }
 
 template <unsigned D1, unsigned D2, mpfr_allocation_type A1, mpfr_allocation_type A2, unsigned D3>
-inline void eval_multiply(mpfr_float_backend<D1, A1>& a, const mpfr_float_backend<D2, A2>& x, const mpfr_float_backend<D3>& y)
+inline void eval_multiply(mpfr_float_backend<D1, A1> &a, const mpfr_float_backend<D2, A2> &x, const mpfr_float_backend<D3> &y)
 {
-   if((void*)&x == (void*)&y)
+   if ((void *)&x == (void *)&y)
       mpfr_sqr(a.data(), x.data(), GMP_RNDN);
    else
       mpfr_mul(a.data(), x.data(), y.data(), GMP_RNDN);
 }
 template <unsigned D1, unsigned D2, mpfr_allocation_type A1, mpfr_allocation_type A2>
-inline void eval_multiply(mpfr_float_backend<D1, A1>& a, const mpfr_float_backend<D2, A2>& x, unsigned long y)
+inline void eval_multiply(mpfr_float_backend<D1, A1> &a, const mpfr_float_backend<D2, A2> &x, unsigned long y)
 {
    mpfr_mul_ui(a.data(), x.data(), y, GMP_RNDN);
 }
 template <unsigned D1, unsigned D2, mpfr_allocation_type A1, mpfr_allocation_type A2>
-inline void eval_multiply(mpfr_float_backend<D1, A1>& a, const mpfr_float_backend<D2, A2>& x, long y)
+inline void eval_multiply(mpfr_float_backend<D1, A1> &a, const mpfr_float_backend<D2, A2> &x, long y)
 {
-   if(y < 0)
+   if (y < 0)
    {
       mpfr_mul_ui(a.data(), x.data(), boost::multiprecision::detail::unsigned_abs(y), GMP_RNDN);
       a.negate();
@@ -1193,14 +1197,14 @@ inline void eval_multiply(mpfr_float_backend<D1, A1>& a, const mpfr_float_backen
       mpfr_mul_ui(a.data(), x.data(), y, GMP_RNDN);
 }
 template <unsigned D1, unsigned D2, mpfr_allocation_type A1, mpfr_allocation_type A2>
-inline void eval_multiply(mpfr_float_backend<D1, A1>& a, unsigned long x, const mpfr_float_backend<D2, A2>& y)
+inline void eval_multiply(mpfr_float_backend<D1, A1> &a, unsigned long x, const mpfr_float_backend<D2, A2> &y)
 {
    mpfr_mul_ui(a.data(), y.data(), x, GMP_RNDN);
 }
 template <unsigned D1, unsigned D2, mpfr_allocation_type A1, mpfr_allocation_type A2>
-inline void eval_multiply(mpfr_float_backend<D1, A1>& a, long x, const mpfr_float_backend<D2, A2>& y)
+inline void eval_multiply(mpfr_float_backend<D1, A1> &a, long x, const mpfr_float_backend<D2, A2> &y)
 {
-   if(x < 0)
+   if (x < 0)
    {
       mpfr_mul_ui(a.data(), y.data(), boost::multiprecision::detail::unsigned_abs(x), GMP_RNDN);
       mpfr_neg(a.data(), a.data(), GMP_RNDN);
@@ -1210,19 +1214,19 @@ inline void eval_multiply(mpfr_float_backend<D1, A1>& a, long x, const mpfr_floa
 }
 
 template <unsigned D1, unsigned D2, mpfr_allocation_type A1, mpfr_allocation_type A2, unsigned D3>
-inline void eval_divide(mpfr_float_backend<D1, A1>& a, const mpfr_float_backend<D2, A2>& x, const mpfr_float_backend<D3>& y)
+inline void eval_divide(mpfr_float_backend<D1, A1> &a, const mpfr_float_backend<D2, A2> &x, const mpfr_float_backend<D3> &y)
 {
    mpfr_div(a.data(), x.data(), y.data(), GMP_RNDN);
 }
 template <unsigned D1, unsigned D2, mpfr_allocation_type A1, mpfr_allocation_type A2>
-inline void eval_divide(mpfr_float_backend<D1, A1>& a, const mpfr_float_backend<D2, A2>& x, unsigned long y)
+inline void eval_divide(mpfr_float_backend<D1, A1> &a, const mpfr_float_backend<D2, A2> &x, unsigned long y)
 {
    mpfr_div_ui(a.data(), x.data(), y, GMP_RNDN);
 }
 template <unsigned D1, unsigned D2, mpfr_allocation_type A1, mpfr_allocation_type A2>
-inline void eval_divide(mpfr_float_backend<D1, A1>& a, const mpfr_float_backend<D2, A2>& x, long y)
+inline void eval_divide(mpfr_float_backend<D1, A1> &a, const mpfr_float_backend<D2, A2> &x, long y)
 {
-   if(y < 0)
+   if (y < 0)
    {
       mpfr_div_ui(a.data(), x.data(), boost::multiprecision::detail::unsigned_abs(y), GMP_RNDN);
       a.negate();
@@ -1231,14 +1235,14 @@ inline void eval_divide(mpfr_float_backend<D1, A1>& a, const mpfr_float_backend<
       mpfr_div_ui(a.data(), x.data(), y, GMP_RNDN);
 }
 template <unsigned D1, unsigned D2, mpfr_allocation_type A1, mpfr_allocation_type A2>
-inline void eval_divide(mpfr_float_backend<D1, A1>& a, unsigned long x, const mpfr_float_backend<D2, A2>& y)
+inline void eval_divide(mpfr_float_backend<D1, A1> &a, unsigned long x, const mpfr_float_backend<D2, A2> &y)
 {
    mpfr_ui_div(a.data(), x, y.data(), GMP_RNDN);
 }
 template <unsigned D1, unsigned D2, mpfr_allocation_type A1, mpfr_allocation_type A2>
-inline void eval_divide(mpfr_float_backend<D1, A1>& a, long x, const mpfr_float_backend<D2, A2>& y)
+inline void eval_divide(mpfr_float_backend<D1, A1> &a, long x, const mpfr_float_backend<D2, A2> &y)
 {
-   if(x < 0)
+   if (x < 0)
    {
       mpfr_ui_div(a.data(), boost::multiprecision::detail::unsigned_abs(x), y.data(), GMP_RNDN);
       mpfr_neg(a.data(), a.data(), GMP_RNDN);
@@ -1248,29 +1252,29 @@ inline void eval_divide(mpfr_float_backend<D1, A1>& a, long x, const mpfr_float_
 }
 
 template <unsigned digits10, mpfr_allocation_type AllocationType>
-inline bool eval_is_zero(const mpfr_float_backend<digits10, AllocationType>& val) BOOST_NOEXCEPT
+inline bool eval_is_zero(const mpfr_float_backend<digits10, AllocationType> &val) BOOST_NOEXCEPT
 {
    return 0 != mpfr_zero_p(val.data());
 }
 template <unsigned digits10, mpfr_allocation_type AllocationType>
-inline int eval_get_sign(const mpfr_float_backend<digits10, AllocationType>& val) BOOST_NOEXCEPT
+inline int eval_get_sign(const mpfr_float_backend<digits10, AllocationType> &val) BOOST_NOEXCEPT
 {
    return mpfr_sgn(val.data());
 }
 
 template <unsigned digits10, mpfr_allocation_type AllocationType>
-inline void eval_convert_to(unsigned long* result, const mpfr_float_backend<digits10, AllocationType>& val)
+inline void eval_convert_to(unsigned long *result, const mpfr_float_backend<digits10, AllocationType> &val)
 {
-   if(mpfr_nan_p(val.data()))
+   if (mpfr_nan_p(val.data()))
    {
       BOOST_THROW_EXCEPTION(std::runtime_error("Could not convert NaN to integer."));
    }
    *result = mpfr_get_ui(val.data(), GMP_RNDZ);
 }
 template <unsigned digits10, mpfr_allocation_type AllocationType>
-inline void eval_convert_to(long* result, const mpfr_float_backend<digits10, AllocationType>& val)
+inline void eval_convert_to(long *result, const mpfr_float_backend<digits10, AllocationType> &val)
 {
-   if(mpfr_nan_p(val.data()))
+   if (mpfr_nan_p(val.data()))
    {
       BOOST_THROW_EXCEPTION(std::runtime_error("Could not convert NaN to integer."));
    }
@@ -1278,18 +1282,18 @@ inline void eval_convert_to(long* result, const mpfr_float_backend<digits10, All
 }
 #ifdef _MPFR_H_HAVE_INTMAX_T
 template <unsigned digits10, mpfr_allocation_type AllocationType>
-inline void eval_convert_to(boost::ulong_long_type* result, const mpfr_float_backend<digits10, AllocationType>& val)
+inline void eval_convert_to(boost::ulong_long_type *result, const mpfr_float_backend<digits10, AllocationType> &val)
 {
-   if(mpfr_nan_p(val.data()))
+   if (mpfr_nan_p(val.data()))
    {
       BOOST_THROW_EXCEPTION(std::runtime_error("Could not convert NaN to integer."));
    }
    *result = mpfr_get_uj(val.data(), GMP_RNDZ);
 }
 template <unsigned digits10, mpfr_allocation_type AllocationType>
-inline void eval_convert_to(boost::long_long_type* result, const mpfr_float_backend<digits10, AllocationType>& val)
+inline void eval_convert_to(boost::long_long_type *result, const mpfr_float_backend<digits10, AllocationType> &val)
 {
-   if(mpfr_nan_p(val.data()))
+   if (mpfr_nan_p(val.data()))
    {
       BOOST_THROW_EXCEPTION(std::runtime_error("Could not convert NaN to integer."));
    }
@@ -1297,17 +1301,17 @@ inline void eval_convert_to(boost::long_long_type* result, const mpfr_float_back
 }
 #endif
 template <unsigned digits10, mpfr_allocation_type AllocationType>
-inline void eval_convert_to(float* result, const mpfr_float_backend<digits10, AllocationType>& val) BOOST_NOEXCEPT
+inline void eval_convert_to(float *result, const mpfr_float_backend<digits10, AllocationType> &val) BOOST_NOEXCEPT
 {
    *result = mpfr_get_flt(val.data(), GMP_RNDN);
 }
 template <unsigned digits10, mpfr_allocation_type AllocationType>
-inline void eval_convert_to(double* result, const mpfr_float_backend<digits10, AllocationType>& val) BOOST_NOEXCEPT
+inline void eval_convert_to(double *result, const mpfr_float_backend<digits10, AllocationType> &val) BOOST_NOEXCEPT
 {
    *result = mpfr_get_d(val.data(), GMP_RNDN);
 }
 template <unsigned digits10, mpfr_allocation_type AllocationType>
-inline void eval_convert_to(long double* result, const mpfr_float_backend<digits10, AllocationType>& val) BOOST_NOEXCEPT
+inline void eval_convert_to(long double *result, const mpfr_float_backend<digits10, AllocationType> &val) BOOST_NOEXCEPT
 {
    *result = mpfr_get_ld(val.data(), GMP_RNDN);
 }
@@ -1316,49 +1320,49 @@ inline void eval_convert_to(long double* result, const mpfr_float_backend<digits
 // Native non-member operations:
 //
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline void eval_sqrt(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& val)
+inline void eval_sqrt(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &val)
 {
    mpfr_sqrt(result.data(), val.data(), GMP_RNDN);
 }
 
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline void eval_abs(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& val)
+inline void eval_abs(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &val)
 {
    mpfr_abs(result.data(), val.data(), GMP_RNDN);
 }
 
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline void eval_fabs(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& val)
+inline void eval_fabs(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &val)
 {
    mpfr_abs(result.data(), val.data(), GMP_RNDN);
 }
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline void eval_ceil(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& val)
+inline void eval_ceil(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &val)
 {
    mpfr_ceil(result.data(), val.data());
 }
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline void eval_floor(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& val)
+inline void eval_floor(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &val)
 {
    mpfr_floor(result.data(), val.data());
 }
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline void eval_trunc(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& val)
+inline void eval_trunc(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &val)
 {
    mpfr_trunc(result.data(), val.data());
 }
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline void eval_ldexp(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& val, long e)
+inline void eval_ldexp(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &val, long e)
 {
-   if(e > 0)
+   if (e > 0)
       mpfr_mul_2exp(result.data(), val.data(), e, GMP_RNDN);
-   else if(e < 0)
+   else if (e < 0)
       mpfr_div_2exp(result.data(), val.data(), -e, GMP_RNDN);
    else
       result = val;
 }
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline void eval_frexp(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& val, int* e)
+inline void eval_frexp(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &val, int *e)
 {
    long v;
    mpfr_get_d_2exp(&v, val.data(), GMP_RNDN);
@@ -1366,22 +1370,22 @@ inline void eval_frexp(mpfr_float_backend<Digits10, AllocateType>& result, const
    eval_ldexp(result, val, -v);
 }
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline void eval_frexp(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& val, long* e)
+inline void eval_frexp(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &val, long *e)
 {
    mpfr_get_d_2exp(e, val.data(), GMP_RNDN);
    return eval_ldexp(result, val, -*e);
 }
 
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline int eval_fpclassify(const mpfr_float_backend<Digits10, AllocateType>& val) BOOST_NOEXCEPT
+inline int eval_fpclassify(const mpfr_float_backend<Digits10, AllocateType> &val) BOOST_NOEXCEPT
 {
    return mpfr_inf_p(val.data()) ? FP_INFINITE : mpfr_nan_p(val.data()) ? FP_NAN : mpfr_zero_p(val.data()) ? FP_ZERO : FP_NORMAL;
 }
 
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline void eval_pow(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& b, const mpfr_float_backend<Digits10, AllocateType>& e)
+inline void eval_pow(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &b, const mpfr_float_backend<Digits10, AllocateType> &e)
 {
-   if(mpfr_zero_p(b.data()) && mpfr_integer_p(e.data()) && (mpfr_signbit(e.data()) == 0) && mpfr_fits_ulong_p(e.data(), GMP_RNDN) && (mpfr_get_ui(e.data(), GMP_RNDN) & 1))
+   if (mpfr_zero_p(b.data()) && mpfr_integer_p(e.data()) && (mpfr_signbit(e.data()) == 0) && mpfr_fits_ulong_p(e.data(), GMP_RNDN) && (mpfr_get_ui(e.data(), GMP_RNDN) & 1))
    {
       mpfr_set(result.data(), b.data(), GMP_RNDN);
    }
@@ -1395,21 +1399,21 @@ inline void eval_pow(mpfr_float_backend<Digits10, AllocateType>& result, const m
 // certain other enable_if usages are defined first.  It's a capricious
 // and rather annoying compiler bug in other words....
 //
-# define BOOST_MP_ENABLE_IF_WORKAROUND (Digits10 || !Digits10) &&
+#define BOOST_MP_ENABLE_IF_WORKAROUND (Digits10 || !Digits10) &&
 #else
 #define BOOST_MP_ENABLE_IF_WORKAROUND
 #endif
 
 template <unsigned Digits10, mpfr_allocation_type AllocateType, class Integer>
-inline typename enable_if<mpl::and_<is_signed<Integer>, mpl::bool_<BOOST_MP_ENABLE_IF_WORKAROUND (sizeof(Integer) <= sizeof(long))> > >::type
-   eval_pow(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& b, const Integer& e)
+inline typename enable_if<mpl::and_<is_signed<Integer>, mpl::bool_<BOOST_MP_ENABLE_IF_WORKAROUND(sizeof(Integer) <= sizeof(long))> > >::type
+eval_pow(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &b, const Integer &e)
 {
    mpfr_pow_si(result.data(), b.data(), e, GMP_RNDN);
 }
 
 template <unsigned Digits10, mpfr_allocation_type AllocateType, class Integer>
-inline typename enable_if<mpl::and_<is_unsigned<Integer>, mpl::bool_<BOOST_MP_ENABLE_IF_WORKAROUND (sizeof(Integer) <= sizeof(long))> > >::type
-   eval_pow(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& b, const Integer& e)
+inline typename enable_if<mpl::and_<is_unsigned<Integer>, mpl::bool_<BOOST_MP_ENABLE_IF_WORKAROUND(sizeof(Integer) <= sizeof(long))> > >::type
+eval_pow(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &b, const Integer &e)
 {
    mpfr_pow_ui(result.data(), b.data(), e, GMP_RNDN);
 }
@@ -1417,99 +1421,99 @@ inline typename enable_if<mpl::and_<is_unsigned<Integer>, mpl::bool_<BOOST_MP_EN
 #undef BOOST_MP_ENABLE_IF_WORKAROUND
 
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline void eval_exp(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& arg)
+inline void eval_exp(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &arg)
 {
    mpfr_exp(result.data(), arg.data(), GMP_RNDN);
 }
 
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline void eval_exp2(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& arg)
+inline void eval_exp2(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &arg)
 {
    mpfr_exp2(result.data(), arg.data(), GMP_RNDN);
 }
 
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline void eval_log(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& arg)
+inline void eval_log(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &arg)
 {
    mpfr_log(result.data(), arg.data(), GMP_RNDN);
 }
 
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline void eval_log10(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& arg)
+inline void eval_log10(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &arg)
 {
    mpfr_log10(result.data(), arg.data(), GMP_RNDN);
 }
 
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline void eval_sin(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& arg)
+inline void eval_sin(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &arg)
 {
    mpfr_sin(result.data(), arg.data(), GMP_RNDN);
 }
 
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline void eval_cos(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& arg)
+inline void eval_cos(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &arg)
 {
    mpfr_cos(result.data(), arg.data(), GMP_RNDN);
 }
 
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline void eval_tan(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& arg)
+inline void eval_tan(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &arg)
 {
    mpfr_tan(result.data(), arg.data(), GMP_RNDN);
 }
 
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline void eval_asin(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& arg)
+inline void eval_asin(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &arg)
 {
    mpfr_asin(result.data(), arg.data(), GMP_RNDN);
 }
 
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline void eval_acos(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& arg)
+inline void eval_acos(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &arg)
 {
    mpfr_acos(result.data(), arg.data(), GMP_RNDN);
 }
 
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline void eval_atan(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& arg)
+inline void eval_atan(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &arg)
 {
    mpfr_atan(result.data(), arg.data(), GMP_RNDN);
 }
 
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline void eval_atan2(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& arg1, const mpfr_float_backend<Digits10, AllocateType>& arg2)
+inline void eval_atan2(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &arg1, const mpfr_float_backend<Digits10, AllocateType> &arg2)
 {
    mpfr_atan2(result.data(), arg1.data(), arg2.data(), GMP_RNDN);
 }
 
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline void eval_sinh(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& arg)
+inline void eval_sinh(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &arg)
 {
    mpfr_sinh(result.data(), arg.data(), GMP_RNDN);
 }
 
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline void eval_cosh(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& arg)
+inline void eval_cosh(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &arg)
 {
    mpfr_cosh(result.data(), arg.data(), GMP_RNDN);
 }
 
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline void eval_tanh(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& arg)
+inline void eval_tanh(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &arg)
 {
    mpfr_tanh(result.data(), arg.data(), GMP_RNDN);
 }
 
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline void eval_log2(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& arg)
+inline void eval_log2(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &arg)
 {
    mpfr_log2(result.data(), arg.data(), GMP_RNDN);
 }
 
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline void eval_modf(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& arg, mpfr_float_backend<Digits10, AllocateType>* pipart)
+inline void eval_modf(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &arg, mpfr_float_backend<Digits10, AllocateType> *pipart)
 {
-   if(0 == pipart)
+   if (0 == pipart)
    {
       mpfr_float_backend<Digits10, AllocateType> ipart;
       mpfr_modf(ipart.data(), result.data(), arg.data(), GMP_RNDN);
@@ -1520,63 +1524,64 @@ inline void eval_modf(mpfr_float_backend<Digits10, AllocateType>& result, const 
    }
 }
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline void eval_remainder(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& a, const mpfr_float_backend<Digits10, AllocateType>& b)
+inline void eval_remainder(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &a, const mpfr_float_backend<Digits10, AllocateType> &b)
 {
    mpfr_remainder(result.data(), a.data(), b.data(), GMP_RNDN);
 }
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline void eval_remquo(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& a, const mpfr_float_backend<Digits10, AllocateType>& b, int* pi)
+inline void eval_remquo(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &a, const mpfr_float_backend<Digits10, AllocateType> &b, int *pi)
 {
    long l;
    mpfr_remquo(result.data(), &l, a.data(), b.data(), GMP_RNDN);
-   if(pi) *pi = l;
+   if (pi)
+      *pi = l;
 }
 
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline void eval_fmod(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& a, const mpfr_float_backend<Digits10, AllocateType>& b)
+inline void eval_fmod(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &a, const mpfr_float_backend<Digits10, AllocateType> &b)
 {
    mpfr_fmod(result.data(), a.data(), b.data(), GMP_RNDN);
 }
 
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline void eval_multiply_add(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& a, const mpfr_float_backend<Digits10, AllocateType>& b)
+inline void eval_multiply_add(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &a, const mpfr_float_backend<Digits10, AllocateType> &b)
 {
    mpfr_fma(result.data(), a.data(), b.data(), result.data(), GMP_RNDN);
 }
 
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline void eval_multiply_add(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& a, const mpfr_float_backend<Digits10, AllocateType>& b, const mpfr_float_backend<Digits10, AllocateType>& c)
+inline void eval_multiply_add(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &a, const mpfr_float_backend<Digits10, AllocateType> &b, const mpfr_float_backend<Digits10, AllocateType> &c)
 {
    mpfr_fma(result.data(), a.data(), b.data(), c.data(), GMP_RNDN);
 }
 
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline void eval_multiply_subtract(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& a, const mpfr_float_backend<Digits10, AllocateType>& b)
+inline void eval_multiply_subtract(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &a, const mpfr_float_backend<Digits10, AllocateType> &b)
 {
    mpfr_fms(result.data(), a.data(), b.data(), result.data(), GMP_RNDN);
    result.negate();
 }
 
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline void eval_multiply_subtract(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& a, const mpfr_float_backend<Digits10, AllocateType>& b, const mpfr_float_backend<Digits10, AllocateType>& c)
+inline void eval_multiply_subtract(mpfr_float_backend<Digits10, AllocateType> &result, const mpfr_float_backend<Digits10, AllocateType> &a, const mpfr_float_backend<Digits10, AllocateType> &b, const mpfr_float_backend<Digits10, AllocateType> &c)
 {
    mpfr_fms(result.data(), a.data(), b.data(), c.data(), GMP_RNDN);
 }
 
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline int eval_signbit BOOST_PREVENT_MACRO_SUBSTITUTION(const mpfr_float_backend<Digits10, AllocateType>& arg)
+inline int eval_signbit BOOST_PREVENT_MACRO_SUBSTITUTION(const mpfr_float_backend<Digits10, AllocateType> &arg)
 {
    return (arg.data()[0]._mpfr_sign < 0) ? 1 : 0;
 }
 
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
-inline std::size_t hash_value(const mpfr_float_backend<Digits10, AllocateType>& val)
+inline std::size_t hash_value(const mpfr_float_backend<Digits10, AllocateType> &val)
 {
    std::size_t result = 0;
-   std::size_t len = val.data()[0]._mpfr_prec / mp_bits_per_limb;
-   if(val.data()[0]._mpfr_prec % mp_bits_per_limb)
+   std::size_t len    = val.data()[0]._mpfr_prec / mp_bits_per_limb;
+   if (val.data()[0]._mpfr_prec % mp_bits_per_limb)
       ++len;
-   for(std::size_t i = 0; i < len; ++i)
+   for (std::size_t i = 0; i < len; ++i)
       boost::hash_combine(result, val.data()[0]._mpfr_d[i]);
    boost::hash_combine(result, val.data()[0]._mpfr_exp);
    boost::hash_combine(result, val.data()[0]._mpfr_sign);
@@ -1587,60 +1592,62 @@ inline std::size_t hash_value(const mpfr_float_backend<Digits10, AllocateType>& 
 
 #ifdef BOOST_NO_SFINAE_EXPR
 
-namespace detail{
+namespace detail {
 
-template<unsigned D1, unsigned D2, mpfr_allocation_type A1, mpfr_allocation_type A2>
-struct is_explicitly_convertible<backends::mpfr_float_backend<D1, A1>, backends::mpfr_float_backend<D2, A2> > : public mpl::true_ {};
+template <unsigned D1, unsigned D2, mpfr_allocation_type A1, mpfr_allocation_type A2>
+struct is_explicitly_convertible<backends::mpfr_float_backend<D1, A1>, backends::mpfr_float_backend<D2, A2> > : public mpl::true_
+{};
 
-}
+} // namespace detail
 
 #endif
 
-namespace detail
-{
-   template<>
-   struct is_variable_precision<backends::mpfr_float_backend<0> > : public true_type {};
-}
+namespace detail {
+template <>
+struct is_variable_precision<backends::mpfr_float_backend<0> > : public true_type
+{};
+} // namespace detail
 
-template<>
-struct number_category<detail::canonical<mpfr_t, backends::mpfr_float_backend<0> >::type> : public mpl::int_<number_kind_floating_point>{};
+template <>
+struct number_category<detail::canonical<mpfr_t, backends::mpfr_float_backend<0> >::type> : public mpl::int_<number_kind_floating_point>
+{};
 
 using boost::multiprecision::backends::mpfr_float_backend;
 
-typedef number<mpfr_float_backend<50> >    mpfr_float_50;
-typedef number<mpfr_float_backend<100> >   mpfr_float_100;
-typedef number<mpfr_float_backend<500> >   mpfr_float_500;
-typedef number<mpfr_float_backend<1000> >  mpfr_float_1000;
-typedef number<mpfr_float_backend<0> >     mpfr_float;
+typedef number<mpfr_float_backend<50> >   mpfr_float_50;
+typedef number<mpfr_float_backend<100> >  mpfr_float_100;
+typedef number<mpfr_float_backend<500> >  mpfr_float_500;
+typedef number<mpfr_float_backend<1000> > mpfr_float_1000;
+typedef number<mpfr_float_backend<0> >    mpfr_float;
 
-typedef number<mpfr_float_backend<50, allocate_stack> >    static_mpfr_float_50;
-typedef number<mpfr_float_backend<100, allocate_stack> >   static_mpfr_float_100;
+typedef number<mpfr_float_backend<50, allocate_stack> >  static_mpfr_float_50;
+typedef number<mpfr_float_backend<100, allocate_stack> > static_mpfr_float_100;
 
-template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
-inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> copysign BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates>& a, const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates>& b)
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
+inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> copysign BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> &a, const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> &b)
 {
    return (boost::multiprecision::signbit)(a) != (boost::multiprecision::signbit)(b) ? boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates>(-a) : a;
 }
 
-template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
-inline boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType> >, ExpressionTemplates> copysign BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType> >, ExpressionTemplates>& a, const boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType> >, ExpressionTemplates>& b)
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
+inline boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType> >, ExpressionTemplates> copysign BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType> >, ExpressionTemplates> &a, const boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType> >, ExpressionTemplates> &b)
 {
    return (boost::multiprecision::signbit)(a) != (boost::multiprecision::signbit)(b) ? boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType> >, ExpressionTemplates>(-a) : a;
 }
 
 } // namespace multiprecision
 
-namespace math{
+namespace math {
 
-   using boost::multiprecision::signbit;
-   using boost::multiprecision::copysign;
+using boost::multiprecision::copysign;
+using boost::multiprecision::signbit;
 
-namespace tools{
+namespace tools {
 
 template <>
 inline int digits<boost::multiprecision::mpfr_float>()
 #ifdef BOOST_MATH_NOEXCEPT
-   BOOST_NOEXCEPT
+    BOOST_NOEXCEPT
 #endif
 {
    return multiprecision::detail::digits10_2_2(boost::multiprecision::mpfr_float::default_precision());
@@ -1648,7 +1655,7 @@ inline int digits<boost::multiprecision::mpfr_float>()
 template <>
 inline int digits<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0>, boost::multiprecision::et_off> >()
 #ifdef BOOST_MATH_NOEXCEPT
-   BOOST_NOEXCEPT
+    BOOST_NOEXCEPT
 #endif
 {
    return multiprecision::detail::digits10_2_2(boost::multiprecision::mpfr_float::default_precision());
@@ -1656,7 +1663,7 @@ inline int digits<boost::multiprecision::number<boost::multiprecision::mpfr_floa
 
 template <>
 inline boost::multiprecision::mpfr_float
-   max_value<boost::multiprecision::mpfr_float>()
+max_value<boost::multiprecision::mpfr_float>()
 {
    boost::multiprecision::mpfr_float result(0.5);
    mpfr_mul_2exp(result.backend().data(), result.backend().data(), mpfr_get_emax(), GMP_RNDN);
@@ -1666,7 +1673,7 @@ inline boost::multiprecision::mpfr_float
 
 template <>
 inline boost::multiprecision::mpfr_float
-   min_value<boost::multiprecision::mpfr_float>()
+min_value<boost::multiprecision::mpfr_float>()
 {
    boost::multiprecision::mpfr_float result(0.5);
    mpfr_div_2exp(result.backend().data(), result.backend().data(), -mpfr_get_emin(), GMP_RNDN);
@@ -1675,8 +1682,8 @@ inline boost::multiprecision::mpfr_float
 }
 
 template <>
-inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0>, boost::multiprecision::et_off> 
-   max_value<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0>, boost::multiprecision::et_off> >()
+inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0>, boost::multiprecision::et_off>
+max_value<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0>, boost::multiprecision::et_off> >()
 {
    boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0>, boost::multiprecision::et_off> result(0.5);
    mpfr_mul_2exp(result.backend().data(), result.backend().data(), mpfr_get_emax(), GMP_RNDN);
@@ -1686,7 +1693,7 @@ inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0
 
 template <>
 inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0>, boost::multiprecision::et_off>
-   min_value<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0>, boost::multiprecision::et_off> >()
+min_value<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0>, boost::multiprecision::et_off> >()
 {
    boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0>, boost::multiprecision::et_off> result(0.5);
    mpfr_div_2exp(result.backend().data(), result.backend().data(), -mpfr_get_emin(), GMP_RNDN);
@@ -1697,7 +1704,7 @@ inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0
 template <>
 inline int digits<boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpfr_float::backend_type> > >()
 #ifdef BOOST_MATH_NOEXCEPT
-BOOST_NOEXCEPT
+    BOOST_NOEXCEPT
 #endif
 {
    return multiprecision::detail::digits10_2_2(boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpfr_float::backend_type> >::default_precision());
@@ -1705,7 +1712,7 @@ BOOST_NOEXCEPT
 template <>
 inline int digits<boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpfr_float_backend<0> >, boost::multiprecision::et_off> >()
 #ifdef BOOST_MATH_NOEXCEPT
-BOOST_NOEXCEPT
+    BOOST_NOEXCEPT
 #endif
 {
    return multiprecision::detail::digits10_2_2(boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpfr_float::backend_type> >::default_precision());
@@ -1741,129 +1748,134 @@ min_value<boost::multiprecision::number<boost::multiprecision::debug_adaptor<boo
 
 } // namespace tools
 
-namespace constants{ namespace detail{
+namespace constants { namespace detail {
 
-template <class T> struct constant_pi;
-template <class T> struct constant_ln_two;
-template <class T> struct constant_euler;
-template <class T> struct constant_catalan;
+template <class T>
+struct constant_pi;
+template <class T>
+struct constant_ln_two;
+template <class T>
+struct constant_euler;
+template <class T>
+struct constant_catalan;
 
-namespace detail{
+namespace detail {
 
-   template <class T, int N>
-   struct mpfr_constant_initializer
+template <class T, int N>
+struct mpfr_constant_initializer
+{
+   static void force_instantiate()
    {
-      static void force_instantiate()
+      init.force_instantiate();
+   }
+
+ private:
+   struct initializer
+   {
+      initializer()
       {
-         init.force_instantiate();
+         T::get(mpl::int_<N>());
       }
-   private:
-      struct initializer
-      {
-         initializer()
-         {
-            T::get(mpl::int_<N>());
-         }
-         void force_instantiate()const{}
-      };
-      static const initializer init;
+      void force_instantiate() const {}
    };
+   static const initializer init;
+};
 
-   template <class T, int N>
-   typename mpfr_constant_initializer<T, N>::initializer const mpfr_constant_initializer<T, N>::init;
+template <class T, int N>
+typename mpfr_constant_initializer<T, N>::initializer const mpfr_constant_initializer<T, N>::init;
 
-}
+} // namespace detail
 
-template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
 struct constant_pi<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >
 {
    typedef boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result_type;
-   template<int N>
-   static inline const result_type& get(const mpl::int_<N>&)
+   template <int N>
+   static inline const result_type &get(const mpl::int_<N> &)
    {
       detail::mpfr_constant_initializer<constant_pi<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >, N>::force_instantiate();
       static result_type result;
-      static bool has_init = false;
-      if(!has_init)
+      static bool        has_init = false;
+      if (!has_init)
       {
          mpfr_const_pi(result.backend().data(), GMP_RNDN);
          has_init = true;
       }
       return result;
    }
-   static inline const result_type get(const mpl::int_<0>&)
+   static inline const result_type get(const mpl::int_<0> &)
    {
       result_type result;
       mpfr_const_pi(result.backend().data(), GMP_RNDN);
       return result;
    }
 };
-template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
 struct constant_ln_two<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >
 {
    typedef boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result_type;
-   template<int N>
-   static inline const result_type& get(const mpl::int_<N>&)
+   template <int N>
+   static inline const result_type &get(const mpl::int_<N> &)
    {
       detail::mpfr_constant_initializer<constant_ln_two<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >, N>::force_instantiate();
       static result_type result;
-      static bool init = false;
-      if(!init)
+      static bool        init = false;
+      if (!init)
       {
          mpfr_const_log2(result.backend().data(), GMP_RNDN);
          init = true;
       }
       return result;
    }
-   static inline const result_type get(const mpl::int_<0>&)
+   static inline const result_type get(const mpl::int_<0> &)
    {
       result_type result;
       mpfr_const_log2(result.backend().data(), GMP_RNDN);
       return result;
    }
 };
-template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
 struct constant_euler<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >
 {
    typedef boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result_type;
-   template<int N>
-   static inline const result_type& get(const mpl::int_<N>&)
+   template <int N>
+   static inline const result_type &get(const mpl::int_<N> &)
    {
       detail::mpfr_constant_initializer<constant_euler<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >, N>::force_instantiate();
       static result_type result;
-      static bool init = false;
-      if(!init)
+      static bool        init = false;
+      if (!init)
       {
          mpfr_const_euler(result.backend().data(), GMP_RNDN);
          init = true;
       }
       return result;
    }
-   static inline const result_type get(const mpl::int_<0>&)
+   static inline const result_type get(const mpl::int_<0> &)
    {
       result_type result;
       mpfr_const_euler(result.backend().data(), GMP_RNDN);
       return result;
    }
 };
-template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
 struct constant_catalan<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >
 {
    typedef boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result_type;
-   template<int N>
-   static inline const result_type& get(const mpl::int_<N>&)
+   template <int N>
+   static inline const result_type &get(const mpl::int_<N> &)
    {
       detail::mpfr_constant_initializer<constant_catalan<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >, N>::force_instantiate();
       static result_type result;
-      static bool init = false;
-      if(!init)
+      static bool        init = false;
+      if (!init)
       {
          mpfr_const_catalan(result.backend().data(), GMP_RNDN);
          init = true;
       }
       return result;
    }
-   static inline const result_type get(const mpl::int_<0>&)
+   static inline const result_type get(const mpl::int_<0> &)
    {
       result_type result;
       mpfr_const_catalan(result.backend().data(), GMP_RNDN);
@@ -1871,96 +1883,96 @@ struct constant_catalan<boost::multiprecision::number<boost::multiprecision::mpf
    }
 };
 
-template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
 struct constant_pi<boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType> >, ExpressionTemplates> >
 {
    typedef boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType> >, ExpressionTemplates> result_type;
-   template<int N>
-   static inline const result_type& get(const mpl::int_<N>&)
+   template <int N>
+   static inline const result_type &get(const mpl::int_<N> &)
    {
       detail::mpfr_constant_initializer<constant_pi<boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType> >, ExpressionTemplates> >, N>::force_instantiate();
       static result_type result;
-      static bool has_init = false;
-      if(!has_init)
+      static bool        has_init = false;
+      if (!has_init)
       {
          mpfr_const_pi(result.backend().value().data(), GMP_RNDN);
          has_init = true;
       }
       return result;
    }
-   static inline const result_type get(const mpl::int_<0>&)
+   static inline const result_type get(const mpl::int_<0> &)
    {
       result_type result;
       mpfr_const_pi(result.backend().value().data(), GMP_RNDN);
       return result;
    }
 };
-template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
 struct constant_ln_two<boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType> >, ExpressionTemplates> >
 {
    typedef boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType> >, ExpressionTemplates> result_type;
-   template<int N>
-   static inline const result_type& get(const mpl::int_<N>&)
+   template <int N>
+   static inline const result_type &get(const mpl::int_<N> &)
    {
       detail::mpfr_constant_initializer<constant_ln_two<boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType> >, ExpressionTemplates> >, N>::force_instantiate();
       static result_type result;
-      static bool init = false;
-      if(!init)
+      static bool        init = false;
+      if (!init)
       {
          mpfr_const_log2(result.backend().value().data(), GMP_RNDN);
          init = true;
       }
       return result;
    }
-   static inline const result_type get(const mpl::int_<0>&)
+   static inline const result_type get(const mpl::int_<0> &)
    {
       result_type result;
       mpfr_const_log2(result.backend().value().data(), GMP_RNDN);
       return result;
    }
 };
-template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
 struct constant_euler<boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType> >, ExpressionTemplates> >
 {
    typedef boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType> >, ExpressionTemplates> result_type;
-   template<int N>
-   static inline const result_type& get(const mpl::int_<N>&)
+   template <int N>
+   static inline const result_type &get(const mpl::int_<N> &)
    {
       detail::mpfr_constant_initializer<constant_euler<boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType> >, ExpressionTemplates> >, N>::force_instantiate();
       static result_type result;
-      static bool init = false;
-      if(!init)
+      static bool        init = false;
+      if (!init)
       {
          mpfr_const_euler(result.backend().value().data(), GMP_RNDN);
          init = true;
       }
       return result;
    }
-   static inline const result_type get(const mpl::int_<0>&)
+   static inline const result_type get(const mpl::int_<0> &)
    {
       result_type result;
       mpfr_const_euler(result.backend().value().data(), GMP_RNDN);
       return result;
    }
 };
-template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
 struct constant_catalan<boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType> >, ExpressionTemplates> >
 {
    typedef boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType> >, ExpressionTemplates> result_type;
-   template<int N>
-   static inline const result_type& get(const mpl::int_<N>&)
+   template <int N>
+   static inline const result_type &get(const mpl::int_<N> &)
    {
       detail::mpfr_constant_initializer<constant_catalan<boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType> >, ExpressionTemplates> >, N>::force_instantiate();
       static result_type result;
-      static bool init = false;
-      if(!init)
+      static bool        init = false;
+      if (!init)
       {
          mpfr_const_catalan(result.backend().value().data(), GMP_RNDN);
          init = true;
       }
       return result;
    }
-   static inline const result_type get(const mpl::int_<0>&)
+   static inline const result_type get(const mpl::int_<0> &)
    {
       result_type result;
       mpfr_const_catalan(result.backend().value().data(), GMP_RNDN);
@@ -1968,374 +1980,374 @@ struct constant_catalan<boost::multiprecision::number<boost::multiprecision::deb
    }
 };
 
-}} // namespaces
+}} // namespace constants::detail
+
+} // namespace math
+
+namespace multiprecision {
+//
+// Overloaded special functions which call native mpfr routines:
+//
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
+inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> asinh BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> &arg)
+{
+   boost::multiprecision::detail::scoped_default_precision<number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
+
+   boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
+   mpfr_asinh(result.backend().data(), arg.backend().data(), GMP_RNDN);
+   return BOOST_MP_MOVE(result);
+}
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
+inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> acosh BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> &arg)
+{
+   boost::multiprecision::detail::scoped_default_precision<number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
+
+   boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
+   mpfr_acosh(result.backend().data(), arg.backend().data(), GMP_RNDN);
+   return BOOST_MP_MOVE(result);
+}
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
+inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> atanh BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> &arg)
+{
+   boost::multiprecision::detail::scoped_default_precision<number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
+
+   boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
+   mpfr_atanh(result.backend().data(), arg.backend().data(), GMP_RNDN);
+   return BOOST_MP_MOVE(result);
+}
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
+inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> cbrt BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> &arg)
+{
+   boost::multiprecision::detail::scoped_default_precision<number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
+
+   boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
+   mpfr_cbrt(result.backend().data(), arg.backend().data(), GMP_RNDN);
+   return BOOST_MP_MOVE(result);
+}
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
+inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> erf BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> &arg)
+{
+   boost::multiprecision::detail::scoped_default_precision<number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
+
+   boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
+   mpfr_erf(result.backend().data(), arg.backend().data(), GMP_RNDN);
+   return BOOST_MP_MOVE(result);
+}
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
+inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> erfc BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> &arg)
+{
+   boost::multiprecision::detail::scoped_default_precision<number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
+
+   boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
+   mpfr_erfc(result.backend().data(), arg.backend().data(), GMP_RNDN);
+   return BOOST_MP_MOVE(result);
+}
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
+inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> expm1 BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> &arg)
+{
+   boost::multiprecision::detail::scoped_default_precision<number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
+
+   boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
+   mpfr_expm1(result.backend().data(), arg.backend().data(), GMP_RNDN);
+   return BOOST_MP_MOVE(result);
+}
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
+inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> lgamma BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> &arg)
+{
+   boost::multiprecision::detail::scoped_default_precision<number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
+
+   boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
+   mpfr_lngamma(result.backend().data(), arg.backend().data(), GMP_RNDN);
+   return BOOST_MP_MOVE(result);
+}
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
+inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> tgamma BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> &arg)
+{
+   boost::multiprecision::detail::scoped_default_precision<number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
+
+   boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
+   mpfr_gamma(result.backend().data(), arg.backend().data(), GMP_RNDN);
+   return BOOST_MP_MOVE(result);
+}
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
+inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> log1p BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> &arg)
+{
+   boost::multiprecision::detail::scoped_default_precision<number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
+
+   boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
+   mpfr_log1p(result.backend().data(), arg.backend().data(), GMP_RNDN);
+   return BOOST_MP_MOVE(result);
+}
 
 } // namespace multiprecision
 
-namespace multiprecision {
-   //
-   // Overloaded special functions which call native mpfr routines:
-   //
-   template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
-   inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> asinh BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates>& arg)
-   {
-      boost::multiprecision::detail::scoped_default_precision<number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
+namespace math {
+//
+// Overloaded special functions which call native mpfr routines:
+//
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates, class Policy>
+inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> asinh BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> &arg, const Policy &pol)
+{
+   boost::multiprecision::detail::scoped_default_precision<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
 
-      boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
-      mpfr_asinh(result.backend().data(), arg.backend().data(), GMP_RNDN);
-      return BOOST_MP_MOVE(result);
-   }
-   template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
-   inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> acosh BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates>& arg)
-   {
-      boost::multiprecision::detail::scoped_default_precision<number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
-
-      boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
-      mpfr_acosh(result.backend().data(), arg.backend().data(), GMP_RNDN);
-      return BOOST_MP_MOVE(result);
-   }
-   template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
-   inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> atanh BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates>& arg)
-   {
-      boost::multiprecision::detail::scoped_default_precision<number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
-
-      boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
-      mpfr_atanh(result.backend().data(), arg.backend().data(), GMP_RNDN);
-      return BOOST_MP_MOVE(result);
-   }
-   template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
-   inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> cbrt BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates>& arg)
-   {
-      boost::multiprecision::detail::scoped_default_precision<number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
-
-      boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
-      mpfr_cbrt(result.backend().data(), arg.backend().data(), GMP_RNDN);
-      return BOOST_MP_MOVE(result);
-   }
-   template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
-   inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> erf BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates>& arg)
-   {
-      boost::multiprecision::detail::scoped_default_precision<number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
-
-      boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
-      mpfr_erf(result.backend().data(), arg.backend().data(), GMP_RNDN);
-      return BOOST_MP_MOVE(result);
-   }
-   template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
-   inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> erfc BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates>& arg)
-   {
-      boost::multiprecision::detail::scoped_default_precision<number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
-
-      boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
-      mpfr_erfc(result.backend().data(), arg.backend().data(), GMP_RNDN);
-      return BOOST_MP_MOVE(result);
-   }
-   template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
-   inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> expm1 BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates>& arg)
-   {
-      boost::multiprecision::detail::scoped_default_precision<number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
-
-      boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
-      mpfr_expm1(result.backend().data(), arg.backend().data(), GMP_RNDN);
-      return BOOST_MP_MOVE(result);
-   }
-   template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
-   inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> lgamma BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates>& arg)
-   {
-      boost::multiprecision::detail::scoped_default_precision<number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
-
-      boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
-      mpfr_lngamma(result.backend().data(), arg.backend().data(), GMP_RNDN);
-      return BOOST_MP_MOVE(result);
-   }
-   template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
-   inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> tgamma BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates>& arg)
-   {
-      boost::multiprecision::detail::scoped_default_precision<number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
-
-      boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
-      mpfr_gamma(result.backend().data(), arg.backend().data(), GMP_RNDN);
-      return BOOST_MP_MOVE(result);
-   }
-   template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
-   inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> log1p BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates>& arg)
-   {
-      boost::multiprecision::detail::scoped_default_precision<number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
-
-      boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
-      mpfr_log1p(result.backend().data(), arg.backend().data(), GMP_RNDN);
-      return BOOST_MP_MOVE(result);
-   }
-
+   boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
+   mpfr_asinh(result.backend().data(), arg.backend().data(), GMP_RNDN);
+   if (mpfr_inf_p(result.backend().data()))
+      return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("asinh<%1%>(%1%)", 0, Policy());
+   if (mpfr_nan_p(result.backend().data()))
+      return policies::raise_evaluation_error("asinh<%1%>(%1%)", "Unknown error, result is a NaN", result, Policy());
+   return result;
+}
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
+inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> asinh BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> &arg)
+{
+   return asinh(arg, policies::policy<>());
 }
 
-namespace math {
-   //
-   // Overloaded special functions which call native mpfr routines:
-   //
-   template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates, class Policy>
-   inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> asinh BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates>& arg, const Policy& pol)
-   {
-      boost::multiprecision::detail::scoped_default_precision<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates, class Policy>
+inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> acosh BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> &arg, const Policy &pol)
+{
+   boost::multiprecision::detail::scoped_default_precision<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
 
-      boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
-      mpfr_asinh(result.backend().data(), arg.backend().data(), GMP_RNDN);
-      if (mpfr_inf_p(result.backend().data()))
-         return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("asinh<%1%>(%1%)", 0, Policy());
-      if (mpfr_nan_p(result.backend().data()))
-         return policies::raise_evaluation_error("asinh<%1%>(%1%)", "Unknown error, result is a NaN", result, Policy());
-      return result;
+   boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
+   mpfr_acosh(result.backend().data(), arg.backend().data(), GMP_RNDN);
+   if (mpfr_inf_p(result.backend().data()))
+      return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("acosh<%1%>(%1%)", 0, Policy());
+   if (mpfr_nan_p(result.backend().data()))
+      return policies::raise_evaluation_error("acosh<%1%>(%1%)", "Unknown error, result is a NaN", result, Policy());
+   return result;
+}
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
+inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> acosh BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> &arg)
+{
+   return acosh(arg, policies::policy<>());
+}
+
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates, class Policy>
+inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> atanh BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> &arg, const Policy &pol)
+{
+   boost::multiprecision::detail::scoped_default_precision<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
+
+   boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
+   mpfr_atanh(result.backend().data(), arg.backend().data(), GMP_RNDN);
+   if (mpfr_inf_p(result.backend().data()))
+      return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("atanh<%1%>(%1%)", 0, Policy());
+   if (mpfr_nan_p(result.backend().data()))
+      return policies::raise_evaluation_error("atanh<%1%>(%1%)", "Unknown error, result is a NaN", result, Policy());
+   return result;
+}
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
+inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> atanh BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> &arg)
+{
+   return atanh(arg, policies::policy<>());
+}
+
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates, class Policy>
+inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> cbrt BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> &arg, const Policy &pol)
+{
+   boost::multiprecision::detail::scoped_default_precision<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
+
+   boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
+   mpfr_cbrt(result.backend().data(), arg.backend().data(), GMP_RNDN);
+   if (mpfr_inf_p(result.backend().data()))
+      return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("cbrt<%1%>(%1%)", 0, Policy());
+   if (mpfr_nan_p(result.backend().data()))
+      return policies::raise_evaluation_error("cbrt<%1%>(%1%)", "Unknown error, result is a NaN", result, Policy());
+   return result;
+}
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
+inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> cbrt BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> &arg)
+{
+   return cbrt(arg, policies::policy<>());
+}
+
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates, class Policy>
+inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> erf BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> &arg, const Policy &pol)
+{
+   boost::multiprecision::detail::scoped_default_precision<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
+
+   boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
+   mpfr_erf(result.backend().data(), arg.backend().data(), GMP_RNDN);
+   if (mpfr_inf_p(result.backend().data()))
+      return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("erf<%1%>(%1%)", 0, pol);
+   if (mpfr_nan_p(result.backend().data()))
+      return policies::raise_evaluation_error("erf<%1%>(%1%)", "Unknown error, result is a NaN", result, pol);
+   return result;
+}
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
+inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> erf BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> &arg)
+{
+   return erf(arg, policies::policy<>());
+}
+
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates, class Policy>
+inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> erfc BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> &arg, const Policy &pol)
+{
+   boost::multiprecision::detail::scoped_default_precision<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
+
+   boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
+   mpfr_erfc(result.backend().data(), arg.backend().data(), GMP_RNDN);
+   if (mpfr_inf_p(result.backend().data()))
+      return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("erfc<%1%>(%1%)", 0, pol);
+   if (mpfr_nan_p(result.backend().data()))
+      return policies::raise_evaluation_error("erfc<%1%>(%1%)", "Unknown error, result is a NaN", result, pol);
+   return result;
+}
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
+inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> erfc BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> &arg)
+{
+   return erfc(arg, policies::policy<>());
+}
+
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates, class Policy>
+inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> expm1 BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> &arg, const Policy &pol)
+{
+   boost::multiprecision::detail::scoped_default_precision<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
+
+   boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
+   mpfr_expm1(result.backend().data(), arg.backend().data(), GMP_RNDN);
+   if (mpfr_inf_p(result.backend().data()))
+      return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("expm1<%1%>(%1%)", 0, pol);
+   if (mpfr_nan_p(result.backend().data()))
+      return policies::raise_evaluation_error("expm1<%1%>(%1%)", "Unknown error, result is a NaN", result, pol);
+   return result;
+}
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
+inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> exm1 BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> &arg)
+{
+   return expm1(arg, policies::policy<>());
+}
+
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates, class Policy>
+inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> lgamma BOOST_PREVENT_MACRO_SUBSTITUTION(boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> arg, int *sign, const Policy &pol)
+{
+   boost::multiprecision::detail::scoped_default_precision<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
+
+   boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
+   if (arg > 0)
+   {
+      mpfr_lngamma(result.backend().data(), arg.backend().data(), GMP_RNDN);
+      if (sign)
+         *sign = 1;
    }
-   template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
-   inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> asinh BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates>& arg)
+   else
    {
-      return asinh(arg, policies::policy<>());
-   }
+      if (floor(arg) == arg)
+         return policies::raise_pole_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >(
+             "lgamma<%1%>", "Evaluation of lgamma at a negative integer %1%.", arg, pol);
 
-   template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates, class Policy>
-   inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> acosh BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates>& arg, const Policy& pol)
-   {
-      boost::multiprecision::detail::scoped_default_precision<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
-
-      boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
-      mpfr_acosh(result.backend().data(), arg.backend().data(), GMP_RNDN);
-      if (mpfr_inf_p(result.backend().data()))
-         return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("acosh<%1%>(%1%)", 0, Policy());
-      if (mpfr_nan_p(result.backend().data()))
-         return policies::raise_evaluation_error("acosh<%1%>(%1%)", "Unknown error, result is a NaN", result, Policy());
-      return result;
-   }
-   template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
-   inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> acosh BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates>& arg)
-   {
-      return acosh(arg, policies::policy<>());
-   }
-
-   template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates, class Policy>
-   inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> atanh BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates>& arg, const Policy& pol)
-   {
-      boost::multiprecision::detail::scoped_default_precision<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
-
-      boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
-      mpfr_atanh(result.backend().data(), arg.backend().data(), GMP_RNDN);
-      if (mpfr_inf_p(result.backend().data()))
-         return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("atanh<%1%>(%1%)", 0, Policy());
-      if (mpfr_nan_p(result.backend().data()))
-         return policies::raise_evaluation_error("atanh<%1%>(%1%)", "Unknown error, result is a NaN", result, Policy());
-      return result;
-   }
-   template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
-   inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> atanh BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates>& arg)
-   {
-      return atanh(arg, policies::policy<>());
-   }
-
-   template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates, class Policy>
-   inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> cbrt BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates>& arg, const Policy& pol)
-   {
-      boost::multiprecision::detail::scoped_default_precision<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
-
-      boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
-      mpfr_cbrt(result.backend().data(), arg.backend().data(), GMP_RNDN);
-      if (mpfr_inf_p(result.backend().data()))
-         return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("cbrt<%1%>(%1%)", 0, Policy());
-      if (mpfr_nan_p(result.backend().data()))
-         return policies::raise_evaluation_error("cbrt<%1%>(%1%)", "Unknown error, result is a NaN", result, Policy());
-      return result;
-   }
-   template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
-   inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> cbrt BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates>& arg)
-   {
-      return cbrt(arg, policies::policy<>());
-   }
-
-   template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates, class Policy>
-   inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> erf BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates>& arg, const Policy& pol)
-   {
-      boost::multiprecision::detail::scoped_default_precision<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
-
-      boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
-      mpfr_erf(result.backend().data(), arg.backend().data(), GMP_RNDN);
-      if (mpfr_inf_p(result.backend().data()))
-         return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("erf<%1%>(%1%)", 0, pol);
-      if (mpfr_nan_p(result.backend().data()))
-         return policies::raise_evaluation_error("erf<%1%>(%1%)", "Unknown error, result is a NaN", result, pol);
-      return result;
-   }
-   template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
-   inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> erf BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates>& arg)
-   {
-      return erf(arg, policies::policy<>());
-   }
-
-   template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates, class Policy>
-   inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> erfc BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates>& arg, const Policy& pol)
-   {
-      boost::multiprecision::detail::scoped_default_precision<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
-
-      boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
-      mpfr_erfc(result.backend().data(), arg.backend().data(), GMP_RNDN);
-      if (mpfr_inf_p(result.backend().data()))
-         return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("erfc<%1%>(%1%)", 0, pol);
-      if (mpfr_nan_p(result.backend().data()))
-         return policies::raise_evaluation_error("erfc<%1%>(%1%)", "Unknown error, result is a NaN", result, pol);
-      return result;
-   }
-   template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
-   inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> erfc BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates>& arg)
-   {
-      return erfc(arg, policies::policy<>());
-   }
-
-   template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates, class Policy>
-   inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> expm1 BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates>& arg, const Policy& pol)
-   {
-      boost::multiprecision::detail::scoped_default_precision<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
-
-      boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
-      mpfr_expm1(result.backend().data(), arg.backend().data(), GMP_RNDN);
-      if (mpfr_inf_p(result.backend().data()))
-         return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("expm1<%1%>(%1%)", 0, pol);
-      if (mpfr_nan_p(result.backend().data()))
-         return policies::raise_evaluation_error("expm1<%1%>(%1%)", "Unknown error, result is a NaN", result, pol);
-      return result;
-   }
-   template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
-   inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> exm1 BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates>& arg)
-   {
-      return expm1(arg, policies::policy<>());
-   }
-
-   template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates, class Policy>
-   inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> lgamma BOOST_PREVENT_MACRO_SUBSTITUTION(boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> arg, int* sign, const Policy& pol)
-   {
-      boost::multiprecision::detail::scoped_default_precision<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
-
-      boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
-      if (arg > 0)
+      boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> t = detail::sinpx(arg);
+      arg                                                                                                                     = -arg;
+      if (t < 0)
       {
-         mpfr_lngamma(result.backend().data(), arg.backend().data(), GMP_RNDN);
-         if (sign)
+         t = -t;
+      }
+      result = log(boost::math::constants::pi<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >()) - lgamma(arg, 0, pol) - log(t);
+      if (sign)
+      {
+         boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> phase = 1 - arg;
+         phase                                                                                                                       = floor(phase) / 2;
+         if (floor(phase) == phase)
+            *sign = -1;
+         else
             *sign = 1;
       }
-      else
-      {
-         if (floor(arg) == arg)
-            return policies::raise_pole_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >(
-               "lgamma<%1%>", "Evaluation of lgamma at a negative integer %1%.", arg, pol);
-
-         boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> t = detail::sinpx(arg);
-         arg = -arg;
-         if (t < 0)
-         {
-            t = -t;
-         }
-         result = log(boost::math::constants::pi<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >()) - lgamma(arg, 0, pol) - log(t);
-         if (sign)
-         {
-            boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> phase = 1 - arg;
-            phase = floor(phase) / 2;
-            if (floor(phase) == phase)
-               *sign = -1;
-            else
-               *sign = 1;
-         }
-      }
-      if (mpfr_inf_p(result.backend().data()))
-         return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("lgamma<%1%>(%1%)", 0, pol);
-      if (mpfr_nan_p(result.backend().data()))
-         return policies::raise_evaluation_error("lgamma<%1%>(%1%)", "Unknown error, result is a NaN", result, pol);
-      return result;
    }
-   template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
-   inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> lgamma BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates>& arg, int* sign)
-   {
-      return lgamma(arg, sign, policies::policy<>());
-   }
-   template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates, class Policy>
-   inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> lgamma BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates>& arg, const Policy& pol)
-   {
-      return lgamma(arg, 0, pol);
-   }
-   template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
-   inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> lgamma BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates>& arg)
-   {
-      return lgamma(arg, 0, policies::policy<>());
-   }
-
-   template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates, class Policy>
-   inline typename boost::enable_if_c<boost::math::policies::is_policy<Policy>::value, boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >::type tgamma BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates>& arg, const Policy& pol)
-   {
-      boost::multiprecision::detail::scoped_default_precision<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
-
-      boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
-      mpfr_gamma(result.backend().data(), arg.backend().data(), GMP_RNDN);
-      if (mpfr_inf_p(result.backend().data()))
-         return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("tgamma<%1%>(%1%)", 0, pol);
-      if (mpfr_nan_p(result.backend().data()))
-         return policies::raise_evaluation_error("tgamma<%1%>(%1%)", "Unknown error, result is a NaN", result, pol);
-      return result;
-   }
-   template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
-   inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> tgamma BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates>& arg)
-   {
-      return tgamma(arg, policies::policy<>());
-   }
-
-   template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates, class Policy>
-   inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> log1p BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates>& arg, const Policy& pol)
-   {
-      boost::multiprecision::detail::scoped_default_precision<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
-
-      boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
-      mpfr_log1p(result.backend().data(), arg.backend().data(), GMP_RNDN);
-      if (mpfr_inf_p(result.backend().data()))
-         return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("log1p<%1%>(%1%)", 0, pol);
-      if (mpfr_nan_p(result.backend().data()))
-         return policies::raise_evaluation_error("log1p<%1%>(%1%)", "Unknown error, result is a NaN", result, pol);
-      return result;
-   }
-   template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
-   inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> log1p BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates>& arg)
-   {
-      return log1p(arg, policies::policy<>());
-   }
-
-
+   if (mpfr_inf_p(result.backend().data()))
+      return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("lgamma<%1%>(%1%)", 0, pol);
+   if (mpfr_nan_p(result.backend().data()))
+      return policies::raise_evaluation_error("lgamma<%1%>(%1%)", "Unknown error, result is a NaN", result, pol);
+   return result;
+}
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
+inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> lgamma BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> &arg, int *sign)
+{
+   return lgamma(arg, sign, policies::policy<>());
+}
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates, class Policy>
+inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> lgamma BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> &arg, const Policy &pol)
+{
+   return lgamma(arg, 0, pol);
+}
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
+inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> lgamma BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> &arg)
+{
+   return lgamma(arg, 0, policies::policy<>());
 }
 
-}  // namespace boost
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates, class Policy>
+inline typename boost::enable_if_c<boost::math::policies::is_policy<Policy>::value, boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >::type tgamma BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> &arg, const Policy &pol)
+{
+   boost::multiprecision::detail::scoped_default_precision<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
 
-namespace std{
+   boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
+   mpfr_gamma(result.backend().data(), arg.backend().data(), GMP_RNDN);
+   if (mpfr_inf_p(result.backend().data()))
+      return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("tgamma<%1%>(%1%)", 0, pol);
+   if (mpfr_nan_p(result.backend().data()))
+      return policies::raise_evaluation_error("tgamma<%1%>(%1%)", "Unknown error, result is a NaN", result, pol);
+   return result;
+}
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
+inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> tgamma BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> &arg)
+{
+   return tgamma(arg, policies::policy<>());
+}
+
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates, class Policy>
+inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> log1p BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> &arg, const Policy &pol)
+{
+   boost::multiprecision::detail::scoped_default_precision<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> > precision_guard(arg);
+
+   boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
+   mpfr_log1p(result.backend().data(), arg.backend().data(), GMP_RNDN);
+   if (mpfr_inf_p(result.backend().data()))
+      return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("log1p<%1%>(%1%)", 0, pol);
+   if (mpfr_nan_p(result.backend().data()))
+      return policies::raise_evaluation_error("log1p<%1%>(%1%)", "Unknown error, result is a NaN", result, pol);
+   return result;
+}
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
+inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> log1p BOOST_PREVENT_MACRO_SUBSTITUTION(const boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> &arg)
+{
+   return log1p(arg, policies::policy<>());
+}
+
+} // namespace math
+
+} // namespace boost
+
+namespace std {
 
 //
 // numeric_limits [partial] specializations for the types declared in this header:
 //
-template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
 class numeric_limits<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >
 {
    typedef boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> number_type;
-public:
+
+ public:
    BOOST_STATIC_CONSTEXPR bool is_specialized = true;
-   static number_type (min)()
+   static number_type(min)()
    {
       initializer.do_nothing();
       static std::pair<bool, number_type> value;
-      if(!value.first)
+      if (!value.first)
       {
-         value.first = true;
+         value.first  = true;
          value.second = 0.5;
          mpfr_div_2exp(value.second.backend().data(), value.second.backend().data(), -mpfr_get_emin(), GMP_RNDN);
       }
       return value.second;
    }
-   static number_type (max)()
+   static number_type(max)()
    {
       initializer.do_nothing();
       static std::pair<bool, number_type> value;
-      if(!value.first)
+      if (!value.first)
       {
-         value.first = true;
+         value.first  = true;
          value.second = 0.5;
          mpfr_mul_2exp(value.second.backend().data(), value.second.backend().data(), mpfr_get_emax(), GMP_RNDN);
       }
@@ -2345,21 +2357,21 @@ public:
    {
       return -(max)();
    }
-   BOOST_STATIC_CONSTEXPR int digits = static_cast<int>((Digits10 * 1000L) / 301L + ((Digits10 * 1000L) % 301 ? 2 : 1));
+   BOOST_STATIC_CONSTEXPR int digits   = static_cast<int>((Digits10 * 1000L) / 301L + ((Digits10 * 1000L) % 301 ? 2 : 1));
    BOOST_STATIC_CONSTEXPR int digits10 = Digits10;
    // Is this really correct???
-   BOOST_STATIC_CONSTEXPR int max_digits10 = Digits10 + 3;
-   BOOST_STATIC_CONSTEXPR bool is_signed = true;
-   BOOST_STATIC_CONSTEXPR bool is_integer = false;
-   BOOST_STATIC_CONSTEXPR bool is_exact = false;
-   BOOST_STATIC_CONSTEXPR int radix = 2;
-   static number_type epsilon()
+   BOOST_STATIC_CONSTEXPR int  max_digits10 = Digits10 + 3;
+   BOOST_STATIC_CONSTEXPR bool is_signed    = true;
+   BOOST_STATIC_CONSTEXPR bool is_integer   = false;
+   BOOST_STATIC_CONSTEXPR bool is_exact     = false;
+   BOOST_STATIC_CONSTEXPR int  radix        = 2;
+   static number_type          epsilon()
    {
       initializer.do_nothing();
       static std::pair<bool, number_type> value;
-      if(!value.first)
+      if (!value.first)
       {
-         value.first = true;
+         value.first  = true;
          value.second = 1;
          mpfr_div_2exp(value.second.backend().data(), value.second.backend().data(), std::numeric_limits<number_type>::digits - 1, GMP_RNDN);
       }
@@ -2371,31 +2383,31 @@ public:
       // returns epsilon/2
       initializer.do_nothing();
       static std::pair<bool, number_type> value;
-      if(!value.first)
+      if (!value.first)
       {
-         value.first = true;
+         value.first  = true;
          value.second = 1;
          mpfr_div_2exp(value.second.backend().data(), value.second.backend().data(), 1, GMP_RNDN);
       }
       return value.second;
    }
-   BOOST_STATIC_CONSTEXPR long min_exponent = MPFR_EMIN_DEFAULT;
-   BOOST_STATIC_CONSTEXPR long min_exponent10 = (MPFR_EMIN_DEFAULT / 1000) * 301L;
-   BOOST_STATIC_CONSTEXPR long max_exponent = MPFR_EMAX_DEFAULT;
-   BOOST_STATIC_CONSTEXPR long max_exponent10 = (MPFR_EMAX_DEFAULT / 1000) * 301L;
-   BOOST_STATIC_CONSTEXPR bool has_infinity = true;
-   BOOST_STATIC_CONSTEXPR bool has_quiet_NaN = true;
-   BOOST_STATIC_CONSTEXPR bool has_signaling_NaN = false;
-   BOOST_STATIC_CONSTEXPR float_denorm_style has_denorm = denorm_absent;
-   BOOST_STATIC_CONSTEXPR bool has_denorm_loss = false;
-   static number_type infinity()
+   BOOST_STATIC_CONSTEXPR long min_exponent                  = MPFR_EMIN_DEFAULT;
+   BOOST_STATIC_CONSTEXPR long min_exponent10                = (MPFR_EMIN_DEFAULT / 1000) * 301L;
+   BOOST_STATIC_CONSTEXPR long max_exponent                  = MPFR_EMAX_DEFAULT;
+   BOOST_STATIC_CONSTEXPR long max_exponent10                = (MPFR_EMAX_DEFAULT / 1000) * 301L;
+   BOOST_STATIC_CONSTEXPR bool has_infinity                  = true;
+   BOOST_STATIC_CONSTEXPR bool has_quiet_NaN                 = true;
+   BOOST_STATIC_CONSTEXPR bool has_signaling_NaN             = false;
+   BOOST_STATIC_CONSTEXPR float_denorm_style has_denorm      = denorm_absent;
+   BOOST_STATIC_CONSTEXPR bool               has_denorm_loss = false;
+   static number_type                        infinity()
    {
       // returns epsilon/2
       initializer.do_nothing();
       static std::pair<bool, number_type> value;
-      if(!value.first)
+      if (!value.first)
       {
-         value.first = true;
+         value.first  = true;
          value.second = 1;
          mpfr_set_inf(value.second.backend().data(), 1);
       }
@@ -2406,9 +2418,9 @@ public:
       // returns epsilon/2
       initializer.do_nothing();
       static std::pair<bool, number_type> value;
-      if(!value.first)
+      if (!value.first)
       {
-         value.first = true;
+         value.first  = true;
          value.second = 1;
          mpfr_set_nan(value.second.backend().data());
       }
@@ -2419,14 +2431,14 @@ public:
       return number_type(0);
    }
    BOOST_STATIC_CONSTEXPR number_type denorm_min() { return number_type(0); }
-   BOOST_STATIC_CONSTEXPR bool is_iec559 = false;
-   BOOST_STATIC_CONSTEXPR bool is_bounded = true;
-   BOOST_STATIC_CONSTEXPR bool is_modulo = false;
-   BOOST_STATIC_CONSTEXPR bool traps = true;
-   BOOST_STATIC_CONSTEXPR bool tinyness_before = false;
+   BOOST_STATIC_CONSTEXPR bool        is_iec559         = false;
+   BOOST_STATIC_CONSTEXPR bool        is_bounded        = true;
+   BOOST_STATIC_CONSTEXPR bool        is_modulo         = false;
+   BOOST_STATIC_CONSTEXPR bool        traps             = true;
+   BOOST_STATIC_CONSTEXPR bool        tinyness_before   = false;
    BOOST_STATIC_CONSTEXPR float_round_style round_style = round_to_nearest;
 
-private:
+ private:
    struct data_initializer
    {
       data_initializer()
@@ -2438,12 +2450,12 @@ private:
          std::numeric_limits<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<digits10, AllocateType> > >::infinity();
          std::numeric_limits<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<digits10, AllocateType> > >::quiet_NaN();
       }
-      void do_nothing()const{}
+      void do_nothing() const {}
    };
    static const data_initializer initializer;
 };
 
-template<unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
+template <unsigned Digits10, boost::multiprecision::mpfr_allocation_type AllocateType, boost::multiprecision::expression_template_option ExpressionTemplates>
 const typename numeric_limits<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >::data_initializer numeric_limits<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >::initializer;
 
 #ifndef BOOST_NO_INCLASS_MEMBER_INITIALIZATION
@@ -2495,12 +2507,12 @@ BOOST_CONSTEXPR_OR_CONST float_round_style numeric_limits<boost::multiprecision:
 
 #endif
 
-
-template<boost::multiprecision::expression_template_option ExpressionTemplates>
+template <boost::multiprecision::expression_template_option ExpressionTemplates>
 class numeric_limits<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0>, ExpressionTemplates> >
 {
    typedef boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0>, ExpressionTemplates> number_type;
-public:
+
+ public:
    BOOST_STATIC_CONSTEXPR bool is_specialized = false;
    static number_type(min)()
    {
@@ -2518,14 +2530,14 @@ public:
    {
       return -(max)();
    }
-   BOOST_STATIC_CONSTEXPR int digits = INT_MAX;
-   BOOST_STATIC_CONSTEXPR int digits10 = INT_MAX;
-   BOOST_STATIC_CONSTEXPR int max_digits10 = INT_MAX;
-   BOOST_STATIC_CONSTEXPR bool is_signed = true;
-   BOOST_STATIC_CONSTEXPR bool is_integer = false;
-   BOOST_STATIC_CONSTEXPR bool is_exact = false;
-   BOOST_STATIC_CONSTEXPR int radix = 2;
-   static number_type epsilon()
+   BOOST_STATIC_CONSTEXPR int  digits       = INT_MAX;
+   BOOST_STATIC_CONSTEXPR int  digits10     = INT_MAX;
+   BOOST_STATIC_CONSTEXPR int  max_digits10 = INT_MAX;
+   BOOST_STATIC_CONSTEXPR bool is_signed    = true;
+   BOOST_STATIC_CONSTEXPR bool is_integer   = false;
+   BOOST_STATIC_CONSTEXPR bool is_exact     = false;
+   BOOST_STATIC_CONSTEXPR int  radix        = 2;
+   static number_type          epsilon()
    {
       number_type value(1);
       mpfr_div_2exp(value.backend().data(), value.backend().data(), boost::multiprecision::detail::digits10_2_2(number_type::default_precision()) - 1, GMP_RNDN);
@@ -2535,16 +2547,16 @@ public:
    {
       return epsilon() / 2;
    }
-   BOOST_STATIC_CONSTEXPR long min_exponent = MPFR_EMIN_DEFAULT;
-   BOOST_STATIC_CONSTEXPR long min_exponent10 = (MPFR_EMIN_DEFAULT / 1000) * 301L;
-   BOOST_STATIC_CONSTEXPR long max_exponent = MPFR_EMAX_DEFAULT;
-   BOOST_STATIC_CONSTEXPR long max_exponent10 = (MPFR_EMAX_DEFAULT / 1000) * 301L;
-   BOOST_STATIC_CONSTEXPR bool has_infinity = true;
-   BOOST_STATIC_CONSTEXPR bool has_quiet_NaN = true;
-   BOOST_STATIC_CONSTEXPR bool has_signaling_NaN = false;
-   BOOST_STATIC_CONSTEXPR float_denorm_style has_denorm = denorm_absent;
-   BOOST_STATIC_CONSTEXPR bool has_denorm_loss = false;
-   static number_type infinity()
+   BOOST_STATIC_CONSTEXPR long min_exponent                  = MPFR_EMIN_DEFAULT;
+   BOOST_STATIC_CONSTEXPR long min_exponent10                = (MPFR_EMIN_DEFAULT / 1000) * 301L;
+   BOOST_STATIC_CONSTEXPR long max_exponent                  = MPFR_EMAX_DEFAULT;
+   BOOST_STATIC_CONSTEXPR long max_exponent10                = (MPFR_EMAX_DEFAULT / 1000) * 301L;
+   BOOST_STATIC_CONSTEXPR bool has_infinity                  = true;
+   BOOST_STATIC_CONSTEXPR bool has_quiet_NaN                 = true;
+   BOOST_STATIC_CONSTEXPR bool has_signaling_NaN             = false;
+   BOOST_STATIC_CONSTEXPR float_denorm_style has_denorm      = denorm_absent;
+   BOOST_STATIC_CONSTEXPR bool               has_denorm_loss = false;
+   static number_type                        infinity()
    {
       number_type value;
       mpfr_set_inf(value.backend().data(), 1);
@@ -2556,13 +2568,13 @@ public:
       mpfr_set_nan(value.backend().data());
       return value;
    }
-   static number_type signaling_NaN() { return number_type(0); }
-   static number_type denorm_min() { return number_type(0); }
-   BOOST_STATIC_CONSTEXPR bool is_iec559 = false;
-   BOOST_STATIC_CONSTEXPR bool is_bounded = true;
-   BOOST_STATIC_CONSTEXPR bool is_modulo = false;
-   BOOST_STATIC_CONSTEXPR bool traps = false;
-   BOOST_STATIC_CONSTEXPR bool tinyness_before = false;
+   static number_type          signaling_NaN() { return number_type(0); }
+   static number_type          denorm_min() { return number_type(0); }
+   BOOST_STATIC_CONSTEXPR bool is_iec559                = false;
+   BOOST_STATIC_CONSTEXPR bool is_bounded               = true;
+   BOOST_STATIC_CONSTEXPR bool is_modulo                = false;
+   BOOST_STATIC_CONSTEXPR bool traps                    = false;
+   BOOST_STATIC_CONSTEXPR bool tinyness_before          = false;
    BOOST_STATIC_CONSTEXPR float_round_style round_style = round_toward_zero;
 };
 

--- a/include/boost/multiprecision/rational_adaptor.hpp
+++ b/include/boost/multiprecision/rational_adaptor.hpp
@@ -6,126 +6,126 @@
 #ifndef BOOST_MATH_RATIONAL_ADAPTER_HPP
 #define BOOST_MATH_RATIONAL_ADAPTER_HPP
 
-#include <iostream>
-#include <iomanip>
-#include <sstream>
 #include <boost/cstdint.hpp>
 #include <boost/functional/hash_fwd.hpp>
 #include <boost/multiprecision/number.hpp>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
 #ifdef BOOST_MSVC
-#  pragma warning(push)
-#  pragma warning(disable:4512 4127)
+#pragma warning(push)
+#pragma warning(disable : 4512 4127)
 #endif
 #include <boost/rational.hpp>
 #ifdef BOOST_MSVC
-#  pragma warning(pop)
+#pragma warning(pop)
 #endif
 
-namespace boost{
-namespace multiprecision{
-namespace backends{
+namespace boost {
+namespace multiprecision {
+namespace backends {
 
 template <class IntBackend>
 struct rational_adaptor
 {
-   typedef number<IntBackend>                integer_type;
-   typedef boost::rational<integer_type>        rational_type;
+   typedef number<IntBackend>            integer_type;
+   typedef boost::rational<integer_type> rational_type;
 
-   typedef typename IntBackend::signed_types    signed_types;
-   typedef typename IntBackend::unsigned_types  unsigned_types;
-   typedef typename IntBackend::float_types     float_types;
+   typedef typename IntBackend::signed_types   signed_types;
+   typedef typename IntBackend::unsigned_types unsigned_types;
+   typedef typename IntBackend::float_types    float_types;
 
    rational_adaptor() BOOST_MP_NOEXCEPT_IF(noexcept(rational_type())) {}
-   rational_adaptor(const rational_adaptor& o) BOOST_MP_NOEXCEPT_IF(noexcept(std::declval<rational_type&>() = std::declval<const rational_type&>()))
+   rational_adaptor(const rational_adaptor &o) BOOST_MP_NOEXCEPT_IF(noexcept(std::declval<rational_type &>() = std::declval<const rational_type &>()))
    {
       m_value = o.m_value;
    }
-   rational_adaptor(const IntBackend& o) BOOST_MP_NOEXCEPT_IF(noexcept(rational_type(std::declval<const IntBackend&>()))) : m_value(o) {}
+   rational_adaptor(const IntBackend &o) BOOST_MP_NOEXCEPT_IF(noexcept(rational_type(std::declval<const IntBackend &>()))) : m_value(o) {}
 
    template <class U>
-   rational_adaptor(const U& u, typename enable_if_c<is_convertible<U, IntBackend>::value>::type* = 0) 
-      : m_value(static_cast<integer_type>(u)){}
+   rational_adaptor(const U &u, typename enable_if_c<is_convertible<U, IntBackend>::value>::type * = 0)
+       : m_value(static_cast<integer_type>(u)) {}
    template <class U>
-   explicit rational_adaptor(const U& u, 
-      typename enable_if_c<
-         boost::multiprecision::detail::is_explicitly_convertible<U, IntBackend>::value && !is_convertible<U, IntBackend>::value
-      >::type* = 0) 
-      : m_value(IntBackend(u)){}
+   explicit rational_adaptor(const U &u,
+                             typename enable_if_c<
+                                 boost::multiprecision::detail::is_explicitly_convertible<U, IntBackend>::value && !is_convertible<U, IntBackend>::value>::type * = 0)
+       : m_value(IntBackend(u)) {}
    template <class U>
-   typename enable_if_c<(boost::multiprecision::detail::is_explicitly_convertible<U, IntBackend>::value && !is_arithmetic<U>::value), rational_adaptor&>::type operator = (const U& u) 
+   typename enable_if_c<(boost::multiprecision::detail::is_explicitly_convertible<U, IntBackend>::value && !is_arithmetic<U>::value), rational_adaptor &>::type operator=(const U &u)
    {
       m_value = IntBackend(u);
       return *this;
    }
 
 #ifndef BOOST_NO_CXX11_RVALUE_REFERENCES
-   rational_adaptor(rational_adaptor&& o) BOOST_MP_NOEXCEPT_IF(noexcept(rational_type(std::declval<rational_type>()))) : m_value(static_cast<rational_type&&>(o.m_value)) {}
-   rational_adaptor(IntBackend&& o) BOOST_MP_NOEXCEPT_IF(noexcept(rational_type(std::declval<IntBackend>()))) : m_value(static_cast<IntBackend&&>(o)) {}
-   rational_adaptor& operator = (rational_adaptor&& o) BOOST_MP_NOEXCEPT_IF(noexcept(std::declval<rational_type&>() = std::declval<rational_type>()))
+   rational_adaptor(rational_adaptor &&o) BOOST_MP_NOEXCEPT_IF(noexcept(rational_type(std::declval<rational_type>()))) : m_value(static_cast<rational_type &&>(o.m_value))
+   {}
+   rational_adaptor(IntBackend &&o) BOOST_MP_NOEXCEPT_IF(noexcept(rational_type(std::declval<IntBackend>()))) : m_value(static_cast<IntBackend &&>(o)) {}
+   rational_adaptor &operator=(rational_adaptor &&o) BOOST_MP_NOEXCEPT_IF(noexcept(std::declval<rational_type &>() = std::declval<rational_type>()))
    {
-      m_value = static_cast<rational_type&&>(o.m_value);
+      m_value = static_cast<rational_type &&>(o.m_value);
       return *this;
    }
 #endif
-   rational_adaptor& operator = (const rational_adaptor& o)
+   rational_adaptor &operator=(const rational_adaptor &o)
    {
       m_value = o.m_value;
       return *this;
    }
-   rational_adaptor& operator = (const IntBackend& o)
+   rational_adaptor &operator=(const IntBackend &o)
    {
       m_value = o;
       return *this;
    }
    template <class Int>
-   typename enable_if<is_integral<Int>, rational_adaptor&>::type operator = (Int i)
+   typename enable_if<is_integral<Int>, rational_adaptor &>::type operator=(Int i)
    {
       m_value = i;
       return *this;
    }
    template <class Float>
-   typename enable_if<is_floating_point<Float>, rational_adaptor&>::type operator = (Float i)
+   typename enable_if<is_floating_point<Float>, rational_adaptor &>::type operator=(Float i)
    {
-      int e;
+      int   e;
       Float f = std::frexp(i, &e);
-      f = std::ldexp(f, std::numeric_limits<Float>::digits);
+      f       = std::ldexp(f, std::numeric_limits<Float>::digits);
       e -= std::numeric_limits<Float>::digits;
       integer_type num(f);
       integer_type denom(1u);
-      if(e > 0)
+      if (e > 0)
       {
          num <<= e;
       }
-      else if(e < 0)
+      else if (e < 0)
       {
          denom <<= -e;
       }
       m_value.assign(num, denom);
       return *this;
    }
-   rational_adaptor& operator = (const char* s)
+   rational_adaptor &operator=(const char *s)
    {
-      std::string s1;
+      std::string                        s1;
       multiprecision::number<IntBackend> v1, v2;
-      char c;
-      bool have_hex = false;
-      const char* p = s; // saved for later
+      char                               c;
+      bool                               have_hex = false;
+      const char *                       p        = s; // saved for later
 
-      while((0 != (c = *s)) && (c == 'x' || c == 'X' || c == '-' || c == '+' || (c >= '0' && c <= '9') || (have_hex && (c >= 'a' && c <= 'f')) || (have_hex && (c >= 'A' && c <= 'F'))))
+      while ((0 != (c = *s)) && (c == 'x' || c == 'X' || c == '-' || c == '+' || (c >= '0' && c <= '9') || (have_hex && (c >= 'a' && c <= 'f')) || (have_hex && (c >= 'A' && c <= 'F'))))
       {
-         if(c == 'x' || c == 'X')
+         if (c == 'x' || c == 'X')
             have_hex = true;
          s1.append(1, c);
          ++s;
       }
       v1.assign(s1);
       s1.erase();
-      if(c == '/')
+      if (c == '/')
       {
          ++s;
-         while((0 != (c = *s)) && (c == 'x' || c == 'X' || c == '-' || c == '+' || (c >= '0' && c <= '9') || (have_hex && (c >= 'a' && c <= 'f')) || (have_hex && (c >= 'A' && c <= 'F'))))
+         while ((0 != (c = *s)) && (c == 'x' || c == 'X' || c == '-' || c == '+' || (c >= '0' && c <= '9') || (have_hex && (c >= 'a' && c <= 'f')) || (have_hex && (c >= 'A' && c <= 'F'))))
          {
-            if(c == 'x' || c == 'X')
+            if (c == 'x' || c == 'X')
                have_hex = true;
             s1.append(1, c);
             ++s;
@@ -134,24 +134,24 @@ struct rational_adaptor
       }
       else
          v2 = 1;
-      if(*s)
+      if (*s)
       {
          BOOST_THROW_EXCEPTION(std::runtime_error(std::string("Could not parse the string \"") + p + std::string("\" as a valid rational number.")));
       }
       data().assign(v1, v2);
       return *this;
    }
-   void swap(rational_adaptor& o)
+   void swap(rational_adaptor &o)
    {
       std::swap(m_value, o.m_value);
    }
-   std::string str(std::streamsize digits, std::ios_base::fmtflags f)const
+   std::string str(std::streamsize digits, std::ios_base::fmtflags f) const
    {
       //
       // We format the string ourselves so we can match what GMP's mpq type does:
       //
       std::string result = data().numerator().str(digits, f);
-      if(data().denominator() != 1)
+      if (data().denominator() != 1)
       {
          result.append(1, '/');
          result.append(data().denominator().str(digits, f));
@@ -162,72 +162,73 @@ struct rational_adaptor
    {
       m_value = -m_value;
    }
-   int compare(const rational_adaptor& o)const
+   int compare(const rational_adaptor &o) const
    {
       return m_value > o.m_value ? 1 : (m_value < o.m_value ? -1 : 0);
    }
    template <class Arithmatic>
-   typename enable_if_c<is_arithmetic<Arithmatic>::value && !is_floating_point<Arithmatic>::value, int>::type compare(Arithmatic i)const
+   typename enable_if_c<is_arithmetic<Arithmatic>::value && !is_floating_point<Arithmatic>::value, int>::type compare(Arithmatic i) const
    {
       return m_value > i ? 1 : (m_value < i ? -1 : 0);
    }
    template <class Arithmatic>
-   typename enable_if_c<is_floating_point<Arithmatic>::value, int>::type compare(Arithmatic i)const
+   typename enable_if_c<is_floating_point<Arithmatic>::value, int>::type compare(Arithmatic i) const
    {
       rational_adaptor r;
       r = i;
       return this->compare(r);
    }
-   rational_type& data() { return m_value; }
-   const rational_type& data()const { return m_value; }
+   rational_type &      data() { return m_value; }
+   const rational_type &data() const { return m_value; }
 
    template <class Archive>
-   void serialize(Archive& ar, const mpl::true_&)
+   void serialize(Archive &ar, const mpl::true_ &)
    {
       // Saving
       integer_type n(m_value.numerator()), d(m_value.denominator());
-      ar & boost::serialization::make_nvp("numerator", n);
-      ar & boost::serialization::make_nvp("denominator", d);
+      ar &         boost::serialization::make_nvp("numerator", n);
+      ar &         boost::serialization::make_nvp("denominator", d);
    }
    template <class Archive>
-   void serialize(Archive& ar, const mpl::false_&)
+   void serialize(Archive &ar, const mpl::false_ &)
    {
       // Loading
       integer_type n, d;
-      ar & boost::serialization::make_nvp("numerator", n);
-      ar & boost::serialization::make_nvp("denominator", d);
+      ar &         boost::serialization::make_nvp("numerator", n);
+      ar &         boost::serialization::make_nvp("denominator", d);
       m_value.assign(n, d);
    }
    template <class Archive>
-   void serialize(Archive& ar, const unsigned int /*version*/)
+   void serialize(Archive &ar, const unsigned int /*version*/)
    {
       typedef typename Archive::is_saving tag;
       serialize(ar, tag());
    }
-private:
+
+ private:
    rational_type m_value;
 };
 
 template <class IntBackend>
-inline void eval_add(rational_adaptor<IntBackend>& result, const rational_adaptor<IntBackend>& o)
+inline void eval_add(rational_adaptor<IntBackend> &result, const rational_adaptor<IntBackend> &o)
 {
    result.data() += o.data();
 }
 template <class IntBackend>
-inline void eval_subtract(rational_adaptor<IntBackend>& result, const rational_adaptor<IntBackend>& o)
+inline void eval_subtract(rational_adaptor<IntBackend> &result, const rational_adaptor<IntBackend> &o)
 {
    result.data() -= o.data();
 }
 template <class IntBackend>
-inline void eval_multiply(rational_adaptor<IntBackend>& result, const rational_adaptor<IntBackend>& o)
+inline void eval_multiply(rational_adaptor<IntBackend> &result, const rational_adaptor<IntBackend> &o)
 {
    result.data() *= o.data();
 }
 template <class IntBackend>
-inline void eval_divide(rational_adaptor<IntBackend>& result, const rational_adaptor<IntBackend>& o)
+inline void eval_divide(rational_adaptor<IntBackend> &result, const rational_adaptor<IntBackend> &o)
 {
    using default_ops::eval_is_zero;
-   if(eval_is_zero(o))
+   if (eval_is_zero(o))
    {
       BOOST_THROW_EXCEPTION(std::overflow_error("Divide by zero."));
    }
@@ -235,7 +236,7 @@ inline void eval_divide(rational_adaptor<IntBackend>& result, const rational_ada
 }
 
 template <class R, class IntBackend>
-inline typename enable_if_c<number_category<R>::value == number_kind_floating_point>::type eval_convert_to(R* result, const rational_adaptor<IntBackend>& backend)
+inline typename enable_if_c<number_category<R>::value == number_kind_floating_point>::type eval_convert_to(R *result, const rational_adaptor<IntBackend> &backend)
 {
    //
    // The generic conversion is as good as anything we can write here:
@@ -244,59 +245,60 @@ inline typename enable_if_c<number_category<R>::value == number_kind_floating_po
 }
 
 template <class R, class IntBackend>
-inline typename enable_if_c<(number_category<R>::value != number_kind_integer) && (number_category<R>::value != number_kind_floating_point)>::type eval_convert_to(R* result, const rational_adaptor<IntBackend>& backend)
+inline typename enable_if_c<(number_category<R>::value != number_kind_integer) && (number_category<R>::value != number_kind_floating_point)>::type eval_convert_to(R *result, const rational_adaptor<IntBackend> &backend)
 {
    typedef typename component_type<number<rational_adaptor<IntBackend> > >::type comp_t;
-   comp_t num(backend.data().numerator());
-   comp_t denom(backend.data().denominator());
+   comp_t                                                                        num(backend.data().numerator());
+   comp_t                                                                        denom(backend.data().denominator());
    *result = num.template convert_to<R>();
    *result /= denom.template convert_to<R>();
 }
 
 template <class R, class IntBackend>
-inline typename enable_if_c<number_category<R>::value == number_kind_integer>::type eval_convert_to(R* result, const rational_adaptor<IntBackend>& backend)
+inline typename enable_if_c<number_category<R>::value == number_kind_integer>::type eval_convert_to(R *result, const rational_adaptor<IntBackend> &backend)
 {
    typedef typename component_type<number<rational_adaptor<IntBackend> > >::type comp_t;
-   comp_t t = backend.data().numerator();
+   comp_t                                                                        t = backend.data().numerator();
    t /= backend.data().denominator();
    *result = t.template convert_to<R>();
 }
 
 template <class IntBackend>
-inline bool eval_is_zero(const rational_adaptor<IntBackend>& val)
+inline bool eval_is_zero(const rational_adaptor<IntBackend> &val)
 {
    using default_ops::eval_is_zero;
    return eval_is_zero(val.data().numerator().backend());
 }
 template <class IntBackend>
-inline int eval_get_sign(const rational_adaptor<IntBackend>& val)
+inline int eval_get_sign(const rational_adaptor<IntBackend> &val)
 {
    using default_ops::eval_get_sign;
    return eval_get_sign(val.data().numerator().backend());
 }
 
-template<class IntBackend, class V>
-inline void assign_components(rational_adaptor<IntBackend>& result, const V& v1, const V& v2)
+template <class IntBackend, class V>
+inline void assign_components(rational_adaptor<IntBackend> &result, const V &v1, const V &v2)
 {
    result.data().assign(v1, v2);
 }
 
 template <class IntBackend>
-inline std::size_t hash_value(const rational_adaptor<IntBackend>& val)
+inline std::size_t hash_value(const rational_adaptor<IntBackend> &val)
 {
    std::size_t result = hash_value(val.data().numerator());
    boost::hash_combine(result, val.data().denominator());
    return result;
 }
 
-
 } // namespace backends
 
-template<class IntBackend>
-struct expression_template_default<backends::rational_adaptor<IntBackend> > : public expression_template_default<IntBackend> {};
-   
-template<class IntBackend>
-struct number_category<backends::rational_adaptor<IntBackend> > : public mpl::int_<number_kind_rational>{};
+template <class IntBackend>
+struct expression_template_default<backends::rational_adaptor<IntBackend> > : public expression_template_default<IntBackend>
+{};
+
+template <class IntBackend>
+struct number_category<backends::rational_adaptor<IntBackend> > : public mpl::int_<number_kind_rational>
+{};
 
 using boost::multiprecision::backends::rational_adaptor;
 
@@ -307,42 +309,43 @@ struct component_type<number<backends::rational_adaptor<Backend>, ExpressionTemp
 };
 
 template <class IntBackend, expression_template_option ET>
-inline number<IntBackend, ET> numerator(const number<rational_adaptor<IntBackend>, ET>& val)
+inline number<IntBackend, ET> numerator(const number<rational_adaptor<IntBackend>, ET> &val)
 {
    return val.backend().data().numerator();
 }
 template <class IntBackend, expression_template_option ET>
-inline number<IntBackend, ET> denominator(const number<rational_adaptor<IntBackend>, ET>& val)
+inline number<IntBackend, ET> denominator(const number<rational_adaptor<IntBackend>, ET> &val)
 {
    return val.backend().data().denominator();
 }
 
 #ifdef BOOST_NO_SFINAE_EXPR
 
-namespace detail{
+namespace detail {
 
-template<class U, class IntBackend>
-struct is_explicitly_convertible<U, rational_adaptor<IntBackend> > : public is_explicitly_convertible<U, IntBackend> {};
+template <class U, class IntBackend>
+struct is_explicitly_convertible<U, rational_adaptor<IntBackend> > : public is_explicitly_convertible<U, IntBackend>
+{};
 
-}
+} // namespace detail
 
 #endif
 
-}} // namespaces
+}} // namespace boost::multiprecision
 
-
-namespace std{
+namespace std {
 
 template <class IntBackend, boost::multiprecision::expression_template_option ExpressionTemplates>
 class numeric_limits<boost::multiprecision::number<boost::multiprecision::rational_adaptor<IntBackend>, ExpressionTemplates> > : public std::numeric_limits<boost::multiprecision::number<IntBackend, ExpressionTemplates> >
 {
-   typedef std::numeric_limits<boost::multiprecision::number<IntBackend> > base_type;
+   typedef std::numeric_limits<boost::multiprecision::number<IntBackend> >                     base_type;
    typedef boost::multiprecision::number<boost::multiprecision::rational_adaptor<IntBackend> > number_type;
-public:
+
+ public:
    BOOST_STATIC_CONSTEXPR bool is_integer = false;
-   BOOST_STATIC_CONSTEXPR bool is_exact = true;
-   BOOST_STATIC_CONSTEXPR number_type (min)() { return (base_type::min)(); }
-   BOOST_STATIC_CONSTEXPR number_type (max)() { return (base_type::max)(); }
+   BOOST_STATIC_CONSTEXPR bool is_exact   = true;
+   BOOST_STATIC_CONSTEXPR      number_type(min)() { return (base_type::min)(); }
+   BOOST_STATIC_CONSTEXPR      number_type(max)() { return (base_type::max)(); }
    BOOST_STATIC_CONSTEXPR number_type lowest() { return -(max)(); }
    BOOST_STATIC_CONSTEXPR number_type epsilon() { return base_type::epsilon(); }
    BOOST_STATIC_CONSTEXPR number_type round_error() { return epsilon() / 2; }
@@ -361,7 +364,6 @@ BOOST_CONSTEXPR_OR_CONST bool numeric_limits<boost::multiprecision::number<boost
 
 #endif
 
-
-}
+} // namespace std
 
 #endif


### PR DESCRIPTION
Semi-automatic reformatting according to the ```.clang_format``` introduced.

This would allow us to adjust the ```.clang_format``` contents.

I think this is necessary because for further development I'm going to be using semi-automatic tools, so I think do you. This is the exact result it produced according to ```.clang_format```.