### PR TITLE
Faster gcd for double-limb-case.

### DIFF
--- a/include/boost/multiprecision/cpp_int/misc.hpp
+++ b/include/boost/multiprecision/cpp_int/misc.hpp
@@ -437,7 +437,15 @@ eval_gcd(
          result = a;
       return;
    }
-   double_limb_type res = eval_integer_modulus(a, b);
+   double_limb_type res = 0;
+   if(a.sign() == 0)
+      res = eval_integer_modulus(a, b);
+   else
+   {
+      cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> t(a);
+      t.negate();
+      res = eval_integer_modulus(t, b);
+   }
    res            = eval_gcd(res, b);
    result = res;
    result.sign(false);

--- a/include/boost/multiprecision/cpp_int/misc.hpp
+++ b/include/boost/multiprecision/cpp_int/misc.hpp
@@ -547,8 +547,24 @@ eval_gcd(
          u.swap(v);
       if (s == 0)
          break;
+
+      while(((u.size() + 2 < v.size()) && (v.size() * 100 / u.size() > 105)) || ((u.size() <= 2) && (v.size() > 4)))
+      {
+         //
+         // Speical case: if u and v differ considerably in size, then a Euclid step
+         // is more efficient as we reduce v by several limbs in one go.
+         // Unfortunately it requires an expensive long division:
+         //
+         eval_modulus(v, v, u);
+         u.swap(v);
+      }
       if (v.size() <= 2)
       {
+         //
+         // Special case: if v has no more than 2 limbs
+         // then we can reduce u and v to a pair of integers and perform
+         // direct integer gcd:
+         //
          if (v.size() == 1)
             u = eval_gcd(*v.limbs(), *u.limbs());
          else
@@ -559,6 +575,9 @@ eval_gcd(
          }
          break;
       }
+      //
+      // Regular binary gcd case:
+      //
       eval_subtract(v, u);
       vs = eval_lsb(v);
       eval_right_shift(v, vs);

--- a/include/boost/multiprecision/cpp_int/misc.hpp
+++ b/include/boost/multiprecision/cpp_int/misc.hpp
@@ -450,7 +450,18 @@ eval_gcd(
    result = res;
    result.sign(false);
 }
-
+template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1>
+inline BOOST_MP_CXX14_CONSTEXPR typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value>::type
+eval_gcd(
+   cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result,
+   const cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& a,
+   signed_double_limb_type                                                     v)
+{
+   eval_gcd(result, a, static_cast<double_limb_type>(v < 0 ? -v : v));
+}
+//
+// These 2 overloads take care of gcd against an (unsigned) short etc:
+//
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1, class Integer>
 inline BOOST_MP_CXX14_CONSTEXPR typename enable_if_c<is_unsigned<Integer>::value && (sizeof(Integer) <= sizeof(limb_type)) && !is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value>::type
 eval_gcd(
@@ -469,6 +480,7 @@ eval_gcd(
 {
    eval_gcd(result, a, static_cast<limb_type>(v < 0 ? -v : v));
 }
+
 
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1>
 inline BOOST_MP_CXX14_CONSTEXPR typename enable_if_c<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value>::type

--- a/include/boost/multiprecision/cpp_int/misc.hpp
+++ b/include/boost/multiprecision/cpp_int/misc.hpp
@@ -385,29 +385,19 @@ BOOST_MP_FORCEINLINE BOOST_MP_CXX14_CONSTEXPR limb_type eval_gcd(limb_type u, li
 
 inline BOOST_MP_CXX14_CONSTEXPR double_limb_type eval_gcd(double_limb_type u, double_limb_type v)
 {
-#if __cpp_lib_gcd_lcm >= 201606L
+#if (__cpp_lib_gcd_lcm >= 201606L) && (!defined(BOOST_HAS_INT128) || !defined(__STRICT_ANSI__))
    return std::gcd(u, v);
 #else
+   unsigned shift = boost::multiprecision::detail::find_lsb(u | v);
+   u >>= boost::multiprecision::detail::find_lsb(u);
    do
    {
+      v >>= boost::multiprecision::detail::find_lsb(v);
       if (u > v)
          std_constexpr::swap(u, v);
-      if (u == v)
-         break;
-      if (v <= ~static_cast<limb_type>(0))
-      {
-         u = eval_gcd(static_cast<limb_type>(v), static_cast<limb_type>(u));
-         break;
-      }
       v -= u;
-#ifdef __MSVC_RUNTIME_CHECKS
-      while ((v & 1u) == 0)
-#else
-      while ((static_cast<unsigned>(v) & 1u) == 0)
-#endif
-         v >>= 1;
-   } while (true);
-   return u;
+   } while (v);
+   return u << shift;
 #endif
 }
 

--- a/include/boost/multiprecision/cpp_int/misc.hpp
+++ b/include/boost/multiprecision/cpp_int/misc.hpp
@@ -362,20 +362,6 @@ eval_integer_modulus(const cpp_int_backend<MinBits1, MaxBits1, SignType1, Checke
    return eval_integer_modulus(x, boost::multiprecision::detail::unsigned_abs(val));
 }
 
-inline BOOST_MP_CXX14_CONSTEXPR limb_type integer_gcd_reduce(limb_type u, limb_type v)
-{
-   do
-   {
-      if (u > v)
-         std_constexpr::swap(u, v);
-      if (u == v)
-         break;
-      v -= u;
-      v >>= boost::multiprecision::detail::find_lsb(v);
-   } while (true);
-   return u;
-}
-
 BOOST_MP_FORCEINLINE BOOST_MP_CXX14_CONSTEXPR limb_type eval_gcd(limb_type u, limb_type v)
 {
    // boundary cases
@@ -397,8 +383,11 @@ BOOST_MP_FORCEINLINE BOOST_MP_CXX14_CONSTEXPR limb_type eval_gcd(limb_type u, li
 #endif
 }
 
-inline BOOST_MP_CXX14_CONSTEXPR double_limb_type integer_gcd_reduce(double_limb_type u, double_limb_type v)
+inline BOOST_MP_CXX14_CONSTEXPR double_limb_type eval_gcd(double_limb_type u, double_limb_type v)
 {
+#if __cpp_lib_gcd_lcm >= 201606L
+   return std::gcd(u, v);
+#else
    do
    {
       if (u > v)
@@ -419,6 +408,7 @@ inline BOOST_MP_CXX14_CONSTEXPR double_limb_type integer_gcd_reduce(double_limb_
          v >>= 1;
    } while (true);
    return u;
+#endif
 }
 
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1>
@@ -555,7 +545,7 @@ eval_gcd(
          {
             double_limb_type i = v.limbs()[0] | (static_cast<double_limb_type>(v.limbs()[1]) << sizeof(limb_type) * CHAR_BIT);
             double_limb_type j = (u.size() == 1) ? *u.limbs() : u.limbs()[0] | (static_cast<double_limb_type>(u.limbs()[1]) << sizeof(limb_type) * CHAR_BIT);
-            u                  = integer_gcd_reduce(i, j);
+            u                  = eval_gcd(i, j);
          }
          break;
       }

--- a/include/boost/multiprecision/cpp_int/misc.hpp
+++ b/include/boost/multiprecision/cpp_int/misc.hpp
@@ -451,8 +451,10 @@ eval_gcd(
    int s = eval_get_sign(a);
    if (!b || !s)
    {
-      result = a;
-      *result.limbs() |= b;
+      if (!s)
+         result = b;
+      else
+         result = a;
       return;
    }
    double_limb_type res = eval_integer_modulus(a, b);

--- a/include/boost/multiprecision/gmp.hpp
+++ b/include/boost/multiprecision/gmp.hpp
@@ -1219,6 +1219,39 @@ struct gmp_int
       return *this;
    }
 #endif
+#ifdef BOOST_HAS_INT128
+   gmp_int& operator=(unsigned __int128 i)
+   {
+      if (m_data[0]._mp_d == 0)
+         mpz_init(this->m_data);
+      unsigned __int128 mask  = ((((1uLL << (std::numeric_limits<unsigned long>::digits - 1)) - 1) << 1) | 1uLL);
+      unsigned               shift = 0;
+      mpz_t                  t;
+      mpz_set_ui(m_data, 0);
+      mpz_init_set_ui(t, 0);
+      while (i)
+      {
+         mpz_set_ui(t, static_cast<unsigned long>(i & mask));
+         if (shift)
+            mpz_mul_2exp(t, t, shift);
+         mpz_add(m_data, m_data, t);
+         shift += std::numeric_limits<unsigned long>::digits;
+         i >>= std::numeric_limits<unsigned long>::digits;
+      }
+      mpz_clear(t);
+      return *this;
+   }
+   gmp_int& operator=(__int128 i)
+   {
+      if (m_data[0]._mp_d == 0)
+         mpz_init(this->m_data);
+      bool neg = i < 0;
+      *this    = boost::multiprecision::detail::unsigned_abs(i);
+      if (neg)
+         mpz_neg(m_data, m_data);
+      return *this;
+   }
+#endif
    gmp_int& operator=(unsigned long i)
    {
       if (m_data[0]._mp_d == 0)

--- a/test/test_cpp_int.cpp
+++ b/test/test_cpp_int.cpp
@@ -91,6 +91,7 @@ struct tester
    boost::multiprecision::mpz_int a, b, c, d;
    int                            si;
    unsigned                       ui;
+   boost::multiprecision::double_limb_type large_ui;
    test_type                      a1, b1, c1, d1;
 
    void t1()
@@ -360,6 +361,51 @@ struct tester
          BOOST_CHECK_EQUAL(t.str(), t1.str());
       }
    }
+   void t4_large()
+   {
+      using namespace boost::multiprecision;
+      // Now check operations involving unsigned integers:
+      BOOST_CHECK_EQUAL(mpz_int(a + large_ui).str(), test_type(a1 + large_ui).str());
+      BOOST_CHECK_EQUAL(mpz_int(-a + large_ui).str(), test_type(-a1 + large_ui).str());
+      BOOST_CHECK_EQUAL(mpz_int(large_ui + a).str(), test_type(large_ui + a1).str());
+      BOOST_CHECK_EQUAL((mpz_int(a) += large_ui).str(), (test_type(a1) += large_ui).str());
+      BOOST_CHECK_EQUAL((mpz_int(-a) += large_ui).str(), (test_type(-a1) += large_ui).str());
+      BOOST_CHECK_EQUAL(mpz_int(a - large_ui).str(), test_type(a1 - large_ui).str());
+      BOOST_CHECK_EQUAL(mpz_int(-a - large_ui).str(), test_type(-a1 - large_ui).str());
+      BOOST_CHECK_EQUAL(mpz_int(large_ui - a).str(), test_type(large_ui - a1).str());
+      BOOST_CHECK_EQUAL((mpz_int(a) -= large_ui).str(), (test_type(a1) -= large_ui).str());
+      BOOST_CHECK_EQUAL((mpz_int(-a) -= large_ui).str(), (test_type(-a1) -= large_ui).str());
+      BOOST_CHECK_EQUAL(mpz_int(b * large_ui).str(), test_type(b1 * large_ui).str());
+      BOOST_CHECK_EQUAL(mpz_int(-b * large_ui).str(), test_type(-b1 * large_ui).str());
+      BOOST_CHECK_EQUAL(mpz_int(large_ui * b).str(), test_type(large_ui * b1).str());
+      BOOST_CHECK_EQUAL((mpz_int(a) *= large_ui).str(), (test_type(a1) *= large_ui).str());
+      BOOST_CHECK_EQUAL((mpz_int(-a) *= large_ui).str(), (test_type(-a1) *= large_ui).str());
+      BOOST_CHECK_EQUAL(mpz_int(a / large_ui).str(), test_type(a1 / large_ui).str());
+      BOOST_CHECK_EQUAL(mpz_int(-a / large_ui).str(), test_type(-a1 / large_ui).str());
+      BOOST_CHECK_EQUAL((mpz_int(a) /= large_ui).str(), (test_type(a1) /= large_ui).str());
+      BOOST_CHECK_EQUAL((mpz_int(-a) /= large_ui).str(), (test_type(-a1) /= large_ui).str());
+      BOOST_CHECK_EQUAL(mpz_int(a % large_ui).str(), test_type(a1 % large_ui).str());
+      BOOST_CHECK_EQUAL(mpz_int(-a % large_ui).str(), test_type(-a1 % large_ui).str());
+      BOOST_CHECK_EQUAL((mpz_int(a) %= large_ui).str(), (test_type(a1) %= large_ui).str());
+      BOOST_CHECK_EQUAL((mpz_int(-a) %= large_ui).str(), (test_type(-a1) %= large_ui).str());
+      BOOST_CHECK_EQUAL(mpz_int(a | large_ui).str(), test_type(a1 | large_ui).str());
+      BOOST_CHECK_EQUAL((mpz_int(a) |= large_ui).str(), (test_type(a1) |= large_ui).str());
+      BOOST_CHECK_EQUAL(mpz_int(a & large_ui).str(), test_type(a1 & large_ui).str());
+      BOOST_CHECK_EQUAL((mpz_int(a) &= large_ui).str(), (test_type(a1) &= large_ui).str());
+      BOOST_CHECK_EQUAL(mpz_int(a ^ large_ui).str(), test_type(a1 ^ large_ui).str());
+      BOOST_CHECK_EQUAL((mpz_int(a) ^= large_ui).str(), (test_type(a1) ^= large_ui).str());
+      BOOST_CHECK_EQUAL(mpz_int(large_ui | a).str(), test_type(large_ui | a1).str());
+      BOOST_CHECK_EQUAL(mpz_int(large_ui & a).str(), test_type(large_ui & a1).str());
+      BOOST_CHECK_EQUAL(mpz_int(large_ui ^ a).str(), test_type(large_ui ^ a1).str());
+      BOOST_CHECK_EQUAL(mpz_int(gcd(a, large_ui)).str(), test_type(gcd(a1, large_ui)).str());
+      BOOST_CHECK_EQUAL(mpz_int(gcd(large_ui, b)).str(), test_type(gcd(large_ui, b1)).str());
+      BOOST_CHECK_EQUAL(mpz_int(lcm(c, large_ui)).str(), test_type(lcm(c1, large_ui)).str());
+      BOOST_CHECK_EQUAL(mpz_int(lcm(large_ui, d)).str(), test_type(lcm(large_ui, d1)).str());
+      BOOST_CHECK_EQUAL(mpz_int(gcd(-a, large_ui)).str(), test_type(gcd(-a1, large_ui)).str());
+      BOOST_CHECK_EQUAL(mpz_int(lcm(-c, large_ui)).str(), test_type(lcm(-c1, large_ui)).str());
+      BOOST_CHECK_EQUAL(mpz_int(gcd(large_ui, -b)).str(), test_type(gcd(large_ui, -b1)).str());
+      BOOST_CHECK_EQUAL(mpz_int(lcm(large_ui, -d)).str(), test_type(lcm(large_ui, -d1)).str());
+   }
 
    void t5()
    {
@@ -374,6 +420,8 @@ struct tester
       BOOST_CHECK_EQUAL(z1.str(), t1.str());
       BOOST_CHECK_EQUAL(z2.str(), t2.str());
       BOOST_CHECK_EQUAL(integer_modulus(a, si), integer_modulus(a1, si));
+      BOOST_CHECK_EQUAL(integer_modulus(a, ui), integer_modulus(a1, ui));
+      BOOST_CHECK_EQUAL(mpz_int(integer_modulus(a, large_ui)).str(), test_type(integer_modulus(a1, large_ui)).str());
       BOOST_CHECK_EQUAL(lsb(a), lsb(a1));
       BOOST_CHECK_EQUAL(msb(a), msb(a1));
 
@@ -705,6 +753,7 @@ struct tester
 
          si = d.convert_to<int>();
          ui = si;
+         large_ui = c.convert_to<boost::multiprecision::double_limb_type>();
 
          a1 = static_cast<test_type>(a.str());
          b1 = static_cast<test_type>(b.str());
@@ -716,6 +765,7 @@ struct tester
 #ifndef SLOW_COMPILER
          t3();
          t4();
+         t4_large();
          t5();
 #endif
 


### PR DESCRIPTION
Using the performance test from @madhur4127 I see:

```
Before:
BM<cpp_int>/400        8202 ns         7952 ns        74667
BM<cpp_int>/600       14937 ns        14579 ns        40727
BM<cpp_int>/800       21660 ns        21449 ns        29867
BM<cpp_int>/1000      25239 ns        25112 ns        28000
BM<cpp_int>/1200      34091 ns        34424 ns        21333
BM<cpp_int>/1400      43222 ns        43493 ns        15448
BM<cpp_int>/1600      53205 ns        53013 ns        11200
BM<cpp_int>/1800      62238 ns        62500 ns        10000
BM<cpp_int>/2000      71333 ns        69754 ns         8960

after:
BM<cpp_int>/400        2251 ns         2176 ns       373333
BM<cpp_int>/600        2659 ns         2651 ns       224000
BM<cpp_int>/800        3826 ns         3770 ns       194783
BM<cpp_int>/1000       4351 ns         4297 ns       160000
BM<cpp_int>/1200       5064 ns         4604 ns       112000
BM<cpp_int>/1400       6112 ns         6138 ns       112000
BM<cpp_int>/1600       8036 ns         7952 ns       112000
BM<cpp_int>/1800       9050 ns         8894 ns        89600
BM<cpp_int>/2000      10376 ns        10463 ns        89600
```

With msvc.