### PR TITLE
Gauss laguerre

### DIFF
--- a/example/Jamfile.v2
+++ b/example/Jamfile.v2
@@ -60,6 +60,8 @@ project
       <toolset>msvc:<cxxflags>/wd4701
       <toolset>msvc:<cxxflags>/wd4127
       <toolset>msvc:<cxxflags>/wd4305
+      <toolset>clang:<link>static
+     
     ;
 
 lib gmp : : <search>$(gmp_path) ;

--- a/example/gauss_laguerre_quadrature.cpp
+++ b/example/gauss_laguerre_quadrature.cpp
@@ -467,16 +467,17 @@ namespace detail
 
 } } // namespace gauss::laguerre
 
-namespace local
+struct local
 {
-  BOOST_CONSTEXPR unsigned int my_digits10 = 101U;
+  BOOST_STATIC_CONSTEXPR unsigned int my_digits10 = 101U;
 
-  using float_type =
-    boost::multiprecision::number<boost::multiprecision::cpp_dec_float<local::my_digits10>,
-                                  boost::multiprecision::et_off>;
-}
+  typedef boost::multiprecision::number<boost::multiprecision::cpp_dec_float<my_digits10>,
+                                        boost::multiprecision::et_off>
+  float_type;
+};
 
-BOOST_STATIC_ASSERT_MSG(local::my_digits10 > 20U, "Error: This example is intended to have more than 20 decimal digits");
+BOOST_STATIC_ASSERT_MSG(local::my_digits10 > 20U,
+                        "Error: This example is intended to have more than 20 decimal digits");
 
 int main()
 {
@@ -506,7 +507,7 @@ int main()
 
   std::cout << "laguerre_order: " << laguerre_order << std::endl;
 
-  using abscissas_and_weights_type = gauss::laguerre::detail::abscissas_and_weights<local::float_type>;
+  typedef gauss::laguerre::detail::abscissas_and_weights<local::float_type> abscissas_and_weights_type;
 
   const abscissas_and_weights_type the_abscissas_and_weights(laguerre_order, local::float_type(-1) / 6);
 

--- a/example/gauss_laguerre_quadrature.cpp
+++ b/example/gauss_laguerre_quadrature.cpp
@@ -164,7 +164,7 @@ namespace detail
     {
       using std::abs;
 
-      std::cout << "finding the approximate roots..." << std::endl;
+      std::cout << "Finding the approximate roots..." << std::endl;
 
       std::vector<std::tuple<T, T>> root_estimates;
 
@@ -322,7 +322,7 @@ namespace detail
       // Calculate the abscissas and weights to full precision.
       for(std::size_t i = static_cast<std::size_t>(0U); i < root_estimates.size(); ++i)
       {
-        std::cout << "calculating abscissa and weight for index: " << i << std::endl;
+        std::cout << "Calculating abscissa and weight for index: " << i << std::endl;
 
         // Calculate the abscissas using iterative root-finding.
 

--- a/example/gauss_laguerre_quadrature.cpp
+++ b/example/gauss_laguerre_quadrature.cpp
@@ -74,7 +74,7 @@ void progress_bar(std::ostream& os, const float percent)
 namespace detail
 {
   template<typename T>
-  class laguerre_l_object final
+  class laguerre_l_object BOOST_FINAL
   {
   public:
     laguerre_l_object(const int n, const T a) BOOST_NOEXCEPT
@@ -428,7 +428,7 @@ namespace detail
   };
 
   template<typename T>
-  struct airy_ai_object final
+  struct airy_ai_object BOOST_FINAL
   {
   public:
     airy_ai_object(const T& x) BOOST_NOEXCEPT

--- a/example/gauss_laguerre_quadrature.cpp
+++ b/example/gauss_laguerre_quadrature.cpp
@@ -5,7 +5,6 @@
 //          http://www.boost.org/LICENSE_1_0.txt)
 //
 
-#include <chrono>
 #include <cmath>
 #include <cstdint>
 #include <functional>
@@ -53,7 +52,7 @@ namespace detail
   class laguerre_l_object final
   {
   public:
-    laguerre_l_object(const int n, const T a) noexcept
+    laguerre_l_object(const int n, const T a) BOOST_NOEXCEPT
       : order(n),
         alpha(a),
         p1   (0),
@@ -72,7 +71,7 @@ namespace detail
       return *this;
     }
 
-    T operator()(const T& x) const noexcept
+    T operator()(const T& x) const BOOST_NOEXCEPT
     {
       // Calculate (via forward recursion):
       // * the value of the Laguerre function L(n, alpha, x), called (p2),
@@ -115,10 +114,10 @@ namespace detail
       return p2;
     }
 
-    const T previous  () const noexcept { return p1; }
-    const T derivative() const noexcept { return d2; }
+    const T previous  () const BOOST_NOEXCEPT { return p1; }
+    const T derivative() const BOOST_NOEXCEPT { return d2; }
 
-    static bool root_tolerance(const T& a, const T& b) noexcept
+    static bool root_tolerance(const T& a, const T& b) BOOST_NOEXCEPT
     {
       using std::fabs;
 
@@ -154,8 +153,8 @@ namespace detail
       }
     }
 
-    const std::vector<T>& abscissa_n() const noexcept { return xi; }
-    const std::vector<T>& weight_n  () const noexcept { return wi; }
+    const std::vector<T>& abscissa_n() const BOOST_NOEXCEPT { return xi; }
+    const std::vector<T>& weight_n  () const BOOST_NOEXCEPT { return wi; }
 
   private:
     const int order;
@@ -164,7 +163,10 @@ namespace detail
     std::vector<T> xi;
     std::vector<T> wi;
 
-    abscissas_and_weights() = default;
+    abscissas_and_weights() : order(),
+                              alpha(),
+                              xi   (),
+                              wi   () { }
 
     void calculate()
     {
@@ -404,12 +406,12 @@ namespace detail
   struct airy_ai_object final
   {
   public:
-    airy_ai_object(const T& x) noexcept
+    airy_ai_object(const T& x) BOOST_NOEXCEPT
       : my_x  (x),
         my_zeta  (((sqrt(x) * x) * 2) / 3),
         my_factor(make_factor(my_zeta)) { }
 
-    T operator()(const T& t) const noexcept
+    T operator()(const T& t) const BOOST_NOEXCEPT
     {
       using std::cbrt;
       using std::sqrt;
@@ -422,9 +424,11 @@ namespace detail
     const T my_zeta;
     const T my_factor;
 
-    airy_ai_object() = default;
+    airy_ai_object() : my_x     (),
+                       my_zeta  (),
+                       my_factor() { }
 
-    static T make_factor(const T& z) noexcept
+    static T make_factor(const T& z) BOOST_NOEXCEPT
     {
       using std::cbrt;
       using std::exp;
@@ -497,7 +501,7 @@ int main()
                          local::float_type(0U),
                          std::plus<local::float_type>(),
                          [&this_gauss_laguerre_ai](const local::float_type& this_abscissa,
-                                                   const local::float_type& this_weight) noexcept -> local::float_type
+                                                   const local::float_type& this_weight) BOOST_NOEXCEPT -> local::float_type
                          {
                            return this_gauss_laguerre_ai(this_abscissa) * this_weight;
                          });

--- a/example/gauss_laguerre_quadrature.cpp
+++ b/example/gauss_laguerre_quadrature.cpp
@@ -431,12 +431,12 @@ namespace detail
   struct airy_ai_object BOOST_FINAL
   {
   public:
-    airy_ai_object(const T& x) BOOST_NOEXCEPT
+    airy_ai_object(const T& x)
       : my_x     (x),
         my_zeta  (((sqrt(x) * x) * 2) / 3),
         my_factor(make_factor(my_zeta)) { }
 
-    T operator()(const T& t) const BOOST_NOEXCEPT
+    T operator()(const T& t) const
     {
       using std::sqrt;
 
@@ -452,7 +452,7 @@ namespace detail
                        my_zeta  (),
                        my_factor() { }
 
-    static T make_factor(const T& z) BOOST_NOEXCEPT
+    static T make_factor(const T& z)
     {
       using std::exp;
       using std::sqrt;

--- a/example/gauss_laguerre_quadrature.cpp
+++ b/example/gauss_laguerre_quadrature.cpp
@@ -349,10 +349,10 @@ namespace detail
         if(   ((i % 8U) == 0U)
            || ( i == root_estimates.size() - 1U))
         {
-          const float progress = (100.0F * static_cast<float>(i)) / static_cast<float>(root_estimates.size());
+          const float progress = (100.0F * static_cast<float>(i + 1U)) / static_cast<float>(root_estimates.size());
 
-          std::cout << "Calculating abscissa and weight for index: "
-                    << i
+          std::cout << "Calculating abscissas and weights. Processed "
+                    << (i + 1U)
                     << ", "
                     ;
 
@@ -407,7 +407,7 @@ namespace detail
   {
   public:
     airy_ai_object(const T& x) BOOST_NOEXCEPT
-      : my_x  (x),
+      : my_x     (x),
         my_zeta  (((sqrt(x) * x) * 2) / 3),
         my_factor(make_factor(my_zeta)) { }
 
@@ -446,7 +446,7 @@ namespace local
 {
   struct digits_characteristics
   {
-    BOOST_STATIC_CONSTEXPR unsigned int my_digits10       =  121U;
+    BOOST_STATIC_CONSTEXPR unsigned int my_digits10       =  101U;
     BOOST_STATIC_CONSTEXPR unsigned int my_guard_digits10 =    6U;
     BOOST_STATIC_CONSTEXPR unsigned int my_total_digits10 = my_digits10 + my_guard_digits10;
   };
@@ -479,6 +479,8 @@ int main()
   BOOST_CONSTEXPR_OR_CONST boost::float_least32_t laguerre_order_factor = -1.28301F + ((0.235487F + (0.0000178915F * d)) * d);
 
   BOOST_CONSTEXPR_OR_CONST int laguerre_order = static_cast<int>(laguerre_order_factor * d);
+
+  std::cout << "my_digits10: " << local::digits_characteristics::my_digits10 << std::endl;
 
   std::cout << "laguerre_order: " << laguerre_order << std::endl;
 

--- a/example/gauss_laguerre_quadrature.cpp
+++ b/example/gauss_laguerre_quadrature.cpp
@@ -434,7 +434,7 @@ namespace
 {
   struct digits_characteristics
   {
-    static constexpr unsigned int my_digits10       = 500U;
+    static constexpr unsigned int my_digits10       = 300U;
     static constexpr unsigned int my_guard_digits10 =   6U;
     static constexpr unsigned int my_total_digits10 = my_digits10 + my_guard_digits10;
   };

--- a/example/gauss_laguerre_quadrature.cpp
+++ b/example/gauss_laguerre_quadrature.cpp
@@ -438,10 +438,9 @@ namespace detail
 
     T operator()(const T& t) const BOOST_NOEXCEPT
     {
-      using std::cbrt;
       using std::sqrt;
 
-      return my_factor / sqrt(cbrt(2 + (t / my_zeta)));
+      return my_factor / sqrt(boost::math::cbrt(2 + (t / my_zeta)));
     }
 
   private:
@@ -455,12 +454,10 @@ namespace detail
 
     static T make_factor(const T& z) BOOST_NOEXCEPT
     {
-      using std::cbrt;
       using std::exp;
       using std::sqrt;
-      using std::tgamma;
 
-      return 1 / ((sqrt(boost::math::constants::pi<T>()) * sqrt(cbrt(z * 48))) * (exp(z) * tgamma(T(5) / 6)));
+      return 1 / ((sqrt(boost::math::constants::pi<T>()) * sqrt(boost::math::cbrt(z * 48))) * (exp(z) * boost::math::tgamma(T(5) / 6)));
     }
   };
 } // namespace detail

--- a/example/gauss_laguerre_quadrature.cpp
+++ b/example/gauss_laguerre_quadrature.cpp
@@ -517,7 +517,9 @@ int main()
   {
     const local::float_type x = local::float_type(u) / 7;
 
-    const gauss::laguerre::detail::airy_ai_object<local::float_type> this_gauss_laguerre_ai(x);
+    typedef gauss::laguerre::detail::airy_ai_object<local::float_type> airy_ai_object_type;
+
+    const airy_ai_object_type the_airy_ai_object(x);
 
     const local::float_type airy_ai_value =
       std::inner_product(the_abscissas_and_weights.abscissa_n().cbegin(),
@@ -525,10 +527,10 @@ int main()
                          the_abscissas_and_weights.weight_n().cbegin(),
                          local::float_type(0U),
                          std::plus<local::float_type>(),
-                         [&this_gauss_laguerre_ai](const local::float_type& this_abscissa,
-                                                   const local::float_type& this_weight) BOOST_NOEXCEPT -> local::float_type
+                         [&the_airy_ai_object](const local::float_type& this_abscissa,
+                                               const local::float_type& this_weight) BOOST_NOEXCEPT -> local::float_type
                          {
-                           return this_gauss_laguerre_ai(this_abscissa) * this_weight;
+                           return the_airy_ai_object(this_abscissa) * this_weight;
                          });
 
     static const local::float_type one_third = 1.0F / local::float_type(3U);


### PR DESCRIPTION
Remove unused variables.
Check with GCC's -Wall -Wextra -pedantic and a few more warnings.
Remove all MSVC level 3 warnings.
Other compiler warnings not checked.
Eliminate unused logic paths.
Speedup and calibrate for 50...1200 decimal digits.
Use a few more Boost macros, but not yet fully constexpr.
Repair the correct author and update the copyright information.