### PR TITLE
Remove boost.random dependency

### DIFF
--- a/example/safe_prime.cpp
+++ b/example/safe_prime.cpp
@@ -5,6 +5,7 @@
 
 //[safe_prime
 
+#include <boost/random.hpp>
 #include <boost/multiprecision/cpp_int.hpp>
 #include <boost/multiprecision/miller_rabin.hpp>
 #include <iostream>

--- a/include/boost/multiprecision/detail/uniform_int_distribution.hpp
+++ b/include/boost/multiprecision/detail/uniform_int_distribution.hpp
@@ -42,7 +42,7 @@ struct make_unsigned_mp
     using type = typename make_unsigned_impl<T, boost::multiprecision::detail::is_integral<T>::value>::type;
 };
 
-template <typename Engine, typename T, typename std::enable_if<boost::multiprecision::detail::is_integral<typename Engine::result_type>::value, bool>::type = true>
+template <typename Engine, typename T>
 T generate_uniform_int (Engine& eng, T min_value, T max_value)
 {
     using range_type = typename boost::multiprecision::detail::make_unsigned_mp<T>::type;

--- a/include/boost/multiprecision/detail/uniform_int_distribution.hpp
+++ b/include/boost/multiprecision/detail/uniform_int_distribution.hpp
@@ -1,0 +1,212 @@
+///////////////////////////////////////////////////////////////
+//  Copyright Jens Maurer 2000-2021
+//  Copyright Steven Watanabe 2011-2021
+//  Copyright John Maddock 2015-2021
+//  Copyright Matt Borland 2021
+//  Distributed under the Boost Software License, Version 1.0. 
+//  (See accompanying file LICENSE_1_0.txt or copy at 
+//  https://www.boost.org/LICENSE_1_0.txt
+//
+//  This is a C++11 compliant port of Boost.Random's implementation
+//  of uniform_int_distribution. See their comments for detailed
+//  descriptions
+
+#ifndef BOOST_MP_UNIFORM_INT_DISTRIBUTION_HPP
+#define BOOST_MP_UNIFORM_INT_DISTRIBUTION_HPP
+
+#include <limits>
+#include <type_traits>
+#include <boost/multiprecision/detail/standalone_config.hpp>
+#include <boost/multiprecision/detail/assert.hpp>
+#include <boost/multiprecision/traits/std_integer_traits.hpp>
+
+namespace boost { namespace multiprecision { 
+    
+namespace detail {
+
+template <typename T, bool intrinsic>
+struct make_unsigned_impl
+{
+    using type = typename boost::multiprecision::detail::make_unsigned<T>::type;
+};
+
+template <typename T>
+struct make_unsigned_impl<T, false>
+{
+    using type = T;
+};
+
+template <typename T>
+struct make_unsigned_mp
+{
+    using type = typename make_unsigned_impl<T, boost::multiprecision::detail::is_integral<T>::value>::type;
+};
+
+template <typename Engine, typename T, typename std::enable_if<boost::multiprecision::detail::is_integral<typename Engine::result_type>::value, bool>::type = true>
+T generate_uniform_int (Engine& eng, T min_value, T max_value)
+{
+    using range_type = typename boost::multiprecision::detail::make_unsigned_mp<T>::type;
+    using base_result = typename Engine::result_type;
+    using base_unsigned = typename boost::multiprecision::detail::make_unsigned_mp<base_result>::type;
+
+    const range_type range = max_value - min_value;
+    const base_result bmin = (eng.min)();
+    const base_unsigned brange = (eng.max)() - (eng.min)();
+
+    if(range == 0)
+    {
+        return min_value;
+    }
+    else if (brange < range)
+    {
+        for(;;)
+        {
+            range_type limit;
+            if(range == (std::numeric_limits<range_type>::max)())
+            {
+                limit = range / (range_type(brange) + 1);
+                if(range % (range_type(brange) + 1) == range_type(brange))
+                {
+                    ++limit;
+                }
+            }
+            else
+            {
+                limit = (range + 1) / (range_type(brange) + 1);
+            }
+
+            range_type result = 0;
+            range_type mult = 1;
+
+            while (mult <= limit)
+            {
+                result += static_cast<range_type>(static_cast<range_type>(eng() - bmin) * mult);
+
+                if(mult * range_type(brange) == range - mult + 1)
+                {
+                    return(result);
+                }
+
+                mult *= range_type(brange)+range_type(1);
+            }
+
+            range_type result_increment = generate_uniform_int(eng, range_type(0), range_type(range/mult));
+
+            if(std::numeric_limits<range_type>::is_bounded && ((std::numeric_limits<range_type>::max)() / mult < result_increment))
+            {
+                continue;
+            }
+
+            result_increment *= mult;
+            result += result_increment;
+
+            if(result < result_increment)
+            {
+                continue;
+            }
+            if(result > range)
+            {
+                continue;
+            }
+
+            return result + min_value;
+        }
+    }
+    else
+    {
+        using mixed_range_type = 
+        typename std::conditional<std::numeric_limits<range_type>::is_specialized && std::numeric_limits<base_unsigned>::is_specialized &&
+                                  (std::numeric_limits<range_type>::digits >= std::numeric_limits<base_unsigned>::digits),
+                                  range_type, base_unsigned>::type;
+
+        mixed_range_type bucket_size;
+
+        if(brange == (std::numeric_limits<base_unsigned>::max)()) 
+        {
+            bucket_size = static_cast<mixed_range_type>(brange) / (static_cast<mixed_range_type>(range)+1);
+            if(static_cast<mixed_range_type>(brange) % (static_cast<mixed_range_type>(range)+1) == static_cast<mixed_range_type>(range)) 
+            {
+                ++bucket_size;
+            }
+        } 
+        else 
+        {
+            bucket_size = static_cast<mixed_range_type>(brange + 1) / (static_cast<mixed_range_type>(range)+1);
+        }
+
+        for(;;) 
+        {
+            mixed_range_type result = eng() - bmin;
+            result /= bucket_size;
+
+            if(result <= static_cast<mixed_range_type>(range))
+            {
+                return result + min_value;
+            }
+        }
+    }
+}
+
+} // Namespace detail
+
+template <typename Integer = int>
+class uniform_int_distribution
+{
+private:
+    Integer min_;
+    Integer max_;
+
+public:
+    class param_type
+    {
+    private:
+        Integer min_;
+        Integer max_;
+    
+    public:
+        explicit param_type(Integer min_val, Integer max_val) : min_ {min_val}, max_ {max_val}
+        {
+            BOOST_MP_ASSERT(min_ <= max_);
+        }
+
+        Integer a() const { return min_; }
+        Integer b() const { return max_; }
+    };
+
+    explicit uniform_int_distribution(Integer min_arg, Integer max_arg) : min_ {min_arg}, max_ {max_arg}
+    {
+        BOOST_MP_ASSERT(min_ <= max_);
+    }
+
+    explicit uniform_int_distribution(const param_type& param_arg) : min_ {param_arg.a()}, max_ {param_arg.b()} {}
+
+    Integer min BOOST_PREVENT_MACRO_SUBSTITUTION () const { return min_; }
+    Integer max BOOST_PREVENT_MACRO_SUBSTITUTION () const { return max_; }
+    
+    Integer a() const { return min_; }
+    Integer b() const { return max_; }
+
+    param_type param() const { return param_type(min_, max_); }
+
+    void param(const param_type& param_arg)
+    {
+        min_ = param_arg.a();
+        max_ = param_arg.b();
+    }
+
+    template <typename Engine>
+    Integer operator() (Engine& eng) const
+    {
+        return detail::generate_uniform_int(eng, min_, max_);
+    }
+
+    template <typename Engine>
+    Integer operator() (Engine& eng, const param_type& param_arg) const
+    {
+        return detail::generate_uniform_int(eng, param_arg.a(), param_arg.b());
+    }
+};
+
+}} // Namespaces
+
+#endif // BOOST_MP_UNIFORM_INT_DISTRIBUTION_HPP

--- a/include/boost/multiprecision/miller_rabin.hpp
+++ b/include/boost/multiprecision/miller_rabin.hpp
@@ -6,16 +6,12 @@
 #ifndef BOOST_MP_MR_HPP
 #define BOOST_MP_MR_HPP
 
+#include <random>
 #include <cstdint>
 #include <type_traits>
 #include <boost/multiprecision/detail/standalone_config.hpp>
 #include <boost/multiprecision/integer.hpp>
-
-#ifndef BOOST_MP_STANDALONE
-#include <boost/random.hpp>
-#else
-#include <random>
-#endif
+#include <boost/multiprecision/detail/uniform_int_distribution.hpp>
 
 namespace boost {
 namespace multiprecision {
@@ -169,11 +165,7 @@ miller_rabin_test(const I& n, unsigned trials, Engine& gen)
    q >>= k;
 
    // Declare our random number generator:
-   #ifndef BOOST_MP_STANDALONE
-   boost::random::uniform_int_distribution<number_type> dist(2, n - 2);
-   #else
-   std::uniform_int_distribution<number_type> dist(2, n - 2);
-   #endif
+   boost::multiprecision::uniform_int_distribution<number_type> dist(2, n - 2);
 
    //
    // Execute the trials:
@@ -201,12 +193,11 @@ miller_rabin_test(const I& n, unsigned trials, Engine& gen)
    return true; // Yeheh! probably prime.
 }
 
-#ifndef BOOST_MP_STANDALONE
 template <class I>
 typename std::enable_if<number_category<I>::value == number_kind_integer, bool>::type
 miller_rabin_test(const I& x, unsigned trials)
 {
-   static mt19937 gen;
+   static std::mt19937 gen;
    return miller_rabin_test(x, trials, gen);
 }
 
@@ -223,39 +214,6 @@ bool miller_rabin_test(const detail::expression<tag, Arg1, Arg2, Arg3, Arg4>& n,
    using number_type = typename detail::expression<tag, Arg1, Arg2, Arg3, Arg4>::result_type;
    return miller_rabin_test(number_type(n), trials);
 }
-
-#else
-
-template <class I>
-typename std::enable_if<std::is_integral<I>::value, bool>::type
-miller_rabin_test(const I& x, unsigned trials)
-{
-   static std::mt19937 gen;
-   return miller_rabin_test(x, trials, gen);
-}
-
-template <class I>
-typename std::enable_if<!std::is_integral<I>::value, bool>::type
-miller_rabin_test(const I& x, unsigned trials)
-{
-   static_assert(sizeof(I) == 1, "Standalone mode does not allow for miller-rabin tests on non-builtin types");
-   return false;
-}
-
-template <class tag, class Arg1, class Arg2, class Arg3, class Arg4, class Engine>
-bool miller_rabin_test(const detail::expression<tag, Arg1, Arg2, Arg3, Arg4>& n, unsigned trials, Engine& gen)
-{
-   static_assert(sizeof(tag) == 1, "Standalone mode does not allow for miller-rabin tests on non-builtin types");
-   return false;
-}
-
-template <class tag, class Arg1, class Arg2, class Arg3, class Arg4>
-bool miller_rabin_test(const detail::expression<tag, Arg1, Arg2, Arg3, Arg4>& n, unsigned trials)
-{
-   static_assert(sizeof(tag) == 1, "Standalone mode does not allow for miller-rabin tests on non-builtin types");
-   return false;
-}
-#endif // BOOST_MP_STANDALONE
 
 }} // namespace boost::multiprecision
 

