### PR TITLE
Correct docs for GCC's 'Q' suffix

### DIFF
--- a/doc/html/boost_multiprecision/tut/floats/float128.html
+++ b/doc/html/boost_multiprecision/tut/floats/float128.html
@@ -108,9 +108,10 @@
             </li>
 <li class="listitem">
               When compiling with <code class="computeroutput"><span class="identifier">gcc</span></code>,
-              you need to use the flag <code class="computeroutput"><span class="special">--</span><span class="identifier">std</span><span class="special">=</span><span class="identifier">gnu</span><span class="special">++</span><span class="number">11</span><span class="special">/</span><span class="number">14</span><span class="special">/</span><span class="number">17</span></code>,
-              as the numeric literal operator 'operator""Q' is a GNU extension.
-              Compilation fails with the flag <code class="computeroutput"><span class="special">--</span><span class="identifier">std</span><span class="special">=</span><span class="identifier">c</span><span class="special">++</span><span class="number">11</span><span class="special">/</span><span class="number">14</span><span class="special">/</span><span class="number">17</span></code>.
+              you need to use the flag <code class="computeroutput"><span class="special">-</span><span class="identifier">std</span><span class="special">=</span><span class="identifier">gnu</span><span class="special">++</span><span class="number">11</span><span class="special">/</span><span class="number">14</span><span class="special">/</span><span class="number">17</span></code>,
+              as the suffix 'Q' is a GNU extension.
+              Compilation fails with the flag <code class="computeroutput"><span class="special">-</span><span class="identifier">std</span><span class="special">=</span><span class="identifier">c</span><span class="special">++</span><span class="number">11</span><span class="special">/</span><span class="number">14</span><span class="special">/</span><span class="number">17</span></code>
+              unless you also use <code class="computeroutput"><span class="identifier">-fext-numeric-literals</span></code>.
             </li>
 </ul></div>
 <h6>


### PR DESCRIPTION
There is no 'operator""Q', it's a built-in numeric suffix for floating-point literals, not a user-defined literal operator. Support for that suffix is disabled for -std=c++NN modes unless you use the -fext-numeric-literals option to enable the extension.

Also the correct spelling of the option is -std not --std.