### PR TITLE
Thread contention with GMP backend

### DIFF
--- a/include/boost/multiprecision/detail/precision.hpp
+++ b/include/boost/multiprecision/detail/precision.hpp
@@ -134,7 +134,10 @@ struct scoped_default_precision<R, true>
    }
    ~scoped_default_precision()
    {
-      R::default_precision(m_old_prec);
+     if(m_new_prec!=m_old_prec)
+       {
+         R::default_precision(m_old_prec);
+       }
    }
    BOOST_MP_CXX14_CONSTEXPR unsigned precision() const
    {
@@ -145,7 +148,7 @@ struct scoped_default_precision<R, true>
    BOOST_MP_CXX14_CONSTEXPR void init(unsigned p)
    {
       m_old_prec = R::default_precision();
-      if (p)
+      if (p && p!=m_old_prec)
       {
          R::default_precision(p);
          m_new_prec = p;


### PR DESCRIPTION
I compile the file [gmp_threads.cxx](https://github.com/boostorg/multiprecision/files/4411920/gmp_threads.txt) with the command

`g++ gmp_threads.cxx -o gmp_threads -lgmp -lpthread -Iqft/src/boost_bin/include -g`

and run it under valgrind/helgrind with the command

`valgrind --tool=helgrind ./gmp_threads`

which gives the [these warnings](https://github.com/boostorg/multiprecision/files/4411958/gmp_threads_valgrind.txt).  Looking into the details, it seems that boost::multiprecision is setting the precision in `boost::multiprecision::detail::scoped_default_precision` on line 123 of  `precision.hpp`.  I think it hands this off to gmp's internal routine to set precision.  I think it is properly guarded by a mutex, so there is no obvious undefined behavior.  However, locking this mutex causes other threads to block, which causes my multithreaded program running on 32 cores to run about as fast as a single core.

I do not see this problem with Boost 1.68, but I do see it with 1.70 and later (including the current version on github).

This PR checks within the constructors and destructors of `scoped_default_precision` for whether the precision is actually changing.