### PR TITLE
Fixes #289 with a clear intuitive example

### DIFF
--- a/doc/tutorial_float_builtin_ctor.qbk
+++ b/doc/tutorial_float_builtin_ctor.qbk
@@ -1,0 +1,59 @@
+[/
+  Copyright 2021 John Maddock.
+  Copyright 2021 Paul A. Bristow.
+  Copyright 2021 Christopher Kormanyos.
+
+  Distributed under the Boost Software License, Version 1.0.
+  (See accompanying file LICENSE_1_0.txt or copy at
+  http://www.boost.org/LICENSE_1_0.txt).
+]
+
+[section:floatbuiltinctor Construction from Built-In Floats]
+
+Construction of multiprecision types from built-in floating-point types
+can lead to potentially unexpected, yet correct, results.
+Consider, for instance constructing an instance of `cpp_dec_float_50`
+from the literal built-in floating-point `double` value 11.1.
+
+   #include <iomanip>
+   #include <iostream>
+   #include <limits>
+
+   #include <boost/multiprecision/cpp_dec_float.hpp>
+
+   int main()
+   {
+     using my_dec_100 = boost::multiprecision::cpp_dec_float_50;
+
+     const my_dec_100 f11(11.1);
+
+     // On a system with 64-bit double:
+     // 11.09999999999999964472863211994990706443786621093750
+     std::cout << std::setprecision(std::numeric_limits<my_dec_100>::digits10)
+               << std::fixed
+               << f11
+               << std::endl;
+   }
+
+In this example, the system has a 64-bit built in `double` representation.
+The variable `f11` is initialized with the literal
+`double` value 11.1. Recall that built-in floating-point representations
+are based on successive binary fractional approximations.
+These are, in fact, very close approximations.
+But they are approximations nonetheless, having their built-in finite precision.
+
+For this reason,
+the full multiple precision value of the `double` approximation
+of 11.1 is given by the large value shown above. Observations show
+us that the value is reliable up to the approximate 15 decimal
+digit precision of built-in 64-bit `double` on this system.
+
+If the exact value of 11.1 is desired
+(within the wider precision of the multiprecision type),
+then construction from literal string or from a rational
+integral construction/division sequence can be used.
+
+   const my_dec_100 f11_str("11.1");
+   const my_dec_100 f11_n  (my_dec_100(111) / 10);
+
+[endsect] [/section:floatbuiltinctor Construction from Built-In Floats]

--- a/doc/tutorial_floats.qbk
+++ b/doc/tutorial_floats.qbk
@@ -26,6 +26,6 @@ The following back-ends provide floating-point arithmetic:
 [include tutorial_gmp_float.qbk]
 [include tutorial_mpfr_float.qbk]
 [include tutorial_float128.qbk]
-[include tutorial_float_eg.qbk]
+[include tutorial_float_builtin_ctor.qbk]
 
 [endsect] [/section:floats floating-point Numbers]


### PR DESCRIPTION
Clear intuitive example has been added to the docs as discussed in the dialogue of #289.