### PR TITLE
Fix type_traits usage with clang.

### DIFF
--- a/include/boost/multiprecision/detail/number_base.hpp
+++ b/include/boost/multiprecision/detail/number_base.hpp
@@ -1555,6 +1555,12 @@ BOOST_MP_CXX14_CONSTEXPR typename expression<tag, Arg1, Arg2, Arg3, Arg4>::resul
 template <class tag, class Arg1, class Arg2, class Arg3, class Arg4>
 BOOST_MP_CXX14_CONSTEXPR typename expression<tag, Arg1, Arg2, Arg3, Arg4>::result_type evaluate_if_expression(expression<tag, Arg1, Arg2, Arg3, Arg4>&& val) { return val; }
 
+template <class T>
+struct convertible_to
+{
+   operator T () const;
+};
+
 } // namespace detail
 
 //

--- a/include/boost/multiprecision/number.hpp
+++ b/include/boost/multiprecision/number.hpp
@@ -1045,7 +1045,7 @@ class number
 #if BOOST_WORKAROUND(BOOST_MSVC, < 1900) || (defined(__apple_build_version__) && BOOST_WORKAROUND(__clang_major__, < 9))
    template <class T>
 #else
-   template <class T, class = typename std::enable_if<std::is_enum<T>::value || !(std::is_constructible<T, self_type const&>::value || !std::is_default_constructible<T>::value || (!boost::multiprecision::detail::is_arithmetic<T>::value && !boost::multiprecision::detail::is_complex<T>::value)), T>::type>
+   template <class T, class = typename std::enable_if<std::is_enum<T>::value || !(std::is_constructible<T, detail::convertible_to<self_type const&> >::value || !std::is_default_constructible<T>::value || (!boost::multiprecision::detail::is_arithmetic<T>::value && !boost::multiprecision::detail::is_complex<T>::value)), T>::type>
 #endif
    explicit BOOST_MP_CXX14_CONSTEXPR operator T() const
    {

--- a/test/test_nothrow_cpp_int.cpp
+++ b/test/test_nothrow_cpp_int.cpp
@@ -225,3 +225,54 @@ static_assert(!noexcept(std::declval<checked_uint30_t>() = std::declval<std::uin
 static_assert(!noexcept(std::declval<checked_int32_t>() = std::declval<std::uint64_t>()), "noexcept test");
 static_assert(!noexcept(std::declval<checked_uint32_t>() = std::declval<std::uint64_t>()), "noexcept test");
 
+//
+// Check regular construct/assign as well, see https://github.com/boostorg/multiprecision/issues/383
+//
+//
+// Move assign:
+//
+static_assert(std::is_move_assignable<boost::multiprecision::cpp_int>::value, "noexcept test");
+static_assert(std::is_move_assignable<boost::multiprecision::int128_t>::value, "noexcept test");
+static_assert(std::is_move_assignable<boost::multiprecision::checked_int128_t>::value, "noexcept test");
+static_assert(std::is_move_assignable<boost::multiprecision::uint128_t>::value, "noexcept test");
+static_assert(std::is_move_assignable<boost::multiprecision::checked_uint128_t>::value, "noexcept test");
+static_assert(std::is_move_assignable<boost::multiprecision::int512_t>::value, "noexcept test");
+static_assert(std::is_move_assignable<boost::multiprecision::checked_int512_t>::value, "noexcept test");
+static_assert(std::is_move_assignable<boost::multiprecision::uint512_t>::value, "noexcept test");
+static_assert(std::is_move_assignable<boost::multiprecision::checked_uint512_t>::value, "noexcept test");
+//
+// Construct:
+//
+static_assert(std::is_default_constructible<boost::multiprecision::cpp_int>::value, "noexcept test");
+static_assert(std::is_default_constructible<boost::multiprecision::int128_t>::value, "noexcept test");
+static_assert(std::is_default_constructible<boost::multiprecision::checked_int128_t>::value, "noexcept test");
+static_assert(std::is_default_constructible<boost::multiprecision::uint128_t>::value, "noexcept test");
+static_assert(std::is_default_constructible<boost::multiprecision::checked_uint128_t>::value, "noexcept test");
+static_assert(std::is_default_constructible<boost::multiprecision::int512_t>::value, "noexcept test");
+static_assert(std::is_default_constructible<boost::multiprecision::checked_int512_t>::value, "noexcept test");
+static_assert(std::is_default_constructible<boost::multiprecision::uint512_t>::value, "noexcept test");
+static_assert(std::is_default_constructible<boost::multiprecision::checked_uint512_t>::value, "noexcept test");
+//
+// Copy construct:
+//
+static_assert(std::is_copy_constructible<boost::multiprecision::cpp_int>::value, "noexcept test");
+static_assert(std::is_copy_constructible<boost::multiprecision::int128_t>::value, "noexcept test");
+static_assert(std::is_copy_constructible<boost::multiprecision::checked_int128_t>::value, "noexcept test");
+static_assert(std::is_copy_constructible<boost::multiprecision::uint128_t>::value, "noexcept test");
+static_assert(std::is_copy_constructible<boost::multiprecision::checked_uint128_t>::value, "noexcept test");
+static_assert(std::is_copy_constructible<boost::multiprecision::int512_t>::value, "noexcept test");
+static_assert(std::is_copy_constructible<boost::multiprecision::checked_int512_t>::value, "noexcept test");
+static_assert(std::is_copy_constructible<boost::multiprecision::uint512_t>::value, "noexcept test");
+static_assert(std::is_copy_constructible<boost::multiprecision::checked_uint512_t>::value, "noexcept test");
+//
+// Assign:
+//
+static_assert(std::is_copy_assignable<boost::multiprecision::cpp_int>::value, "noexcept test");
+static_assert(std::is_copy_assignable<boost::multiprecision::int128_t>::value, "noexcept test");
+static_assert(std::is_copy_assignable<boost::multiprecision::checked_int128_t>::value, "noexcept test");
+static_assert(std::is_copy_assignable<boost::multiprecision::uint128_t>::value, "noexcept test");
+static_assert(std::is_copy_assignable<boost::multiprecision::checked_uint128_t>::value, "noexcept test");
+static_assert(std::is_copy_assignable<boost::multiprecision::int512_t>::value, "noexcept test");
+static_assert(std::is_copy_assignable<boost::multiprecision::checked_int512_t>::value, "noexcept test");
+static_assert(std::is_copy_assignable<boost::multiprecision::uint512_t>::value, "noexcept test");
+static_assert(std::is_copy_assignable<boost::multiprecision::checked_uint512_t>::value, "noexcept test");


### PR DESCRIPTION
Prevents recursive instantiation of is_constructible.
Fixes https://github.com/boostorg/multiprecision/issues/383.