### PR TITLE
Remove unused dependencies

### DIFF
--- a/include/boost/multiprecision/number.hpp
+++ b/include/boost/multiprecision/number.hpp
@@ -8,8 +8,6 @@
 
 #include <boost/config.hpp>
 #include <cstdint>
-#include <boost/assert.hpp>
-#include <boost/throw_exception.hpp>
 #include <boost/multiprecision/detail/precision.hpp>
 #include <boost/multiprecision/detail/generic_interconvert.hpp>
 #include <boost/multiprecision/detail/number_compare.hpp>


### PR DESCRIPTION
Boost.assert and Boost.throw_exception are both included but unused in `number.hpp`