### PR TITLE
Restrict Intel intrinsics to Intel processors on msvc.

### DIFF
--- a/include/boost/multiprecision/cpp_int/intel_intrinsics.hpp
+++ b/include/boost/multiprecision/cpp_int/intel_intrinsics.hpp
@@ -30,6 +30,16 @@
 // We appear to crash the compiler if we try to use these intrinsics?
 #undef BOOST_MP_HAS_IMMINTRIN_H
 #endif
+
+#if defined(BOOST_MSVC) && !defined(_M_IX86) && !defined(_M_ARM64) && !defined(_M_X64)
+//
+// When targeting platforms such as ARM, msvc still has the INtel headers in it's include path
+// even though they're not usable.  See https://github.com/boostorg/multiprecision/issues/321
+//
+#undef BOOST_MP_HAS_IMMINTRIN_H
+#endif
+
+
 //
 // If the compiler supports the intrinsics used by GCC internally
 // inside <immintrin.h> then we'll use them directly.


### PR DESCRIPTION
Fixes https://github.com/boostorg/multiprecision/issues/321.