### PR TITLE
Add workaround to is_byte_container for Eigen interop.

### DIFF
--- a/include/boost/multiprecision/traits/is_byte_container.hpp
+++ b/include/boost/multiprecision/traits/is_byte_container.hpp
@@ -22,12 +22,19 @@ struct has_member_const_iterator
 };
 
 
-template <class C, bool b>
-struct is_byte_container_imp
+template <class C, class Iterator>
+struct is_byte_container_imp_2
 {
-   // Note: Don't use C::value_type as this is a rather widespread typedef, even for non-range types
    using container_value_type = typename std::remove_cv<typename std::iterator_traits<typename C::const_iterator>::value_type>::type;
    static constexpr const bool                                                                                  value = boost::multiprecision::detail::is_integral<container_value_type>::value && (sizeof(container_value_type) == 1);
+};
+template <class C>
+struct is_byte_container_imp_2<C, void> : public boost::false_type
+{};
+
+template <class C, bool b>
+struct is_byte_container_imp : public is_byte_container_imp_2<C, typename C::const_iterator>
+{
 };
 
 template <class C>

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -1173,6 +1173,7 @@ test-suite misc :
       [ run test_eigen_interop_mpfr_3.cpp mpfr gmp : : : release [ check-target-builds ../config//has_eigen : : <build>no ] [ check-target-builds ../config//has_mpfr : : <build>no ] ]
       [ run test_eigen_interop_gmp.cpp gmp : : : release [ check-target-builds ../config//has_eigen : : <build>no ] [ check-target-builds ../config//has_gmp : : <build>no ] ]
       [ run test_eigen_interop_mpc.cpp mpc mpfr gmp : : : release [ check-target-builds ../config//has_eigen : : <build>no ] [ check-target-builds ../config//has_mpc : : <build>no ] ]
+      [ run git_issue_393.cpp : : : release [ check-target-builds ../config//has_eigen : : <build>no ] ]
 ;
 
 

--- a/test/git_issue_393.cpp
+++ b/test/git_issue_393.cpp
@@ -1,0 +1,17 @@
+///////////////////////////////////////////////////////////////
+//  Copyright 2021 John Maddock. Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt
+//
+
+#include <Eigen/Dense>
+#include <boost/multiprecision/cpp_int.hpp>
+#include <boost/multiprecision/eigen.hpp>
+
+typedef boost::multiprecision::cpp_rational               NT;
+typedef Eigen::Matrix<NT, Eigen::Dynamic, Eigen::Dynamic> M;
+
+void f(M& m1, M const& m2)
+{
+   m1 = m2 * m2;
+}


### PR DESCRIPTION
Fixes: https://github.com/boostorg/multiprecision/issues/393