### PR TITLE
Comba Multiplier

### DIFF
--- a/include/boost/multiprecision/cpp_int/multiply.hpp
+++ b/include/boost/multiprecision/cpp_int/multiply.hpp
@@ -318,7 +318,7 @@ eval_multiply_comba(
    // Comba Multiplier - based on
    // Exponentiation cryptosystems on the IBM PC, 1990
    int  as = a.size(), bs = b.size(), rs = result.size();
-   auto pr = result.limbs();
+   typename cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::limb_pointer pr = result.limbs();
 
    double_limb_type carry     = 0;
    limb_type        overflow  = 0;
@@ -328,11 +328,11 @@ eval_multiply_comba(
       int i   = r >= as ? as - 1 : r,
           j   = r - i,
           k   = i < bs - j ? i + 1 : bs - j; // min(i+1, bs-j);
-      auto pa = a.limbs() + i;
-      auto pb = b.limbs() + j;
+      typename cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2>::limb_pointer pa = a.limbs() + i;
+      typename cpp_int_backend<MinBits3, MaxBits3, SignType3, Checked3, Allocator3>::limb_pointer pb = b.limbs() + j;
       while (k--)
       {
-         auto temp = carry;
+         double_limb_type temp = carry;
          carry += static_cast<double_limb_type>(*(pa--)) * static_cast<double_limb_type>(*(pb++));
          overflow += carry < temp;
       }

--- a/include/boost/multiprecision/cpp_int/multiply.hpp
+++ b/include/boost/multiprecision/cpp_int/multiply.hpp
@@ -334,7 +334,7 @@ eval_multiply_comba(
       while (k--)
       {
          double_limb_type temp = carry;
-         carry += static_cast<double_limb_type>(*(pa--)) * static_cast<double_limb_type>(*(pb++));
+         carry += static_cast<double_limb_type>(*(pa--)) * (*(pb++));
          overflow += carry < temp;
       }
       *(pr++) = static_cast<limb_type>(carry);

--- a/include/boost/multiprecision/cpp_int/multiply.hpp
+++ b/include/boost/multiprecision/cpp_int/multiply.hpp
@@ -452,7 +452,7 @@ eval_multiply(
    std::memset(pr, 0, result.size() * sizeof(limb_type));   
    double_limb_type carry = 0;
 
-#if true // For testing purposes only, other replace this with : defined(BOOST_MP_COMBA) || __GNUC__ >= 10
+#if 1 // For testing purposes only, other replace this with : defined(BOOST_MP_COMBA) || __GNUC__ >= 10
        // 
 	   // Comba Multiplier might not be efficient because of less efficient assembly
 	   // by the compiler as of 09/01/2020 (DD/MM/YY). See PR #182

--- a/include/boost/multiprecision/cpp_int/multiply.hpp
+++ b/include/boost/multiprecision/cpp_int/multiply.hpp
@@ -439,7 +439,6 @@ eval_multiply(
 	   return ;
    //}
 
-   double_limb_type carry = 0;
    for (unsigned i = 0; i < as; ++i)
    {
       BOOST_ASSERT(result.size() > i);

--- a/include/boost/multiprecision/cpp_int/multiply.hpp
+++ b/include/boost/multiprecision/cpp_int/multiply.hpp
@@ -309,38 +309,39 @@ setup_karatsuba(
 }
 
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1, unsigned MinBits2, unsigned MaxBits2, cpp_integer_type SignType2, cpp_int_check_type Checked2, class Allocator2, unsigned MinBits3, unsigned MaxBits3, cpp_integer_type SignType3, cpp_int_check_type Checked3, class Allocator3>
-	inline BOOST_MP_CXX14_CONSTEXPR typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits3, MaxBits3, SignType3, Checked3, Allocator3> >::value>::type
+inline BOOST_MP_CXX14_CONSTEXPR typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits3, MaxBits3, SignType3, Checked3, Allocator3> >::value>::type
 eval_multiply_comba(
-		cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>&       result,
-		const cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2>& a,
-		const cpp_int_backend<MinBits3, MaxBits3, SignType3, Checked3, Allocator3>& b) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
+    cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>&       result,
+    const cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2>& a,
+    const cpp_int_backend<MinBits3, MaxBits3, SignType3, Checked3, Allocator3>& b) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
-	// Comba Multiplier - based on
-	// Exponentiation cryptosystems on the IBM PC, 1990
-	int as = a.size(), bs = b.size(), rs = result.size();
-	auto pr = result.limbs();
+   // Comba Multiplier - based on
+   // Exponentiation cryptosystems on the IBM PC, 1990
+   int  as = a.size(), bs = b.size(), rs = result.size();
+   auto pr = result.limbs();
 
-	double_limb_type carry = 0;
-	limb_type overflow = 0;
-	unsigned limb_bits = sizeof(limb_type) * CHAR_BIT;
-	for (int r = 0; r < rs - 1; ++r) 
-	{
-		int i = r >= as ? as - 1 : r,
-			j = r - i,
-			k = i <  bs - j ? i + 1 : bs - j; // min(i+1, bs-j);
-		auto pa = a.limbs() + i;
-		auto pb = b.limbs() + j;
-		while(k--){
-			auto temp = carry;
-			carry += static_cast<double_limb_type>(*(pa--)) * static_cast<double_limb_type>(*(pb++));
-			overflow += carry < temp;
-		}
-		*(pr++) = static_cast<limb_type>(carry);
-		carry = (static_cast<double_limb_type>(overflow) << limb_bits) | (carry >> limb_bits);
-	}
-	*(pr++) = static_cast<limb_type>(carry);
-	result.normalize();
-	result.sign(a.sign() != b.sign());
+   double_limb_type carry     = 0;
+   limb_type        overflow  = 0;
+   unsigned         limb_bits = sizeof(limb_type) * CHAR_BIT;
+   for (int r = 0; r < rs - 1; ++r, overflow = 0)
+   {
+      int i   = r >= as ? as - 1 : r,
+          j   = r - i,
+          k   = i < bs - j ? i + 1 : bs - j; // min(i+1, bs-j);
+      auto pa = a.limbs() + i;
+      auto pb = b.limbs() + j;
+      while (k--)
+      {
+         auto temp = carry;
+         carry += static_cast<double_limb_type>(*(pa--)) * static_cast<double_limb_type>(*(pb++));
+         overflow += carry < temp;
+      }
+      *(pr++) = static_cast<limb_type>(carry);
+      carry   = (static_cast<double_limb_type>(overflow) << limb_bits) | (carry >> limb_bits);
+   }
+   *(pr++) = static_cast<limb_type>(carry);
+   result.normalize();
+   result.sign(a.sign() != b.sign());
 }
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1, unsigned MinBits2, unsigned MaxBits2, cpp_integer_type SignType2, cpp_int_check_type Checked2, class Allocator2, unsigned MinBits3, unsigned MaxBits3, cpp_integer_type SignType3, cpp_int_check_type Checked3, class Allocator3>
 inline BOOST_MP_CXX14_CONSTEXPR typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits3, MaxBits3, SignType3, Checked3, Allocator3> >::value>::type

--- a/include/boost/multiprecision/cpp_int/multiply.hpp
+++ b/include/boost/multiprecision/cpp_int/multiply.hpp
@@ -452,7 +452,7 @@ eval_multiply(
    std::memset(pr, 0, result.size() * sizeof(limb_type));   
    double_limb_type carry = 0;
 
-#if 1 // For testing purposes only, other replace this with : defined(BOOST_MP_COMBA) || __GNUC__ >= 10
+#if defined(BOOST_MP_COMBA) || __GNUC__ >= 10
        // 
 	   // Comba Multiplier might not be efficient because of less efficient assembly
 	   // by the compiler as of 09/01/2020 (DD/MM/YY). See PR #182

--- a/include/boost/multiprecision/cpp_int/multiply.hpp
+++ b/include/boost/multiprecision/cpp_int/multiply.hpp
@@ -309,7 +309,7 @@ setup_karatsuba(
 }
 
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1, unsigned MinBits2, unsigned MaxBits2, cpp_integer_type SignType2, cpp_int_check_type Checked2, class Allocator2, unsigned MinBits3, unsigned MaxBits3, cpp_integer_type SignType3, cpp_int_check_type Checked3, class Allocator3>
-inline BOOST_MP_CXX14_CONSTEXPR typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2> >::value && !is_trivial_cpp_int<cpp_int_backend<MinBits3, MaxBits3, SignType3, Checked3, Allocator3> >::value>::type
+inline void
 eval_multiply_comba(
     cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>&       result,
     const cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2>& a,
@@ -317,7 +317,9 @@ eval_multiply_comba(
 {
    // Comba Multiplier - based on Paul Comba's
    // Exponentiation cryptosystems on the IBM PC, 1990
-   int  as = a.size(), bs = b.size(), rs = result.size();
+   int as                                                                                         = a.size(),
+       bs                                                                                         = b.size(),
+       rs                                                                                         = result.size();
    typename cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::limb_pointer pr = result.limbs();
 
    double_limb_type carry      = 0;
@@ -326,11 +328,13 @@ eval_multiply_comba(
    const bool       must_throw = rs < as + bs - 1;
    for (int r = 0, lim = (std::min)(rs, as + bs - 1); r < lim; ++r, overflow = 0)
    {
-      int i   = r >= as ? as - 1 : r,
-          j   = r - i,
-          k   = i < bs - j ? i + 1 : bs - j; // min(i+1, bs-j);
+      int i = r >= as ? as - 1 : r,
+          j = r - i,
+          k = i < bs - j ? i + 1 : bs - j; // min(i+1, bs-j);
+
       typename cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2>::const_limb_pointer pa = a.limbs() + i;
       typename cpp_int_backend<MinBits3, MaxBits3, SignType3, Checked3, Allocator3>::const_limb_pointer pb = b.limbs() + j;
+
       while (k--)
       {
          double_limb_type temp = carry;

--- a/include/boost/multiprecision/cpp_int/multiply.hpp
+++ b/include/boost/multiprecision/cpp_int/multiply.hpp
@@ -322,8 +322,8 @@ eval_multiply_comba(
 
    double_limb_type carry      = 0;
    limb_type        overflow   = 0;
-   unsigned         limb_bits  = sizeof(limb_type) * CHAR_BIT;
-   bool             must_throw = rs < as + bs - 1;
+   const unsigned   limb_bits  = sizeof(limb_type) * CHAR_BIT;
+   const bool       must_throw = rs < as + bs - 1;
    for (int r = 0, lim = (std::min)(rs, as + bs - 1); r < lim; ++r, overflow = 0)
    {
       int i   = r >= as ? as - 1 : r,
@@ -343,7 +343,8 @@ eval_multiply_comba(
    if (carry || must_throw)
    {
       resize_for_carry(result, as + bs);
-      *(pr++) = static_cast<limb_type>(carry);
+      if ((int)result.size() >= as + bs)
+         *pr = static_cast<limb_type>(carry);
    }
    result.normalize();
    result.sign(a.sign() != b.sign());

--- a/include/boost/multiprecision/cpp_int/multiply.hpp
+++ b/include/boost/multiprecision/cpp_int/multiply.hpp
@@ -435,7 +435,7 @@ eval_multiply(
    std::memset(pr, 0, result.size() * sizeof(limb_type));   
    double_limb_type carry = 0;
 
-   if (0){
+   if (1){
 	   // Comba Multiplier might not be efficient because of less efficient assembly
 	   // by the compiler as of 09/01/2020 (DD/MM/YY). Hopefully this will be resolved when
 	   // GCC BUG #93141 and CLANG BUG #44430 are fixed. 

--- a/include/boost/multiprecision/cpp_int/multiply.hpp
+++ b/include/boost/multiprecision/cpp_int/multiply.hpp
@@ -328,8 +328,8 @@ eval_multiply_comba(
       int i   = r >= as ? as - 1 : r,
           j   = r - i,
           k   = i < bs - j ? i + 1 : bs - j; // min(i+1, bs-j);
-      typename cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2>::limb_pointer pa = a.limbs() + i;
-      typename cpp_int_backend<MinBits3, MaxBits3, SignType3, Checked3, Allocator3>::limb_pointer pb = b.limbs() + j;
+      typename cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2>::const_limb_pointer pa = a.limbs() + i;
+      typename cpp_int_backend<MinBits3, MaxBits3, SignType3, Checked3, Allocator3>::const_limb_pointer pb = b.limbs() + j;
       while (k--)
       {
          double_limb_type temp = carry;

--- a/include/boost/multiprecision/cpp_int/multiply.hpp
+++ b/include/boost/multiprecision/cpp_int/multiply.hpp
@@ -452,7 +452,7 @@ eval_multiply(
    std::memset(pr, 0, result.size() * sizeof(limb_type));   
    double_limb_type carry = 0;
 
-#if defined(BOOST_MP_COMBA) || __GNUC__ >= 10
+#if true // For testing purposes only, other replace this with : defined(BOOST_MP_COMBA) || __GNUC__ >= 10
        // 
 	   // Comba Multiplier might not be efficient because of less efficient assembly
 	   // by the compiler as of 09/01/2020 (DD/MM/YY). See PR #182

--- a/include/boost/multiprecision/cpp_int/multiply.hpp
+++ b/include/boost/multiprecision/cpp_int/multiply.hpp
@@ -315,8 +315,11 @@ eval_multiply_comba(
     const cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2>& a,
     const cpp_int_backend<MinBits3, MaxBits3, SignType3, Checked3, Allocator3>& b) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
+   // 
+   // see PR #182
    // Comba Multiplier - based on Paul Comba's
    // Exponentiation cryptosystems on the IBM PC, 1990
+   //
    int as                                                                                         = a.size(),
        bs                                                                                         = b.size(),
        rs                                                                                         = result.size();
@@ -449,11 +452,12 @@ eval_multiply(
    std::memset(pr, 0, result.size() * sizeof(limb_type));   
    double_limb_type carry = 0;
 
-#ifdef BOOST_MP_COMBA 
+#if defined(BOOST_MP_COMBA) || __GNUC__ >= 10
+       // 
 	   // Comba Multiplier might not be efficient because of less efficient assembly
-	   // by the compiler as of 09/01/2020 (DD/MM/YY). Hopefully this will be resolved when
-	   // GCC BUG #93141 and CLANG BUG #44430 are fixed. 
+	   // by the compiler as of 09/01/2020 (DD/MM/YY). See PR #182
 	   // Till then this will lay dormant :(
+	   //
 	   eval_multiply_comba(result, a, b);
 	   return ;
 #endif

--- a/include/boost/multiprecision/cpp_int/multiply.hpp
+++ b/include/boost/multiprecision/cpp_int/multiply.hpp
@@ -434,10 +434,14 @@ eval_multiply(
    std::memset(pr, 0, result.size() * sizeof(limb_type));   
    double_limb_type carry = 0;
 
-   //if ( sizeof(uint128_type) > 2 * sizeof(limb_type) ){
+   if (0){
+	   // Comba Multiplier might not be efficient because of less efficient assembly
+	   // by the compiler as of 09/01/2020 (DD/MM/YY). Hopefully this will be resolved when
+	   // GCC BUG #93141 and CLANG BUG #44430 are fixed. 
+	   // Till then this will lay dormant :(
 	   eval_multiply_comba(result, a, b);
 	   return ;
-   //}
+   }
 
    for (unsigned i = 0; i < as; ++i)
    {

--- a/include/boost/multiprecision/cpp_int/multiply.hpp
+++ b/include/boost/multiprecision/cpp_int/multiply.hpp
@@ -315,7 +315,7 @@ eval_multiply_comba(
     const cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2>& a,
     const cpp_int_backend<MinBits3, MaxBits3, SignType3, Checked3, Allocator3>& b) BOOST_MP_NOEXCEPT_IF((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
-   // Comba Multiplier - based on
+   // Comba Multiplier - based on Paul Comba's
    // Exponentiation cryptosystems on the IBM PC, 1990
    int  as = a.size(), bs = b.size(), rs = result.size();
    typename cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::limb_pointer pr = result.limbs();
@@ -441,7 +441,7 @@ eval_multiply(
    std::memset(pr, 0, result.size() * sizeof(limb_type));   
    double_limb_type carry = 0;
 
-   if (0){
+   if (1){
 	   // Comba Multiplier might not be efficient because of less efficient assembly
 	   // by the compiler as of 09/01/2020 (DD/MM/YY). Hopefully this will be resolved when
 	   // GCC BUG #93141 and CLANG BUG #44430 are fixed. 

--- a/include/boost/multiprecision/cpp_int/multiply.hpp
+++ b/include/boost/multiprecision/cpp_int/multiply.hpp
@@ -449,14 +449,14 @@ eval_multiply(
    std::memset(pr, 0, result.size() * sizeof(limb_type));   
    double_limb_type carry = 0;
 
-   if (1){
+#ifdef BOOST_MP_COMBA 
 	   // Comba Multiplier might not be efficient because of less efficient assembly
 	   // by the compiler as of 09/01/2020 (DD/MM/YY). Hopefully this will be resolved when
 	   // GCC BUG #93141 and CLANG BUG #44430 are fixed. 
 	   // Till then this will lay dormant :(
 	   eval_multiply_comba(result, a, b);
 	   return ;
-   }
+#endif
 
    for (unsigned i = 0; i < as; ++i)
    {

--- a/include/boost/multiprecision/cpp_int/multiply.hpp
+++ b/include/boost/multiprecision/cpp_int/multiply.hpp
@@ -441,7 +441,7 @@ eval_multiply(
    std::memset(pr, 0, result.size() * sizeof(limb_type));   
    double_limb_type carry = 0;
 
-   if (1){
+   if (0){
 	   // Comba Multiplier might not be efficient because of less efficient assembly
 	   // by the compiler as of 09/01/2020 (DD/MM/YY). Hopefully this will be resolved when
 	   // GCC BUG #93141 and CLANG BUG #44430 are fixed. 

--- a/include/boost/multiprecision/cpp_int/multiply.hpp
+++ b/include/boost/multiprecision/cpp_int/multiply.hpp
@@ -246,7 +246,9 @@ eval_multiply_comba(
 	int as = a.size(), bs = b.size(), rs = result.size();
 	auto pr = result.limbs();
 
-	uint128_type carry = 0;
+	double_limb_type carry = 0;
+	limb_type overflow = 0;
+	unsigned limb_bits = sizeof(limb_type) * CHAR_BIT;
 	for (int r = 0; r < rs - 1; ++r) 
 	{
 		int i = r >= as ? as - 1 : r,
@@ -255,10 +257,12 @@ eval_multiply_comba(
 		auto pa = a.limbs() + i;
 		auto pb = b.limbs() + j;
 		while(k--){
+			auto temp = carry;
 			carry += static_cast<double_limb_type>(*(pa--)) * static_cast<double_limb_type>(*(pb++));
+			overflow += carry < temp;
 		}
 		*(pr++) = static_cast<limb_type>(carry);
-		carry >>= sizeof(limb_type) * CHAR_BIT;
+		carry = (static_cast<double_limb_type>(overflow) << limb_bits) | (carry >> limb_bits);
 	}
 	*(pr++) = static_cast<limb_type>(carry);
 	result.normalize();
@@ -339,10 +343,10 @@ eval_multiply(
 
    std::fill(pr, pr + result.size(), 0);
 
-   if ( sizeof(uint128_type) > 2 * sizeof(limb_type) ){
+   //if ( sizeof(uint128_type) > 2 * sizeof(limb_type) ){
 	   eval_multiply_comba(result, a, b);
 	   return ;
-   }
+   //}
 
    double_limb_type carry = 0;
    for (unsigned i = 0; i < as; ++i)

--- a/include/boost/multiprecision/cpp_int/multiply.hpp
+++ b/include/boost/multiprecision/cpp_int/multiply.hpp
@@ -110,9 +110,9 @@ eval_multiply_karatsuba(
    // y = a_l * b_l
    // z = (a_h + a_l)*(b_h + b_l) - x - y
    // a * b = x * (2 ^ (2 * n))+ z * (2 ^ n) + y
-   const typename cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::scoped_shared_storage storage(result, 9 * n + 3);
-   cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>                                       t1(storage, 0, 2 * n + 1), t2(storage, 2 * n + 1, n + 1), t3(storage, 3 * n + 2, n + 1);
-   BOOST_ASSERT(t1.size() == 2 * n + 1);
+   const typename cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::scoped_shared_storage storage(result, 4 * n + 4);
+   cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>                                       t1(storage, 0, 2 * n + 2), t2(storage, 2 * n + 2, n + 1), t3(storage, 3 * n + 3, n + 1);
+   BOOST_ASSERT(t1.size() == 2 * n + 2);
    BOOST_ASSERT(t2.size() == n + 1);
    BOOST_ASSERT(t3.size() == n + 1);
    static_assert(std::is_same<typename std::remove_cv<decltype(t1)>::type, typename std::remove_cv<typename std::remove_reference<decltype(result)>::type>::type>::value, "Mismatched internal types");


### PR DESCRIPTION
Comba multiplier is a computer-friendly multiplication routine which is a drop-in replacement for native schoolbook multiplication.

Algorithmic Differences:
Consider writing the both operands in two lines one below the other.

Naive school book multiplication first multiplies a digit of operand to all the digits of other operands. This can be visualized as a row multiplication where row is the second operand and then these computed rows are added to obtain final answer.

Comba Multiplier can be thought of as a multiplication routine where the digits of answer are computed sequentially. In other words it computes the result column wise first.

For example: 
```
  2               3
x 7               8
--------------------
  14  37(16+21)   24

ans[0] = 8*3       = 24
ans[1] = 2*8 + 3*7 = 37
ans[2] = 2*7       = 14
```

**Benefits:**
There are less additions and assignments.

**Subtleness:**
It might not be evident that how this method will save addition because a compensating addition `overflow += temp < carry` is performed. But taking advantage of hardware this can be reduced to saving the status of Carry Flag to overflow counter using `adc` instruction.
For more optimisation details kindly see the bugs:
1. [GCC 93141](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=93141)
2. [LLVM 44460](https://bugs.llvm.org/show_bug.cgi?id=44460)
 