--- a/include/boost/multiprecision/random.hpp
+++ b/include/boost/multiprecision/random.hpp
@@ -8,10 +8,16 @@
 #ifndef BOOST_MP_RANDOM_HPP
 #define BOOST_MP_RANDOM_HPP
 
+#include <boost/multiprecision/detail/standalone_config.hpp>
+
 #if defined(__GNUC__) || defined(_MSC_VER)
 #pragma message("NOTE: Use of this header (boost/multiprecision/random.hpp) is deprecated: please use the random number library headers directly.")
 #endif
 
+#ifndef BOOST_MP_STANDALONE
 #include <boost/random.hpp>
+#else
+#error "Use of this header is removed in standalone mode"
+#endif
 
 #endif

--- a/performance/miller_rabin_performance.hpp
+++ b/performance/miller_rabin_performance.hpp
@@ -22,6 +22,7 @@
 #endif
 #include <boost/multiprecision/miller_rabin.hpp>
 #include <boost/chrono.hpp>
+#include <boost/random.hpp>
 #include <map>
 
 template <class Clock>

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -948,6 +948,8 @@ test-suite misc :
                [ check-target-builds ../config//has_gmp : : <build>no ]
                release  # otherwise [ runtime is too slow!!
                ]
+        
+      [ run test_miller_rabin_standalone.cpp ]
 
       [ run test_rational_io.cpp $(TOMMATH) no_eh_support
               : # command line

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -949,7 +949,13 @@ test-suite misc :
                release  # otherwise [ runtime is too slow!!
                ]
         
