### PR TITLE
Workaround for over-sized object files on Mingw.

### DIFF
--- a/config/Jamfile.v2
+++ b/config/Jamfile.v2
@@ -74,6 +74,7 @@ exe has_eigen : has_eigen.cpp ;
 exe has_f2c : has_f2c.cpp f2c ;
 obj has_is_constant_evaluated : has_is_constant_evaluated.cpp ;
 obj has_constexpr_limits : has_constexpr_limits_cmd.cpp : <cxxflags>-fconstexpr-ops-limit=268435456 ;
+obj has_big_obj : has_big_obj.cpp : <cxxflags>-Wa,-mbig-obj ;
 
 explicit has_gmp ;
 explicit has_mpfr ;
@@ -85,5 +86,6 @@ explicit has_mpc ;
 explicit has_eigen ;
 explicit has_is_constant_evaluated ;
 explicit has_constexpr_limits ;
+explicit has_big_obj ;
 explicit has_f2c ;
 

--- a/config/has_big_obj.cpp
+++ b/config/has_big_obj.cpp
@@ -1,0 +1,13 @@
+//  Copyright John Maddock 2020.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef __GNUC__
+#error "compiler is not GCC"
+#endif
+
+int main()
+{
+   return 0;
+}

--- a/example/Jamfile.v2
+++ b/example/Jamfile.v2
@@ -31,16 +31,7 @@ project
      <include>../include
      <include>../../..
      
-     <toolset>gcc:<cxxflags>-Wno-missing-braces
-      
-      # Assembler error "File too big" caused by lots of C++ templates, for example, math/floating_point_examples.cpp.
-      # Some projects on some toolsets may require
-      #   <toolset>gcc-mingw:<cxxflags>\"-Wa,-mbig-obj\"
-      # See https://digitalkarabela.com/mingw-w64-how-to-fix-file-too-big-too-many-sections/
-      # <toolset>gcc-mingw:<cxxflags>-Wa,-mbig-obj # Some projects may overflow assembler and require equivalent of MSVC /bigobj.
-      # Requires version 2.30 of GNU binutils.
-      # Best applied only to projects that require this, see run math/floating_point_examples.cpp below.
-
+      <toolset>gcc:<cxxflags>-Wno-missing-braces
       <toolset>darwin:<cxxflags>-Wno-missing-braces
       <toolset>acc:<cxxflags>+W2068,2461,2236,4070
       <toolset>intel:<cxxflags>-Qwd264,239
@@ -95,7 +86,7 @@ test-suite examples :
       [ run debug_adaptor_snips.cpp no_eh_eg_support ]
       [ run float128_snips.cpp quadmath no_eh_eg_support : : : [ check-target-builds ../config//has_float128 : : <build>no ] ]
 
-      [ run floating_point_examples.cpp no_eh_eg_support : : : <toolset>gcc-mingw:<cxxflags>-Wa,-mbig-obj ] # See note above.
+      [ run floating_point_examples.cpp no_eh_eg_support : : : [ check-target-builds ../config//has_big_obj : <cxxflags>-Wa,-mbig-obj <debug-symbols>off ] ]
       [ run gauss_laguerre_quadrature.cpp no_eh_eg_support : : : release [ requires cxx11_lambdas ] ]
       [ run hypergeometric_luke_algorithms.cpp no_eh_eg_support ../../chrono/build//boost_chrono ../../system/build//boost_system : : : [ requires cxx11_nullptr ]  ]
       [ run integer_examples.cpp no_eh_eg_support ]


### PR DESCRIPTION
Fixes https://github.com/boostorg/multiprecision/issues/219