### PR TITLE
Fix for specfun_float128 tests

### DIFF
--- a/include/boost/multiprecision/detail/hash.hpp
+++ b/include/boost/multiprecision/detail/hash.hpp
@@ -7,6 +7,7 @@
 #define BOOST_MULTIPRECISION_DETAIL_HASH_HPP
 
 #include <cstddef>
+#include <functional>
 
 namespace boost { namespace multiprecision { namespace detail {
 
@@ -18,6 +19,13 @@ inline void hash_combine(std::size_t& seed, const T& v, Args... args)
     // gmp types require explicit casting
     seed = static_cast<std::size_t>(static_cast<T>(seed) ^ (v + 0x9e3779b9 + (seed<<6) + (seed>>2)));
     hash_combine(seed, args...);
+}
+
+template <typename T>
+inline std::size_t hash_value(const T& v)
+{
+    std::hash<T> hasher;
+    return hasher(v);
 }
 
 }}} // Namespaces

--- a/include/boost/multiprecision/float128.hpp
+++ b/include/boost/multiprecision/float128.hpp
@@ -632,7 +632,7 @@ inline int eval_signbit BOOST_PREVENT_MACRO_SUBSTITUTION(const float128_backend&
 
 inline std::size_t hash_value(const float128_backend& val)
 {
-   return boost::multiprecision::detail::hash_value(static_cast<double>(val.value()));
+   return hash_value(static_cast<double>(val.value()));
 }
 
 } // namespace backends


### PR DESCRIPTION
This passes locally with the build flags copied from the circleci run.