### PR TITLE
Fast addition in cpp_int

### DIFF
--- a/include/boost/multiprecision/cpp_int/add.hpp
+++ b/include/boost/multiprecision/cpp_int/add.hpp
@@ -11,11 +11,11 @@
 
 #include <boost/multiprecision/detail/constexpr.hpp>
 
-#if (defined(__x86_64__) || defined(__i386__)) && __cplusplus >= 201103L && defined(__has_include)
-#if ((defined(__clang__) || defined(__GNUC__) || defined(__INTEL_COMPILER))) && __has_include(<immintrin.h>)
+#if (defined(__x86_64__) || defined(__i386__)) && defined(__has_include) && (__cplusplus >= 201402L)
+#if ((defined(__clang__) && __clang_major__ >= 9) || (__GNUC__ >= 9) || (__INTEL_COMPILER >= 1300L) && __has_include(<immintrin.h>)
 #include <immintrin.h>
 #define BOOST_MP_ADC_INTRINSICS
-#elif defined(_MSC_VER) && __has_include(<intrin.h>)
+#elif (_MSC_VER >= 1925L) && __has_include(<intrin.h>)
 #include <intrin.h>
 #define BOOST_MP_ADC_INTRINSICS
 #endif // compiler switch
@@ -50,7 +50,7 @@ inline BOOST_MP_CXX14_CONSTEXPR bool add_unsigned_adc(const unsigned long long* 
    using T = unsigned __int64;
 #else
    using T = unsigned long long;
-#endif
+#endif // GCC, LLVM, ICC
    auto add_carry = &_addcarry_u64;
 #elif defined(_MSC_VER)
    using T        = unsigned int;

--- a/include/boost/multiprecision/cpp_int/add.hpp
+++ b/include/boost/multiprecision/cpp_int/add.hpp
@@ -1,3 +1,4 @@
+
 ///////////////////////////////////////////////////////////////
 //  Copyright 2012 John Maddock. Distributed under the Boost
 //  Software License, Version 1.0. (See accompanying file
@@ -49,24 +50,30 @@ inline BOOST_MP_CXX14_CONSTEXPR void add_unsigned(CppInt1& result, const CppInt2
    // First where a and b overlap:
    unsigned      i;
    unsigned char carry = 0;
-#if __GNUC__ || __clang__
-   for (i = 0; i < m; ++i)
+#ifndef __INTEL_COMPILER
+   for (i = 0; i + 4 <= m; i += 4)
    {
+	  carry = _addcarry_u64(carry, pa[i + 0], pb[i + 0], &pr[i + 0]);
+	  carry = _addcarry_u64(carry, pa[i + 1], pb[i + 1], &pr[i + 1]);
+	  carry = _addcarry_u64(carry, pa[i + 2], pb[i + 2], &pr[i + 2]);
+	  carry = _addcarry_u64(carry, pa[i + 3], pb[i + 3], &pr[i + 3]);
+   }
+   for (; i < m; ++i)
 	  carry = _addcarry_u64(carry, pa[i], pb[i], &pr[i]);
-   }
    for (; i < x && carry; ++i)
-   {
 	  carry = _addcarry_u64(carry, pa[i], 0, &pr[i]);
-   }
-#else // for ICC
-   for (i = 0; i < m; ++i)
+#else
+   for (i = 0; i + 4 <= m; i += 4)
    {
+	  carry = _addcarry_u64(carry, pa[i + 0], pb[i + 0], (unsigned long*)&pr[i + 0]);
+	  carry = _addcarry_u64(carry, pa[i + 1], pb[i + 1], (unsigned long*)&pr[i + 1]);
+	  carry = _addcarry_u64(carry, pa[i + 2], pb[i + 2], (unsigned long*)&pr[i + 2]);
+	  carry = _addcarry_u64(carry, pa[i + 3], pb[i + 3], (unsigned long*)&pr[i + 3]);
+   }
+   for (; i < m; ++i)
 	  carry = _addcarry_u64(carry, pa[i], pb[i], (unsigned long*)&pr[i]);
-   }
    for (; i < x && carry; ++i)
-   {
 	  carry = _addcarry_u64(carry, pa[i], 0, (unsigned long*)&pr[i]);
-   }
 #endif
    if (i == x && carry)
    {
@@ -77,7 +84,6 @@ inline BOOST_MP_CXX14_CONSTEXPR void add_unsigned(CppInt1& result, const CppInt2
    }
    else
 	  std_constexpr::copy(pa + i, pa + x, pr + i);
-   //std::cerr << std::hex << "A:\t" << abs(cpp_int{a}) << "\nB:\t" << abs(cpp_int{b}) << "\n\n";
    result.normalize();
    result.sign(a.sign());
 }


### PR DESCRIPTION
Compilers currently generate *bad* assembly so, with a little help to the compiler, I was able to reduce the number of instructions (`mov` and `add` both) in the addition loop. 

[See the Godbolt link showing the difference in assembly](https://godbolt.org/z/lH1_Hc)

Benefits:
- Can be easily unrolled
- Easy to read
- Efficient (?)

```
// clang 10.0, Arch Linux, -std=c++11
// Current develop
BM<bst_int>/40000        3826 ns         3730 ns       191511
BM<bst_int>/80000        4545 ns         4486 ns       157061
BM<bst_int>/120000       5416 ns         5335 ns       135902
BM<bst_int>/160000       6238 ns         6139 ns       113651
BM<bst_int>/200000       6924 ns         6829 ns       103996

// This PR
BM<bst_int>/40000        3395 ns         3362 ns       208408
BM<bst_int>/80000        3954 ns         3921 ns       172037
BM<bst_int>/120000       4551 ns         4511 ns       158986
BM<bst_int>/160000       5120 ns         5063 ns       136567
BM<bst_int>/200000       5545 ns         5496 ns       112399

BM<mpz_int>/40000         751 ns          744 ns       961070
BM<mpz_int>/80000        1536 ns         1522 ns       461803
BM<mpz_int>/120000       2389 ns         2371 ns       297695
BM<mpz_int>/160000       3475 ns         3439 ns       215895
BM<mpz_int>/200000       4008 ns         3972 ns       178096
```

Concerns:
- Most importantly will boost take this path of using intrinsics?
- Still unable to see huge performance gains as `mov` instructions are reduced and also `add` is executed only once instead of 4 times. Needs some investigation.
- GCC cannot unroll the loop while clang can, thus there is a huge disparity between GCC & LLVM.
- This assembly can be optimized further by writing assembly by hand (inline asm?) but still has potential.
- Portability [New!]