### PR TITLE
Remove unused variable warning.

### DIFF
--- a/test/math/high_prec/test_gamma.cpp
+++ b/test/math/high_prec/test_gamma.cpp
@@ -23,19 +23,6 @@ void expected_results()
    // Define the max and mean errors expected for
    // various compilers and platforms.
    //
-   const char* largest_type;
-#ifndef BOOST_MATH_NO_LONG_DOUBLE_MATH_FUNCTIONS
-   if (boost::math::policies::digits<double, boost::math::policies::policy<> >() == boost::math::policies::digits<long double, boost::math::policies::policy<> >())
-   {
-      largest_type = "(long\\s+)?double";
-   }
-   else
-   {
-      largest_type = "long double";
-   }
-#else
-   largest_type = "(long\\s+)?double";
-#endif
    add_expected_result(
        ".*",                                          // compiler
        ".*",                                          // stdlib


### PR DESCRIPTION
It's cluttering the logs; see [here](https://app.circleci.com/pipelines/github/boostorg/multiprecision/727/workflows/a1cd8f75-ccba-4a73-9388-5f20ebc7d454/jobs/2413).