### PR TITLE
Correct mpq_rational conversion to integer.

### DIFF
--- a/include/boost/multiprecision/gmp.hpp
+++ b/include/boost/multiprecision/gmp.hpp
@@ -2468,18 +2468,14 @@ inline void eval_convert_to(__float128* result, const gmp_rational& val)
 }
 #endif
 
-inline void eval_convert_to(long* result, const gmp_rational& val)
+template <class R>
+inline typename std::enable_if<number_category<R>::value == number_kind_integer>::type eval_convert_to(R* result, const gmp_rational& backend)
 {
-   double r;
-   eval_convert_to(&r, val);
-   *result = static_cast<long>(r);
-}
-
-inline void eval_convert_to(unsigned long* result, const gmp_rational& val)
-{
-   double r;
-   eval_convert_to(&r, val);
-   *result = static_cast<long>(r);
+   number<gmp_int> n(mpq_numref(backend.data()));
+   number<gmp_int> d(mpq_denref(backend.data()));
+   n /= d;
+   using default_ops::eval_convert_to;
+   eval_convert_to(result, n.backend());
 }
 
 inline void eval_abs(gmp_rational& result, const gmp_rational& val)

--- a/include/boost/multiprecision/gmp.hpp
+++ b/include/boost/multiprecision/gmp.hpp
@@ -2471,11 +2471,12 @@ inline void eval_convert_to(__float128* result, const gmp_rational& val)
 template <class R>
 inline typename std::enable_if<number_category<R>::value == number_kind_integer>::type eval_convert_to(R* result, const gmp_rational& backend)
 {
-   number<gmp_int> n(mpq_numref(backend.data()));
-   number<gmp_int> d(mpq_denref(backend.data()));
-   n /= d;
+   gmp_int n(mpq_numref(backend.data()));
+   gmp_int d(mpq_denref(backend.data()));
+   using default_ops::eval_divide;
+   eval_divide(n, d);
    using default_ops::eval_convert_to;
-   eval_convert_to(result, n.backend());
+   eval_convert_to(result, n);
 }
 
 inline void eval_abs(gmp_rational& result, const gmp_rational& val)

--- a/test/test_arithmetic.hpp
+++ b/test/test_arithmetic.hpp
@@ -336,6 +336,17 @@ void test_rational(const std::integral_constant<bool, false>&)
    ss << a;
    ss >> b;
    BOOST_CHECK_EQUAL(a, b);
+   //
+   // Conversion to integer, see https://github.com/boostorg/multiprecision/issues/342.
+   //
+   Real three(10, 3);
+   BOOST_CHECK_EQUAL(static_cast<std::uint16_t>(three), 3);
+   BOOST_CHECK_EQUAL(static_cast<std::uint32_t>(three), 3);
+   BOOST_CHECK_EQUAL(static_cast<std::uint64_t>(three), 3);
+   three = -three;
+   BOOST_CHECK_EQUAL(static_cast<std::int16_t>(three), -3);
+   BOOST_CHECK_EQUAL(static_cast<std::int32_t>(three), -3);
+   BOOST_CHECK_EQUAL(static_cast<std::int64_t>(three), -3);
 }
 
 template <class Real>


### PR DESCRIPTION
Fixes https://github.com/boostorg/multiprecision/issues/342.