### PR TITLE
Fix Apple clang version detection false positives.

### DIFF
--- a/include/boost/multiprecision/number.hpp
+++ b/include/boost/multiprecision/number.hpp
@@ -860,7 +860,7 @@ class number
       return this->template convert_to<T>();
    }
 #else
-#if BOOST_WORKAROUND(BOOST_MSVC, < 1900) || (defined(__APPLE_CC__) && BOOST_WORKAROUND(__clang_major__, < 9))
+#if BOOST_WORKAROUND(BOOST_MSVC, < 1900) || (defined(__apple_build_version__) && BOOST_WORKAROUND(__clang_major__, < 9))
    template <class T>
 #else
    template <class T, class = typename boost::disable_if_c<boost::is_constructible<T, self_type const&>::value || !boost::is_default_constructible<T>::value || (!boost::is_arithmetic<T>::value && !boost::is_complex<T>::value), T>::type>


### PR DESCRIPTION
In number.hpp, a workaround is presented for old versions of Apple clang. Apple uses non-standard version numbers, which makes it difficult to rely on ```__clang_major__```. The code first checked ```__APPLE_CC__``` in an attempt to check "is this compiler using Apple's version numbering", but open source upstream clang versions also define this variable when compiling to Apple targets; as this workaround breaks some client code, this makes some codebases impossible to compile for Apple targets with upstream clang. The correct variable to check is ```__apple_build_version__```.