### PR TITLE
reduce dec_float static init with constexpr constants

### DIFF
--- a/include/boost/multiprecision/detail/dynamic_array.hpp
+++ b/include/boost/multiprecision/detail/dynamic_array.hpp
@@ -8,6 +8,8 @@
 #ifndef BOOST_MP_DETAIL_DYNAMIC_ARRAY_HPP
 #define BOOST_MP_DETAIL_DYNAMIC_ARRAY_HPP
 
+#include <algorithm>
+#include <initializer_list>
 #include <vector>
 #include <boost/multiprecision/detail/rebind.hpp>
 
@@ -15,8 +17,19 @@ namespace boost { namespace multiprecision { namespace backends { namespace deta
 template <class value_type, const boost::uint32_t elem_number, class my_allocator>
 struct dynamic_array : public std::vector<value_type, typename rebind<value_type, my_allocator>::type>
 {
-   dynamic_array() : std::vector<value_type, typename rebind<value_type, my_allocator>::type>(static_cast<typename std::vector<value_type, typename rebind<value_type, my_allocator>::type>::size_type>(elem_number), static_cast<value_type>(0))
+private:
+   using base_class_type = std::vector<value_type, typename rebind<value_type, my_allocator>::type>;
+
+public:
+   dynamic_array() : base_class_type(static_cast<typename base_class_type::size_type>(elem_number), static_cast<value_type>(0))
    {
+   }
+
+   dynamic_array( std::initializer_list<value_type> lst ) : base_class_type(static_cast<typename base_class_type::size_type>(elem_number), static_cast<value_type>(0))
+   {
+     std::copy(lst.begin(),
+               lst.end(),
+               base_class_type::begin());
    }
 
    value_type*       data() { return &(*(this->begin())); }


### PR DESCRIPTION
This draft PR investigates using selected features of C++11 in order to reduce the heavy load of static initialization associated with `cpp_dec_float`.

Historically `cpp_dec_float` has rquired certain static instances of class-local constants representing such things as min/max value of the class, epsilon, common small values such as 0.5, 1, 2, etc.

With some C++11 constructs (like `<initializer_list>`, `constexpr`) it might be possible to remove some or most of these static constant values. The run-time impact is expected to be performance-neutral. However, these changes reduce memory consumption (especially for higher digit counts) and significantly reduce the scope and complexity of the so-called static initialization that runs before the call to `main()`.

Aside: Future potential use improveements of `boost::math::constants` might possibly be able to be derived from this kind of technology, but these are not in the scope of this draft PR at the moment.

The checked in code handles nan, inf, max, eps.
