### PR TITLE
Use BOOST_TRY/CATCH

### DIFF
--- a/include/boost/multiprecision/detail/default_ops.hpp
+++ b/include/boost/multiprecision/detail/default_ops.hpp
@@ -6,6 +6,7 @@
 #ifndef BOOST_MATH_BIG_NUM_DEF_OPS
 #define BOOST_MATH_BIG_NUM_DEF_OPS
 
+#include <boost/core/no_exceptions_support.hpp> // BOOST_TRY
 #include <boost/math/policies/error_handling.hpp>
 #include <boost/multiprecision/detail/number_base.hpp>
 #include <boost/math/special_functions/fpclassify.hpp>
@@ -970,11 +971,10 @@ inline void last_chance_eval_convert_to(terminal<R>* result, const B& backend, c
    //
    if (std::numeric_limits<R>::is_integer && !std::numeric_limits<R>::is_signed && (eval_get_sign(backend) < 0))
       BOOST_THROW_EXCEPTION(std::range_error("Attempt to convert negative value to an unsigned integer results in undefined behaviour"));
-   try
-   {
+   BOOST_TRY {
       result->value = boost::lexical_cast<R>(backend.str(0, std::ios_base::fmtflags(0)));
    }
-   catch (const bad_lexical_cast&)
+   BOOST_CATCH (const bad_lexical_cast&)
    {
       if (eval_get_sign(backend) < 0)
       {
@@ -983,6 +983,7 @@ inline void last_chance_eval_convert_to(terminal<R>* result, const B& backend, c
       else
          *result = (std::numeric_limits<R>::max)();
    }
+   BOOST_CATCH_END
 }
 
 template <class R, class B>
@@ -994,14 +995,13 @@ inline void last_chance_eval_convert_to(terminal<R>* result, const B& backend, c
    //
    if (std::numeric_limits<R>::is_integer && !std::numeric_limits<R>::is_signed && (eval_get_sign(backend) < 0))
       BOOST_THROW_EXCEPTION(std::range_error("Attempt to convert negative value to an unsigned integer results in undefined behaviour"));
-   try
-   {
+   BOOST_TRY {
       B t(backend);
       R mask = ~static_cast<R>(0u);
       eval_bitwise_and(t, mask);
       result->value = boost::lexical_cast<R>(t.str(0, std::ios_base::fmtflags(0)));
    }
-   catch (const bad_lexical_cast&)
+   BOOST_CATCH (const bad_lexical_cast&)
    {
       if (eval_get_sign(backend) < 0)
       {
@@ -1010,6 +1010,7 @@ inline void last_chance_eval_convert_to(terminal<R>* result, const B& backend, c
       else
          *result = (std::numeric_limits<R>::max)();
    }
+   BOOST_CATCH_END
 }
 
 template <class R, class B>

--- a/include/boost/multiprecision/detail/functions/pow.hpp
+++ b/include/boost/multiprecision/detail/functions/pow.hpp
@@ -17,6 +17,8 @@
 #pragma warning(disable : 6326) // comparison of two constants
 #endif
 
+#include <boost/core/no_exceptions_support.hpp> // BOOST_TRY
+
 namespace detail {
 
 template <typename T, typename U>
@@ -503,10 +505,9 @@ inline void eval_pow(T& result, const T& x, const T& a)
       case FP_NAN:
          result = a;
          break;
-      case FP_NORMAL:
-      {
+      case FP_NORMAL: {
          // Need to check for a an odd integer as a special case:
-         try
+         BOOST_TRY
          {
             typename boost::multiprecision::detail::canonical<boost::intmax_t, T>::type i;
             eval_convert_to(&i, a);
@@ -536,10 +537,11 @@ inline void eval_pow(T& result, const T& x, const T& a)
                return;
             }
          }
-         catch (const std::exception&)
+         BOOST_CATCH(const std::exception&)
          {
             // fallthrough..
          }
+         BOOST_CATCH_END
          BOOST_FALLTHROUGH;
       }
       default:
@@ -584,31 +586,26 @@ inline void eval_pow(T& result, const T& x, const T& a)
        std::numeric_limits<typename boost::multiprecision::detail::canonical<boost::intmax_t, T>::type>::is_specialized ? (std::numeric_limits<typename boost::multiprecision::detail::canonical<boost::intmax_t, T>::type>::min)() : -min_an;
 
    T fa;
-#ifndef BOOST_NO_EXCEPTIONS
-   try
+   BOOST_TRY
    {
-#endif
       eval_convert_to(&an, a);
       if (a.compare(an) == 0)
       {
          detail::pow_imp(result, x, an, mpl::true_());
          return;
       }
-#ifndef BOOST_NO_EXCEPTIONS
    }
-   catch (const std::exception&)
+   BOOST_CATCH(const std::exception&)
    {
       // conversion failed, just fall through, value is not an integer.
       an = (std::numeric_limits<boost::intmax_t>::max)();
    }
-#endif
+   BOOST_CATCH_END
    if ((eval_get_sign(x) < 0))
    {
       typename boost::multiprecision::detail::canonical<boost::uintmax_t, T>::type aun;
-#ifndef BOOST_NO_EXCEPTIONS
-      try
+      BOOST_TRY
       {
-#endif
          eval_convert_to(&aun, a);
          if (a.compare(aun) == 0)
          {
@@ -619,13 +616,13 @@ inline void eval_pow(T& result, const T& x, const T& a)
                result.negate();
             return;
          }
-#ifndef BOOST_NO_EXCEPTIONS
       }
-      catch (const std::exception&)
+      BOOST_CATCH(const std::exception&)
       {
          // conversion failed, just fall through, value is not an integer.
       }
-#endif
+      BOOST_CATCH_END
+
       eval_floor(result, a);
       // -1^INF is a special case in C99:
       if ((x.compare(si_type(-1)) == 0) && (eval_fpclassify(a) == FP_INFINITE))
@@ -758,7 +755,7 @@ void eval_exp2(T& result, const T& arg)
    // Check for pure-integer arguments which can be either signed or unsigned.
    typename boost::multiprecision::detail::canonical<typename T::exponent_type, T>::type i;
    T                                                                                     temp;
-   try
+   BOOST_TRY
    {
       eval_trunc(temp, arg);
       eval_convert_to(&i, temp);
@@ -769,12 +766,13 @@ void eval_exp2(T& result, const T& arg)
          return;
       }
    }
-   catch (const boost::math::rounding_error&)
+   BOOST_CATCH(const boost::math::rounding_error&)
    { /* Fallthrough */
    }
-   catch (const std::runtime_error&)
+   BOOST_CATCH(const std::runtime_error&)
    { /* Fallthrough */
    }
+   BOOST_CATCH_END
 
    temp = static_cast<typename mpl::front<typename T::unsigned_types>::type>(2u);
    eval_pow(result, temp, arg);


### PR DESCRIPTION
Using the BOOST_TRY/BOOST_CATCH/BOOST_END_CATCH macros instead of `try`/`catch` allows using the multiprecision library with boost configured with `BOOST_NO_EXCEPTIONS=1` and `BOOST_EXCEPTION_DISABLE=1`