### PR TITLE
Update GHA

### DIFF
--- a/.github/workflows/multiprecision.yml
+++ b/.github/workflows/multiprecision.yml
@@ -199,7 +199,7 @@ jobs:
         run: ./config_info_travis
         working-directory: ../boost-root/libs/config/test
       - name: Test
-        run: ../../../b2 define=BOOST_CI_ASAN_BUILD cxxflags=-fsanitize=address linkflags=-fsanitize=address toolset=$TOOLSET ${{ matrix.suite }} define=CI_SUPPRESS_KNOWN_ISSUES
+        run: ../../../b2 define=BOOST_CI_ASAN_BUILD define=BOOST_CI_SANITIZER_BUILD cxxflags=-fsanitize=address linkflags=-fsanitize=address toolset=$TOOLSET ${{ matrix.suite }} define=CI_SUPPRESS_KNOWN_ISSUES
         working-directory: ../boost-root/libs/multiprecision/test
   ubuntu-focal-UBSAN:
     runs-on: ubuntu-20.04
@@ -261,7 +261,7 @@ jobs:
         run: ./config_info_travis
         working-directory: ../boost-root/libs/config/test
       - name: Test
-        run: ../../../b2 define=BOOST_CI_UBSAN_BUILD cxxflags=-fsanitize=undefined linkflags=-fsanitize=undefined toolset=$TOOLSET ${{ matrix.suite }} define=CI_SUPPRESS_KNOWN_ISSUES
+        run: ../../../b2 define=BOOST_CI_UBSAN_BUILD define=BOOST_CI_SANITIZER_BUILD cxxflags=-fsanitize=undefined linkflags=-fsanitize=undefined toolset=$TOOLSET ${{ matrix.suite }} define=CI_SUPPRESS_KNOWN_ISSUES
         working-directory: ../boost-root/libs/multiprecision/test
   ubuntu-bionic:
     runs-on: ubuntu-18.04

--- a/.github/workflows/multiprecision.yml
+++ b/.github/workflows/multiprecision.yml
@@ -23,7 +23,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [ g++-9, g++-10, clang++-10 ]
+        compiler: [ g++-9, g++-10, g++-11, clang++-10, clang++-11 ]
         standard: [ c++11, c++14, c++17, c++2a ]
         suite: [ arithmetic_tests, functions_and_limits, conversions, cpp_int_tests, misc, compile_fail, concepts, examples ]
     steps:
@@ -47,7 +47,7 @@ jobs:
         if: steps.retry1.outcome=='failure'
         run: sudo apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
       - name: Install packages
-        run: sudo apt install g++-9 g++-10 clang-10 libgmp-dev libmpfr-dev libtommath-dev
+        run: sudo apt install g++-9 g++-10 g++-11 clang-10 clang-11 libgmp-dev libmpfr-dev libtommath-dev
       - name: Checkout main boost
         run: git clone -b develop --depth 1 https://github.com/boostorg/boost.git ../boost-root
       - name: Update tools/boostdep
@@ -271,7 +271,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        compiler: [ g++-7, g++-8, clang++-7, clang++-8 ]
+        compiler: [ g++-6, g++-7, g++-8, clang++-6.0, clang++-7, clang++-8 ]
         standard: [ c++11, c++14, c++17 ]
         suite: [ arithmetic_tests, functions_and_limits, conversions, cpp_int_tests, misc, compile_fail, concepts, examples ]
     steps:
@@ -295,69 +295,7 @@ jobs:
         if: steps.retry1.outcome=='failure'
         run: sudo apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
       - name: Install packages
