### PR TITLE
Change range_error->domain_error for lsb/msb failures.

### DIFF
--- a/include/boost/multiprecision/cpp_int/misc.hpp
+++ b/include/boost/multiprecision/cpp_int/misc.hpp
@@ -195,11 +195,11 @@ eval_lsb(const cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocato
    using default_ops::eval_get_sign;
    if (eval_get_sign(a) == 0)
    {
-      BOOST_THROW_EXCEPTION(std::range_error("No bits were set in the operand."));
+      BOOST_THROW_EXCEPTION(std::domain_error("No bits were set in the operand."));
    }
    if (a.sign())
    {
-      BOOST_THROW_EXCEPTION(std::range_error("Testing individual bits in negative values is not supported - results are undefined."));
+      BOOST_THROW_EXCEPTION(std::domain_error("Testing individual bits in negative values is not supported - results are undefined."));
    }
 
    //
@@ -236,11 +236,11 @@ eval_msb(const cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocato
    using default_ops::eval_get_sign;
    if (eval_get_sign(a) == 0)
    {
-      BOOST_THROW_EXCEPTION(std::range_error("No bits were set in the operand."));
+      BOOST_THROW_EXCEPTION(std::domain_error("No bits were set in the operand."));
    }
    if (a.sign())
    {
-      BOOST_THROW_EXCEPTION(std::range_error("Testing individual bits in negative values is not supported - results are undefined."));
+      BOOST_THROW_EXCEPTION(std::domain_error("Testing individual bits in negative values is not supported - results are undefined."));
    }
    return eval_msb_imp(a);
 }
@@ -1158,11 +1158,11 @@ eval_lsb(const cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocato
    using default_ops::eval_get_sign;
    if (eval_get_sign(a) == 0)
    {
-      BOOST_THROW_EXCEPTION(std::range_error("No bits were set in the operand."));
+      BOOST_THROW_EXCEPTION(std::domain_error("No bits were set in the operand."));
    }
    if (a.sign())
    {
-      BOOST_THROW_EXCEPTION(std::range_error("Testing individual bits in negative values is not supported - results are undefined."));
+      BOOST_THROW_EXCEPTION(std::domain_error("Testing individual bits in negative values is not supported - results are undefined."));
    }
    //
    // Find the index of the least significant bit within that limb:
@@ -1187,11 +1187,11 @@ eval_msb(const cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocato
    using default_ops::eval_get_sign;
    if (eval_get_sign(a) == 0)
    {
-      BOOST_THROW_EXCEPTION(std::range_error("No bits were set in the operand."));
+      BOOST_THROW_EXCEPTION(std::domain_error("No bits were set in the operand."));
    }
    if (a.sign())
    {
-      BOOST_THROW_EXCEPTION(std::range_error("Testing individual bits in negative values is not supported - results are undefined."));
+      BOOST_THROW_EXCEPTION(std::domain_error("Testing individual bits in negative values is not supported - results are undefined."));
    }
    return eval_msb_imp(a);
 }

--- a/include/boost/multiprecision/detail/default_ops.hpp
+++ b/include/boost/multiprecision/detail/default_ops.hpp
@@ -1424,11 +1424,11 @@ inline BOOST_MP_CXX14_CONSTEXPR unsigned eval_lsb(const T& val)
    int                                                                          c = eval_get_sign(val);
    if (c == 0)
    {
-      BOOST_THROW_EXCEPTION(std::range_error("No bits were set in the operand."));
+      BOOST_THROW_EXCEPTION(std::domain_error("No bits were set in the operand."));
    }
    if (c < 0)
    {
-      BOOST_THROW_EXCEPTION(std::range_error("Testing individual bits in negative values is not supported - results are undefined."));
+      BOOST_THROW_EXCEPTION(std::domain_error("Testing individual bits in negative values is not supported - results are undefined."));
    }
    unsigned result = 0;
    T        mask, t;
@@ -1449,11 +1449,11 @@ inline BOOST_MP_CXX14_CONSTEXPR int eval_msb(const T& val)
    int c = eval_get_sign(val);
    if (c == 0)
    {
-      BOOST_THROW_EXCEPTION(std::range_error("No bits were set in the operand."));
+      BOOST_THROW_EXCEPTION(std::domain_error("No bits were set in the operand."));
    }
    if (c < 0)
    {
-      BOOST_THROW_EXCEPTION(std::range_error("Testing individual bits in negative values is not supported - results are undefined."));
+      BOOST_THROW_EXCEPTION(std::domain_error("Testing individual bits in negative values is not supported - results are undefined."));
    }
    //
    // This implementation is really really rubbish - it does

--- a/include/boost/multiprecision/gmp.hpp
+++ b/include/boost/multiprecision/gmp.hpp
@@ -1912,11 +1912,11 @@ inline unsigned eval_lsb(const gmp_int& val)
    int c = eval_get_sign(val);
    if (c == 0)
    {
-      BOOST_THROW_EXCEPTION(std::range_error("No bits were set in the operand."));
+      BOOST_THROW_EXCEPTION(std::domain_error("No bits were set in the operand."));
    }
    if (c < 0)
    {
-      BOOST_THROW_EXCEPTION(std::range_error("Testing individual bits in negative values is not supported - results are undefined."));
+      BOOST_THROW_EXCEPTION(std::domain_error("Testing individual bits in negative values is not supported - results are undefined."));
    }
    return static_cast<unsigned>(mpz_scan1(val.data(), 0));
 }
@@ -1926,11 +1926,11 @@ inline unsigned eval_msb(const gmp_int& val)
    int c = eval_get_sign(val);
    if (c == 0)
    {
-      BOOST_THROW_EXCEPTION(std::range_error("No bits were set in the operand."));
+      BOOST_THROW_EXCEPTION(std::domain_error("No bits were set in the operand."));
    }
    if (c < 0)
    {
-      BOOST_THROW_EXCEPTION(std::range_error("Testing individual bits in negative values is not supported - results are undefined."));
+      BOOST_THROW_EXCEPTION(std::domain_error("Testing individual bits in negative values is not supported - results are undefined."));
    }
    return static_cast<unsigned>(mpz_sizeinbase(val.data(), 2) - 1);
 }

