### PR TITLE
Remove dependencies from cpp_int_config

### DIFF
--- a/include/boost/multiprecision/cpp_int/cpp_int_config.hpp
+++ b/include/boost/multiprecision/cpp_int/cpp_int_config.hpp
@@ -1,17 +1,17 @@
 ///////////////////////////////////////////////////////////////
-//  Copyright 2012 John Maddock. Distributed under the Boost
-//  Software License, Version 1.0. (See accompanying file
-//  LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt
+//  Copyright 2012 - 2021 John Maddock.
+//  Copyright 2021 Matt Borland.
+//  Distributed under the Boost Software License, Version 1.0.
+//  See accompanying file LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt
 
 #ifndef BOOST_MP_CPP_INT_CORE_HPP
 #define BOOST_MP_CPP_INT_CORE_HPP
 
+#include <cstdint>
 #include <type_traits>
 #include <limits>
 #include <boost/multiprecision/detail/number_base.hpp>
 #include <boost/multiprecision/detail/assert.hpp>
-#include <boost/integer.hpp>
-#include <boost/integer_traits.hpp>
 
 namespace boost {
 namespace multiprecision {
@@ -21,11 +21,34 @@ namespace detail {
 //
 // These traits calculate the largest type in the list
 // [unsigned] long long, long, int, which has the specified number
-// of bits.  Note that intN_t and boost::int_t<N> find the first
+// of bits.  Note that int_t and uint_t find the first
 // member of the above list, not the last.  We want the last in the
 // list to ensure that mixed arithmetic operations are as efficient
 // as possible.
 //
+
+template <unsigned Bits>
+struct int_t
+{
+   using exact = typename std::conditional<Bits == sizeof(signed char) * CHAR_BIT, signed char,
+                 typename std::conditional<Bits == sizeof(short) * CHAR_BIT, short,
+                 typename std::conditional<Bits == sizeof(int) * CHAR_BIT, int,
+                 typename std::conditional<Bits == sizeof(long) * CHAR_BIT, long, long long
+                 >::type>::type>::type>::type;
+
+};
+
+template <unsigned Bits>
+struct uint_t
+{
+   using exact = typename std::conditional<Bits == sizeof(unsigned char) * CHAR_BIT, unsigned char,
+                 typename std::conditional<Bits == sizeof(unsigned short) * CHAR_BIT, unsigned short,
+                 typename std::conditional<Bits == sizeof(unsigned int) * CHAR_BIT, unsigned int,
+                 typename std::conditional<Bits == sizeof(unsigned long) * CHAR_BIT, unsigned long, unsigned long long
+                 >::type>::type>::type>::type;
+
+};
+
 template <unsigned N>
 struct largest_signed_type
 {
@@ -38,7 +61,7 @@ struct largest_signed_type
            typename std::conditional<
                1 + std::numeric_limits<int>::digits == N,
                int,
-               typename boost::int_t<N>::exact>::type>::type>::type;
+               typename int_t<N>::exact>::type>::type>::type;
 };
 
 template <unsigned N>
@@ -53,7 +76,7 @@ struct largest_unsigned_type
            typename std::conditional<
                std::numeric_limits<unsigned int>::digits == N,
                unsigned int,
-               typename boost::uint_t<N>::exact>::type>::type>::type;
+               typename uint_t<N>::exact>::type>::type>::type;
 };
 
 } // namespace detail

--- a/include/boost/multiprecision/cpp_int/cpp_int_config.hpp
+++ b/include/boost/multiprecision/cpp_int/cpp_int_config.hpp
@@ -6,9 +6,12 @@
 #ifndef BOOST_MP_CPP_INT_CORE_HPP
 #define BOOST_MP_CPP_INT_CORE_HPP
 
+#include <type_traits>
+#include <limits>
+#include <boost/multiprecision/detail/number_base.hpp>
+#include <boost/multiprecision/detail/assert.hpp>
 #include <boost/integer.hpp>
 #include <boost/integer_traits.hpp>
-#include <boost/assert.hpp>
 
 namespace boost {
 namespace multiprecision {
@@ -67,7 +70,7 @@ constexpr const limb_type                       digits_per_block_10 = 18;
 inline BOOST_MP_CXX14_CONSTEXPR limb_type block_multiplier(unsigned count)
 {
    constexpr const limb_type values[digits_per_block_10] = {10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000, 10000000000, 100000000000, 1000000000000, 10000000000000, 100000000000000, 1000000000000000, 10000000000000000, 100000000000000000, 1000000000000000000};
-   BOOST_ASSERT(count < digits_per_block_10);
+   BOOST_MP_ASSERT(count < digits_per_block_10);
    return values[count];
 }
 
@@ -102,7 +105,7 @@ constexpr const limb_type                       digits_per_block_10 = 9;
 inline limb_type block_multiplier(unsigned count)
 {
    constexpr const limb_type values[digits_per_block_10] = {10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000, 1000000000};
-   BOOST_ASSERT(count < digits_per_block_10);
+   BOOST_MP_ASSERT(count < digits_per_block_10);
    return values[count];
 }
 

--- a/include/boost/multiprecision/cpp_int/cpp_int_config.hpp
+++ b/include/boost/multiprecision/cpp_int/cpp_int_config.hpp
@@ -20,7 +20,7 @@ namespace detail {
 
 //
 // These traits calculate the largest type in the list
-// [unsigned] boost::long_long_type, long, int, which has the specified number
+// [unsigned] long long, long, int, which has the specified number
 // of bits.  Note that intN_t and boost::int_t<N> find the first
 // member of the above list, not the last.  We want the last in the
 // list to ensure that mixed arithmetic operations are as efficient
@@ -30,8 +30,8 @@ template <unsigned N>
 struct largest_signed_type
 {
    using type = typename std::conditional<
-       1 + std::numeric_limits<boost::long_long_type>::digits == N,
-       boost::long_long_type,
+       1 + std::numeric_limits<long long>::digits == N,
+       long long,
        typename std::conditional<
            1 + std::numeric_limits<long>::digits == N,
            long,
@@ -45,8 +45,8 @@ template <unsigned N>
 struct largest_unsigned_type
 {
    using type = typename std::conditional<
-       std::numeric_limits<boost::ulong_long_type>::digits == N,
-       boost::ulong_long_type,
+       std::numeric_limits<unsigned long long>::digits == N,
+       unsigned long long,
        typename std::conditional<
            std::numeric_limits<unsigned long>::digits == N,
            unsigned long,
@@ -61,9 +61,9 @@ struct largest_unsigned_type
 #if defined(BOOST_HAS_INT128)
 
 using limb_type = detail::largest_unsigned_type<64>::type;
-using signed_limb_type = detail::largest_signed_type<64>::type  ;
-using double_limb_type = boost::uint128_type                    ;
-using signed_double_limb_type = boost::int128_type                     ;
+using signed_limb_type = detail::largest_signed_type<64>::type;
+using double_limb_type = unsigned __int128;
+using signed_double_limb_type = __int128;
 constexpr const limb_type                       max_block_10        = 1000000000000000000uLL;
 constexpr const limb_type                       digits_per_block_10 = 18;
 

--- a/include/boost/multiprecision/detail/assert.hpp
+++ b/include/boost/multiprecision/detail/assert.hpp
@@ -1,0 +1,34 @@
+//  (C) Copyright Matt Borland 2021.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+//
+// We deliberately use assert in here:
+//
+// boost-no-inspect
+
+#ifndef BOOST_MP_TOOLS_ASSERT_HPP
+#define BOOST_MP_TOOLS_ASSERT_HPP
+
+#include <boost/multiprecision/detail/is_standalone.hpp>
+
+#ifndef BOOST_MP_STANDALONE
+
+#include <boost/assert.hpp>
+#include <boost/static_assert.hpp>
+#define BOOST_MP_ASSERT(expr) BOOST_ASSERT(expr)
+#define BOOST_MP_ASSERT_MSG(expr, msg) BOOST_ASSERT_MSG(expr, msg)
+#define BOOST_MP_STATIC_ASSERT(expr) BOOST_STATIC_ASSERT(expr)
+#define BOOST_MP_STATIC_ASSERT_MSG(expr, msg) BOOST_STATIC_ASSERT_MSG(expr, msg)
+
+#else // Standalone mode - use cassert
+
+#include <cassert>
+#define BOOST_MP_ASSERT(expr) assert(expr)
+#define BOOST_MP_ASSERT_MSG(expr, msg) assert((expr)&&(msg))
+#define BOOST_MP_STATIC_ASSERT(expr) static_assert(expr, #expr " failed")
+#define BOOST_MP_STATIC_ASSERT_MSG(expr, msg) static_assert(expr, msg)
+
+#endif
+
+#endif // BOOST_MATH_TOOLS_ASSERT_HPP

--- a/include/boost/multiprecision/detail/is_standalone.hpp
+++ b/include/boost/multiprecision/detail/is_standalone.hpp
@@ -1,0 +1,18 @@
+//  Copyright Matt Borland 2021.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_MP_TOOLS_IS_STANDALONE_HPP
+#define BOOST_MP_TOOLS_IS_STANDALONE_HPP
+
+#ifdef __has_include
+#if !__has_include(<boost/config.hpp>) || !__has_include(<boost/assert.hpp>) || !__has_include(<boost/lexical_cast.hpp>) || \
+    !__has_include(<boost/throw_exception.hpp>) || !__has_include(<boost/predef/other/endian.h>)
+#   ifndef BOOST_MP_STANDALONE
+#       define BOOST_MP_STANDALONE
+#   endif
+#endif
+#endif
+
+#endif // BOOST_MP_TOOLS_IS_STANDALONE_HPP


### PR DESCRIPTION
Removes uses of boost.assert, and boost.integer. Also implements `BOOST_MP_STANDALONE` to continue work on issue #364.