### PR TITLE
karatsuba multiplication in cpp_int

### DIFF
--- a/include/boost/multiprecision/cpp_int/multiply.hpp
+++ b/include/boost/multiprecision/cpp_int/multiply.hpp
@@ -70,12 +70,6 @@ inline BOOST_MP_CXX14_CONSTEXPR void resize_for_carry(cpp_int_backend<MinBits1, 
    if (result.size() < required)
       result.resize(required, required);
 }
-#define DBG(r) \
-	std::cerr<<#r<<" is: \n"; \
-	for(int i=r.size()-1;i>=0;--i){ \
-		std::cerr<<std::bitset<64>(r.limbs()[i])<<'\n'; \
-	} \
-	std::cerr<<'\n';
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1, unsigned MinBits2, unsigned MaxBits2, cpp_integer_type SignType2, cpp_int_check_type Checked2, class Allocator2, unsigned MinBits3, unsigned MaxBits3, cpp_integer_type SignType3, cpp_int_check_type Checked3, class Allocator3>
 inline BOOST_MP_CXX14_CONSTEXPR typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits3, MaxBits3, SignType3, Checked3, Allocator3> >::value>::type
 eval_multiply(
@@ -144,97 +138,68 @@ eval_multiply(
    typename cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::limb_pointer pr = result.limbs();
    BOOST_STATIC_ASSERT(double_limb_max - 2 * limb_max >= limb_max * limb_max);
 
-//#ifndef BOOST_MP_NO_CONSTEXPR_DETECTION
-//   if (BOOST_MP_IS_CONST_EVALUATED(as))
-//   {
-//      for (unsigned i = 0; i < result.size(); ++i)
-//         pr[i] = 0;
-//   }
-//   else
-//#endif
-//   std::memset(pr, 0, result.size() * sizeof(limb_type));
-	std::fill(pr, pr + result.size(), 0);
-	double_limb_type carry = 0;
+   std::fill(pr, pr + result.size(), 0);
+   double_limb_type carry = 0;
 
-	if(as >= karatsuba_cutoff && bs >= karatsuba_cutoff)
-	{
-		unsigned n = (as > bs ? as : bs) / 2 + 1;
-		// write a, b as a = a_h * 2^n + a_l, b = b_h * 2^n + b_l
-		cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> a_h, a_l, b_h, b_l;
+   if(as >= karatsuba_cutoff && bs >= karatsuba_cutoff)
+   {
+	   unsigned n = (as > bs ? as : bs) / 2 + 1;
+	   // write a, b as a = a_h * 2^n + a_l, b = b_h * 2^n + b_l
+	   cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> a_h, a_l, b_h, b_l;
 
-		unsigned sz = (std::min)(as, n);
-		a_l.resize(sz, sz);
-		std::copy(a.limbs(), a.limbs() + sz, a_l.limbs());
+	   unsigned sz = (std::min)(as, n);
+	   a_l.resize(sz, sz);
+	   std::copy(a.limbs(), a.limbs() + sz, a_l.limbs());
 
-		sz = (std::min)(bs, n);
-		b_l.resize(sz, sz);
-		std::copy(b.limbs(), b.limbs() + sz, b_l.limbs());
+	   sz = (std::min)(bs, n);
+	   b_l.resize(sz, sz);
+	   std::copy(b.limbs(), b.limbs() + sz, b_l.limbs());
 
-		if(as > n){
-			a_h.resize(as - n, as - n);
-			std::copy(a.limbs() + n, a.limbs() + as, a_h.limbs());
-		}
-		else
-		{
-			a_h.resize(1,1);
-			a_h.limbs()[0] = 0;
-		}
-		if(bs > n)
-		{
-			b_h.resize(bs - n, bs - n);
-			std::copy(b.limbs() + n, b.limbs() + bs, b_h.limbs());
-		}
-		else
-		{
-			b_h.resize(1,1);
-			b_h.limbs()[0] = 0;
-		}
+	   if(as > n){
+		   a_h.resize(as - n, as - n);
+		   std::copy(a.limbs() + n, a.limbs() + as, a_h.limbs());
+	   }
+	   else
+	   {
+		   a_h.resize(1,1);
+		   a_h.limbs()[0] = 0;
+	   }
+	   if(bs > n)
+	   {
+		   b_h.resize(bs - n, bs - n);
+		   std::copy(b.limbs() + n, b.limbs() + bs, b_h.limbs());
+	   }
+	   else
+	   {
+		   b_h.resize(1,1);
+		   b_h.limbs()[0] = 0;
+	   }
 
-		cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> t1, t2;
-		eval_multiply(t1, a_l, b_l);
-		std::copy(t1.limbs(), t1.limbs() + t1.size(), result.limbs());
-		eval_multiply(t2, a_h, b_h);
-		resize_for_carry(result, 2 * n + t2.size());
-		std::copy(t2.limbs(), t2.limbs() + t2.size(), result.limbs() + 2 * n);
+	   // x = a_h * b_ h
+	   // y = a_l * b_l
+	   // z = (a_h + a_l)*(b_h + b_l) - x - y
+	   //  a * b = x * (2 ^ (2 * n))+ z * (2 ^ n) + y
+	   cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> t1, t2;
+	   // result = | a_h*b_h  | a_l*b_l |
+	   // (bits)              <-- 2*n -->
+	   eval_multiply(t1, a_l, b_l);
+	   eval_multiply(t2, a_h, b_h);
+	   resize_for_carry(result, t1.size());
+	   std::copy(t1.limbs(), t1.limbs() + t1.size(), result.limbs());
+	   resize_for_carry(result, 2 * n + t2.size());
+	   std::copy(t2.limbs(), t2.limbs() + t2.size(), result.limbs() + 2 * n);
 
-//		DBG(a);
-//		DBG(a_l);
-//		DBG(a_h);
-//		DBG(b);
-//		DBG(b_l);
-//		DBG(b_h);
-//		DBG(t1);
-//		DBG(t2);
-//		DBG(result);
-		eval_add(t1, t2);
-		eval_add(a_l, a_h);
-		eval_add(b_l, b_h);
-		eval_multiply(t2, a_l, b_l);
-		eval_subtract(t2, t1);
-		eval_left_shift(t2, n * limb_bits);
-		eval_add(result, t2);
+	   eval_add(t1, t2);  // t1 = a_l*b_l + a_h*b_h
+	   eval_add(a_l, a_h);
+	   eval_add(b_l, b_h);
+	   eval_multiply(t2, a_l, b_l); // t2 = (a_h+a_l)*(b_h+b_l)
+	   eval_subtract(t2, t1);
+	   eval_left_shift(t2, n * limb_bits); // t2 = 2^n * ( (a_h+a_l)*(b_h*b_l) - a_h*b_h - a_l*b_l)
+	   eval_add(result, t2);
 
-		//resize_for_carry(result, n + t2.size());
-		//unsigned i = 0;
-		//for(i = 0; i < t2.size(); ++i)
-		//{
-		//	carry += static_cast<double_limb_type>(result.limbs()[n + i]) + static_cast<double_limb_type>(t2.limbs()[i]);
-		//	result.limbs()[n + i] = static_cast<limb_type>(carry);
-		//	carry >>= cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::limb_bits;
-		//}
-		//i += n;
-		//while(carry)
-		//{
-		//	resize_for_carry(result, i + 1);
-		//	carry += static_cast<double_limb_type>(result.limbs()[i]);
-		//	result.limbs()[i] = static_cast<limb_type>(carry);
-		//	carry >>= cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::limb_bits;
-		//	i++;
-		//}
-		
-		result.normalize();
-		result.sign(a.sign() != b.sign());	
-		return ;
+	   result.normalize();
+	   result.sign(a.sign() != b.sign());	
+	   return ;
 	}
 
    for (unsigned i = 0; i < as; ++i)

--- a/include/boost/multiprecision/cpp_int/multiply.hpp
+++ b/include/boost/multiprecision/cpp_int/multiply.hpp
@@ -78,7 +78,7 @@ eval_multiply(
     const cpp_int_backend<MinBits3, MaxBits3, SignType3, Checked3, Allocator3>& b) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
    // Uses simple (O(n^2)) multiplication when the limbs are less
-   // otherwise switches to karatsuba algorithm based on experimental value (~10 limbs)
+   // otherwise switches to karatsuba algorithm based on experimental value (~100 limbs)
    //
    // Trivial cases first:
    //
@@ -124,15 +124,15 @@ eval_multiply(
    }
 
 #ifdef BOOST_NO_CXX14_CONSTEXPR
-   static const double_limb_type limb_max        = ~static_cast<limb_type>(0u);
+   static const double_limb_type limb_max = ~static_cast<limb_type>(0u);
    static const double_limb_type double_limb_max = ~static_cast<double_limb_type>(0u);
-   static const size_t karatsuba_cutoff			 = 100;
-   static const unsigned limb_bits 				 = sizeof(limb_type) * CHAR_BIT;
+   static const size_t karatsuba_cutoff	= 100;
+   static const unsigned limb_bits = sizeof(limb_type) * CHAR_BIT;
 #else
-   constexpr const double_limb_type limb_max 		= ~static_cast<limb_type>(0u);
+   constexpr const double_limb_type limb_max = ~static_cast<limb_type>(0u);
    constexpr const double_limb_type double_limb_max = ~static_cast<double_limb_type>(0u);
-   constexpr const size_t karatsuba_cutoff			= 100;
-   constexpr const unsigned limb_bits 				= sizeof(limb_type) * CHAR_BIT;
+   constexpr const size_t karatsuba_cutoff = 100;
+   constexpr const unsigned limb_bits = sizeof(limb_type) * CHAR_BIT;
 #endif
    result.resize(as + bs, as + bs - 1);
    typename cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::limb_pointer pr = result.limbs();

--- a/include/boost/multiprecision/cpp_int/multiply.hpp
+++ b/include/boost/multiprecision/cpp_int/multiply.hpp
@@ -70,8 +70,6 @@ inline BOOST_MP_CXX14_CONSTEXPR void resize_for_carry(cpp_int_backend<MinBits1, 
    if (result.size() < required)
       result.resize(required, required);
 }
-#include<iostream>
-#define DBG(x) std::cerr<<#x<<"is : "<<x<<'\n';
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1, unsigned MinBits2, unsigned MaxBits2, cpp_integer_type SignType2, cpp_int_check_type Checked2, class Allocator2, unsigned MinBits3, unsigned MaxBits3, cpp_integer_type SignType3, cpp_int_check_type Checked3, class Allocator3>
 inline BOOST_MP_CXX14_CONSTEXPR typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits3, MaxBits3, SignType3, Checked3, Allocator3> >::value>::type
 eval_multiply(


### PR DESCRIPTION
Until now, `cpp_int` uses O(n**2) grade school multiplication which is highly optimized for not so small numbers. Note that there are other multiplication algorithms like Toom-3, Toom-4, FFT but for simplicity, karatsuba is chosen.

The karatsuba cutoff is set to 100 limbs which is experimentally determined, although the limit could be as low as 10 limbs (as per GMP) but to avoid deep recursion depth 100 limbs is chosen.

There is ~10% reduction in runtime for numbers falling beyond the cutoff value.  This can be improved further I guess because [python's karatsuba](https://hg.python.org/cpython/file/b514339e41ef/Objects/longobject.c#l2694) is around three times faster. I have tinkered around and I suspect that the `cpp_int` backend is slow as the algorithmic steps used are somewhat similar to that of python's.

Compiling & Testing:
1. Manually tested using randomly generated numbers as high having up to a million digits.
2. Unit test passed
3. No warnings were seen when compiled using `-Wall` using clang++ (v6.0.0) and g++(v7.3.2).