-        run: sudo apt install g++-7 g++-8 clang-7 clang-8 libgmp-dev libmpfr-dev libtommath-dev
-      - name: Checkout main boost
-        run: git clone -b develop --depth 1 https://github.com/boostorg/boost.git ../boost-root
-      - name: Update tools/boostdep
-        run: git submodule update --init tools/boostdep
-        working-directory: ../boost-root
-      - name: Copy files
-        run: cp -r $GITHUB_WORKSPACE/* libs/multiprecision
-        working-directory: ../boost-root
-      - name: Install deps
-        run: python tools/boostdep/depinst/depinst.py multiprecision
-        working-directory: ../boost-root
-      - name: Bootstrap
-        run: ./bootstrap.sh
-        working-directory: ../boost-root
-      - name: Generate headers
-        run: ./b2 headers
-        working-directory: ../boost-root
-      - name: Generate user config
-        run: 'echo "using $TOOLSET : : ${{ matrix.compiler }} : <cxxflags>-std=${{ matrix.standard }} ;" > ~/user-config.jam'
-        working-directory: ../boost-root
-      - name: Config info install
-        run: ../../../b2 config_info_travis_install toolset=$TOOLSET
-        working-directory: ../boost-root/libs/config/test
-      - name: Config info
-        run: ./config_info_travis
-        working-directory: ../boost-root/libs/config/test
-      - name: Test
-        run: ../../../b2 -j2 toolset=$TOOLSET ${{ matrix.suite }} define=CI_SUPPRESS_KNOWN_ISSUES
-        working-directory: ../boost-root/libs/multiprecision/test
-  ubuntu-xenial:
-    runs-on: ubuntu-16.04
-    defaults:
-      run:
-        shell: bash
-    strategy:
-      fail-fast: false
-      matrix:
-        compiler: [ g++-5, g++-6, clang++-5.0, clang++-6.0 ]
-        standard: [ c++11, c++14, c++1z ]
-        suite: [ arithmetic_tests, functions_and_limits, conversions, cpp_int_tests, misc, compile_fail, concepts, examples ]
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: '0'
-      - name: Set TOOLSET
-        run: echo ${{ matrix.compiler }} | awk '/^g/ { print "TOOLSET=gcc" } /^clang/ { print "TOOLSET=clang" }' >> $GITHUB_ENV
-      - name: Add repository
-        continue-on-error: true
-        id: addrepo
-        run: sudo apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
-      - name: Retry Add Repo
-        continue-on-error: true
-        id: retry1
-        if: steps.addrepo.outcome=='failure'
-        run: sudo apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
-      - name: Retry Add Repo 2
-        continue-on-error: true
-        id: retry2
-        if: steps.retry1.outcome=='failure'
-        run: sudo apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
-      - name: Install packages
-        run: sudo apt install g++-5 g++-6 clang-5.0 clang-6.0 libgmp-dev libmpfr-dev libtommath-dev
+        run: sudo apt install g++-6 g++-7 g++-8 clang-6.0 clang-7 clang-8 libgmp-dev libmpfr-dev libtommath-dev
       - name: Checkout main boost
         run: git clone -b develop --depth 1 https://github.com/boostorg/boost.git ../boost-root
       - name: Update tools/boostdep

--- a/config/Jamfile.v2
+++ b/config/Jamfile.v2
@@ -76,6 +76,7 @@ exe has_f2c : has_f2c.cpp f2c ;
 obj has_is_constant_evaluated : has_is_constant_evaluated.cpp ;
 obj has_constexpr_limits : has_constexpr_limits_cmd.cpp : <cxxflags>-fconstexpr-ops-limit=268435456 ;
 obj has_big_obj : has_big_obj.cpp : <cxxflags>-Wa,-mbig-obj ;
+obj is_ci_sanitizer_run : is_ci_sanitizer_run.cpp ;
 
 explicit has_gmp ;
 explicit has_mpfr ;
@@ -89,4 +90,4 @@ explicit has_is_constant_evaluated ;
 explicit has_constexpr_limits ;
 explicit has_big_obj ;
 explicit has_f2c ;
-
+explicit is_ci_sanitizer_run ;

--- a/config/is_ci_sanitizer_run.cpp
+++ b/config/is_ci_sanitizer_run.cpp
@@ -1,0 +1,13 @@
+//  Copyright John Maddock 2021.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#if !defined(BOOST_CI_SANITIZER_BUILD)
+# error "Sanitizer is NOT in effect".
+#endif
+
+int main()
+{
+   return 0;
+}

--- a/config/is_ci_sanitizer_run.cpp
+++ b/config/is_ci_sanitizer_run.cpp
@@ -4,7 +4,7 @@
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
 
 #if !defined(BOOST_CI_SANITIZER_BUILD)
-# error "Sanitizer is NOT in effect".
+#  error "Sanitizer is NOT in effect".
 #endif
 
 int main()

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -695,6 +695,7 @@ test-suite conversions :
               : # input files
               : # requirements
               <define>TEST_MPFR
+               [ check-target-builds ../config//is_ci_sanitizer_run "Sanitizer CI run" : <build>no : ]
                [ check-target-builds ../config//has_mpfr : : <build>no ]
                release # Otherwise [ runtime is slow
               ]


### PR DESCRIPTION
Couple changes to the GHA runs:

1. Removes testing on Ubuntu 16.04 (deprecated and will be removed in september)
2. Removes g++5 and clang++5 testing
3. Adds g++11 and clang++11 testing