--- a/include/boost/multiprecision/integer.hpp
+++ b/include/boost/multiprecision/integer.hpp
@@ -115,11 +115,11 @@ BOOST_MP_CXX14_CONSTEXPR typename enable_if_c<is_integral<Integer>::value, unsig
    {
       if (val == 0)
       {
-         BOOST_THROW_EXCEPTION(std::range_error("No bits were set in the operand."));
+         BOOST_THROW_EXCEPTION(std::domain_error("No bits were set in the operand."));
       }
       else
       {
-         BOOST_THROW_EXCEPTION(std::range_error("Testing individual bits in negative values is not supported - results are undefined."));
+         BOOST_THROW_EXCEPTION(std::domain_error("Testing individual bits in negative values is not supported - results are undefined."));
       }
    }
    return detail::find_lsb(val);
@@ -132,11 +132,11 @@ BOOST_MP_CXX14_CONSTEXPR typename enable_if_c<is_integral<Integer>::value, unsig
    {
       if (val == 0)
       {
-         BOOST_THROW_EXCEPTION(std::range_error("No bits were set in the operand."));
+         BOOST_THROW_EXCEPTION(std::domain_error("No bits were set in the operand."));
       }
       else
       {
-         BOOST_THROW_EXCEPTION(std::range_error("Testing individual bits in negative values is not supported - results are undefined."));
+         BOOST_THROW_EXCEPTION(std::domain_error("Testing individual bits in negative values is not supported - results are undefined."));
       }
    }
    return detail::find_msb(val);

--- a/include/boost/multiprecision/tommath.hpp
+++ b/include/boost/multiprecision/tommath.hpp
@@ -717,11 +717,11 @@ inline unsigned eval_lsb(const tommath_int& val)
    int c = eval_get_sign(val);
    if (c == 0)
    {
-      BOOST_THROW_EXCEPTION(std::range_error("No bits were set in the operand."));
+      BOOST_THROW_EXCEPTION(std::domain_error("No bits were set in the operand."));
    }
    if (c < 0)
    {
-      BOOST_THROW_EXCEPTION(std::range_error("Testing individual bits in negative values is not supported - results are undefined."));
+      BOOST_THROW_EXCEPTION(std::domain_error("Testing individual bits in negative values is not supported - results are undefined."));
    }
    return mp_cnt_lsb(const_cast< ::mp_int*>(&val.data()));
 }
@@ -731,11 +731,11 @@ inline unsigned eval_msb(const tommath_int& val)
    int c = eval_get_sign(val);
    if (c == 0)
    {
-      BOOST_THROW_EXCEPTION(std::range_error("No bits were set in the operand."));
+      BOOST_THROW_EXCEPTION(std::domain_error("No bits were set in the operand."));
    }
    if (c < 0)
    {
-      BOOST_THROW_EXCEPTION(std::range_error("Testing individual bits in negative values is not supported - results are undefined."));
+      BOOST_THROW_EXCEPTION(std::domain_error("Testing individual bits in negative values is not supported - results are undefined."));
    }
    return mp_count_bits(const_cast< ::mp_int*>(&val.data())) - 1;
 }

--- a/test/test_native_integer.cpp
+++ b/test/test_native_integer.cpp
@@ -26,7 +26,7 @@ void test()
    I i(0);
 
 #ifndef BOOST_NO_EXCEPTIONS
-   BOOST_CHECK_THROW(lsb(i), std::range_error);
+   BOOST_CHECK_THROW(lsb(i), std::domain_error);
 #endif
    BOOST_CHECK(bit_test(bit_set(i, 0), 0));
    BOOST_CHECK_EQUAL(bit_set(i, 0), 1);
@@ -49,7 +49,7 @@ void test()
    if (std::numeric_limits<I>::is_signed)
    {
       i = static_cast<I>(-1);
-      BOOST_CHECK_THROW(lsb(i), std::range_error);
+      BOOST_CHECK_THROW(lsb(i), std::domain_error);
    }
 #endif
    H mx = (std::numeric_limits<H>::max)();


### PR DESCRIPTION
Fixes https://github.com/boostorg/multiprecision/issues/257.