-      [ run test_miller_rabin_standalone.cpp gmp ]
+      [ run test_miller_rabin_standalone.cpp no_eh_support gmp
+              : # command line
+              : # input files
+              : # requirements
+               [ check-target-builds ../config//has_gmp : : <build>no ]
+               release  # otherwise [ runtime is too slow!!
+               ]
 
       [ run test_rational_io.cpp $(TOMMATH) no_eh_support
               : # command line

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -949,7 +949,7 @@ test-suite misc :
                release  # otherwise [ runtime is too slow!!
                ]
         
-      [ run test_miller_rabin_standalone.cpp ]
+      [ run test_miller_rabin_standalone.cpp gmp ]
 
       [ run test_rational_io.cpp $(TOMMATH) no_eh_support
               : # command line

--- a/test/test_miller_rabin.cpp
+++ b/test/test_miller_rabin.cpp
@@ -11,6 +11,7 @@
 #include <boost/multiprecision/cpp_int.hpp>
 #include <boost/multiprecision/miller_rabin.hpp>
 #include <boost/math/special_functions/prime.hpp>
+#include <random>
 #include <iostream>
 #include <iomanip>
 #include "test.hpp"
@@ -25,23 +26,18 @@ void test()
    // no reason why they should actually agree - except the probability of
    // disagreement for 25 trials is almost infinitely small.
    //
-   using namespace boost::random;
    using namespace boost::multiprecision;
 
    typedef I test_type;
 
-   static const unsigned test_bits =
-       std::numeric_limits<test_type>::digits && (std::numeric_limits<test_type>::digits <= 256)
-           ? std::numeric_limits<test_type>::digits
-           : 128;
-
-   independent_bits_engine<mt11213b, test_bits, test_type> gen;
+   std::random_device rd;
+   std::mt19937 gen(rd());
    //
    // We must use a different generator for the tests and number generation, otherwise
    // we get false positives.  Further we use the same random number engine for the
    // Miller Rabin test as GMP uses internally:
    //
-   mt19937 gen2;
+   std::ranlux48 gen2(rd());
 
    //
    // Begin by testing the primes in our table as all these should return true:

--- a/test/test_miller_rabin.cpp
+++ b/test/test_miller_rabin.cpp
@@ -11,6 +11,7 @@
 #include <boost/multiprecision/cpp_int.hpp>
 #include <boost/multiprecision/miller_rabin.hpp>
 #include <boost/math/special_functions/prime.hpp>
+#include <boost/random.hpp>
 #include <random>
 #include <iostream>
 #include <iomanip>
@@ -26,18 +27,23 @@ void test()
    // no reason why they should actually agree - except the probability of
    // disagreement for 25 trials is almost infinitely small.
    //
+   using namespace boost::random;
    using namespace boost::multiprecision;
 
    typedef I test_type;
 
-   std::random_device rd;
-   std::mt19937 gen(rd());
+   static const unsigned test_bits =
+      std::numeric_limits<test_type>::digits && (std::numeric_limits<test_type>::digits <= 256)
+         ? std::numeric_limits<test_type>::digits
+         : 128;
+
+   independent_bits_engine<mt11213b, test_bits, test_type> gen;
    //
    // We must use a different generator for the tests and number generation, otherwise
    // we get false positives.  Further we use the same random number engine for the
    // Miller Rabin test as GMP uses internally:
    //
-   std::ranlux48 gen2(rd());
+   mt19937 gen2;
 
    //
    // Begin by testing the primes in our table as all these should return true:

--- a/test/test_miller_rabin_standalone.cpp
+++ b/test/test_miller_rabin_standalone.cpp
@@ -1,0 +1,40 @@
+///////////////////////////////////////////////////////////////
+//  Copyright 2012-2021 John Maddock. Distributed under the Boost
+//  Copyright 2021 Matt Borland.
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt
+
+#define BOOST_MP_STANDALONE
+
+#include <cstdint>
+#include <random>
+#include <limits>
+#include <boost/multiprecision/miller_rabin.hpp>
+#include <boost/math/special_functions/prime.hpp>
+#include "test.hpp"
+
+template <class Integer>
+void test()
+{
+   std::mt19937 gen;
+
+   //
+   // Test the primes in our table as all these should return true:
+   //
+   for (unsigned i = 1; i < boost::math::max_prime; ++i)
+   {
+      BOOST_TEST(boost::multiprecision::miller_rabin_test(Integer(boost::math::prime(i)), 25, gen));
+   }
+}
+
+int main()
+{
+    test<int>();
+    test<unsigned>();
+    test<long>();
+    test<unsigned long>();
+    test<long long>();
+    test<unsigned long long>();
+
+    return boost::report_errors();
+}

--- a/test/test_miller_rabin_standalone.cpp
+++ b/test/test_miller_rabin_standalone.cpp
@@ -1,40 +1,88 @@
 ///////////////////////////////////////////////////////////////
-//  Copyright 2012-2021 John Maddock. Distributed under the Boost
-//  Copyright 2021 Matt Borland.
+//  Copyright 2012-2021 John Maddock.
+//  Copyright 2021 Matt Borland. Distributed under the Boost
 //  Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt
 
-#define BOOST_MP_STANDALONE
-
-#include <cstdint>
-#include <random>
-#include <limits>
-#include <boost/multiprecision/miller_rabin.hpp>
+#include <boost/multiprecision/gmp.hpp>
+#include <boost/multiprecision/cpp_int.hpp>
 #include <boost/math/special_functions/prime.hpp>
+#include <boost/random.hpp>
+#include <random>
+#include <iostream>
+#include <iomanip>
 #include "test.hpp"
 
-template <class Integer>
+#define BOOST_MP_STANDALONE
+#include <boost/multiprecision/miller_rabin.hpp>
+
+template <class I>
 void test()
 {
-   std::mt19937 gen;
+   //
+   // Very simple test program to verify that the GMP's Miller-Rabin
+   // implementation and this one agree on whether some random numbers
+   // are prime or not.  Of course these are probabilistic tests so there's
+   // no reason why they should actually agree - except the probability of
+   // disagreement for 25 trials is almost infinitely small.
+   //
+   using namespace boost::random;
+   using namespace boost::multiprecision;
+
+   typedef I test_type;
+
+   static const unsigned test_bits =
+      std::numeric_limits<test_type>::digits && (std::numeric_limits<test_type>::digits <= 256)
+         ? std::numeric_limits<test_type>::digits
+         : 128;
+
+   independent_bits_engine<mt11213b, test_bits, test_type> gen;
+   //
+   // We must use a different generator for the tests and number generation, otherwise
+   // we get false positives.  Further we use the same random number engine for the
+   // Miller Rabin test as GMP uses internally:
+   //
+   mt19937 gen2;
 
    //
-   // Test the primes in our table as all these should return true:
+   // Begin by testing the primes in our table as all these should return true:
    //
    for (unsigned i = 1; i < boost::math::max_prime; ++i)
    {
-      BOOST_TEST(boost::multiprecision::miller_rabin_test(Integer(boost::math::prime(i)), 25, gen));
+      BOOST_TEST(miller_rabin_test(test_type(boost::math::prime(i)), 25, gen));
+      BOOST_TEST(mpz_probab_prime_p(mpz_int(boost::math::prime(i)).backend().data(), 25));
+   }
+   //
+   // Now test some random values and compare GMP's native routine with ours.
+   //
+   for (unsigned i = 0; i < 10000; ++i)
+   {
+      test_type n              = gen();
+      bool      is_prime_boost = miller_rabin_test(n, 25, gen2);
+      bool      is_gmp_prime   = mpz_probab_prime_p(mpz_int(n).backend().data(), 25) ? true : false;
+      if (is_prime_boost && is_gmp_prime)
+      {
+         std::cout << "We have a prime: " << std::hex << std::showbase << n << std::endl;
+      }
+      if (is_prime_boost != is_gmp_prime)
+         std::cout << std::hex << std::showbase << "n = " << n << std::endl;
+      BOOST_CHECK_EQUAL(is_prime_boost, is_gmp_prime);
    }
 }
 
 int main()
 {
-    test<int>();
-    test<unsigned>();
-    test<long>();
-    test<unsigned long>();
-    test<long long>();
-    test<unsigned long long>();
+   using namespace boost::multiprecision;
 
-    return boost::report_errors();
+   test<mpz_int>();
+   test<number<gmp_int, et_off> >();
+   test<std::uint64_t>();
+   test<std::uint32_t>();
+
+   test<cpp_int>();
+   test<number<cpp_int_backend<64, 64, unsigned_magnitude, checked, void>, et_off> >();
+   test<checked_uint128_t>();
+   test<checked_uint1024_t>();
+
+   return boost::report_errors();
 }


### PR DESCRIPTION
In standalone mode the functionality of `miller_rabin_test` is reduced to only those types that are compatible with `std::uniform_int_distribution`.