### PR TITLE
Update cpp_int->float conversion.

### DIFF
--- a/include/boost/multiprecision/cpp_int/misc.hpp
+++ b/include/boost/multiprecision/cpp_int/misc.hpp
@@ -173,13 +173,63 @@ template <class R, unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignTy
 inline BOOST_MP_CXX14_CONSTEXPR typename std::enable_if<std::is_floating_point<R>::value && !is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value, void>::type
 eval_convert_to(R* result, const cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& backend) noexcept(boost::multiprecision::detail::is_arithmetic<R>::value)
 {
-   typename cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::const_limb_pointer p     = backend.limbs();
-   unsigned                                                                                          shift = cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::limb_bits;
-   *result                                                                                                 = static_cast<R>(*p);
-   for (unsigned i = 1; i < backend.size(); ++i)
+   if (eval_is_zero(backend))
    {
-      *result += static_cast<R>(std::ldexp(static_cast<long double>(p[i]), shift));
-      shift += cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::limb_bits;
+      *result = 0.0f;
+      return;
+   }
+
+   std::ptrdiff_t bits_to_keep = std::numeric_limits<R>::digits;
+   std::ptrdiff_t bits = eval_msb_imp(backend) + 1;
+
+   if (bits > bits_to_keep)
+   {
+      // Extract the bits we need, and then manually round the result:
+      *result = 0.0f;
+      typename cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::const_limb_pointer p = backend.limbs();
+      limb_type mask = ~static_cast<limb_type>(0u);
+      std::size_t index = backend.size() - 1;
+      std::size_t shift = cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::limb_bits * index;
+      while (bits_to_keep > 0)
+      {
+         if (bits_to_keep < cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::limb_bits)
+         {
+            if(index != backend.size() - 1)
+               mask <<= cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::limb_bits - bits_to_keep;
+            else
+            {
+               std::ptrdiff_t bits_in_first_limb = bits % cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::limb_bits;
+               if (bits_in_first_limb == 0)
+                  bits_in_first_limb = cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::limb_bits;
+               if (bits_in_first_limb > bits_to_keep)
+                  mask <<= bits_in_first_limb - bits_to_keep;
+            }
+         }
+         *result += std::ldexp(static_cast<R>(p[index] & mask), (int)shift);
+         shift -= cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::limb_bits;
+         bits_to_keep -= (index == backend.size() - 1) && (bits % cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::limb_bits)
+            ? bits % cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::limb_bits 
+            : cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::limb_bits;
+         --index;
+      }
+      // Perform rounding:
+      bits -= 1 + std::numeric_limits<R>::digits;
+      if (eval_bit_test(backend, (unsigned)bits))
+      {
+         if ((eval_lsb_imp(backend) < bits) || eval_bit_test(backend, (unsigned)(bits + 1)))
+            *result = boost::math::float_next(*result);
+      }
+   }
+   else
+   {
+      typename cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::const_limb_pointer p = backend.limbs();
+      unsigned                                                                                          shift = cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::limb_bits;
+      *result = static_cast<R>(*p);
+      for (unsigned i = 1; i < backend.size(); ++i)
+      {
+         *result += static_cast<R>(std::ldexp(static_cast<long double>(p[i]), shift));
+         shift += cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::limb_bits;
+      }
    }
    if (backend.sign())
       *result = -*result;
@@ -210,18 +260,8 @@ eval_abs(cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& r
 //
 template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1>
 inline BOOST_MP_CXX14_CONSTEXPR typename std::enable_if<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value, unsigned>::type
-eval_lsb(const cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& a)
+eval_lsb_imp(const cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& a)
 {
-   using default_ops::eval_get_sign;
-   if (eval_get_sign(a) == 0)
-   {
-      BOOST_MP_THROW_EXCEPTION(std::domain_error("No bits were set in the operand."));
-   }
-   if (a.sign())
-   {
-      BOOST_MP_THROW_EXCEPTION(std::domain_error("Testing individual bits in negative values is not supported - results are undefined."));
-   }
-
    //
    // Find the index of the least significant limb that is non-zero:
    //
@@ -234,6 +274,22 @@ eval_lsb(const cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocato
    unsigned result = boost::multiprecision::detail::find_lsb(a.limbs()[index]);
 
    return result + index * cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::limb_bits;
+}
+
+template <unsigned MinBits1, unsigned MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1>
+inline BOOST_MP_CXX14_CONSTEXPR typename std::enable_if<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value, unsigned>::type
+eval_lsb(const cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& a)
+{
+   using default_ops::eval_get_sign;
+   if (eval_get_sign(a) == 0)
+   {
+      BOOST_MP_THROW_EXCEPTION(std::domain_error("No bits were set in the operand."));
+   }
+   if (a.sign())
+   {
+      BOOST_MP_THROW_EXCEPTION(std::domain_error("Testing individual bits in negative values is not supported - results are undefined."));
+   }
+   return eval_lsb_imp(a);
 }
 
 //

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -552,6 +552,7 @@ test-suite conversions :
 
    [ run test_test.cpp ]
    [ run test_cpp_int_lit.cpp no_eh_support ]
+   [ run test_convert_cpp_int_2_float.cpp no_eh_support ]
 
       #
       # Interconversion tests:

--- a/test/test_convert_cpp_int_2_float.cpp
+++ b/test/test_convert_cpp_int_2_float.cpp
@@ -1,0 +1,108 @@
+///////////////////////////////////////////////////////////////
+//  Copyright 2021 John Maddock. Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt
+//
+// Simple test that cpp_int -> double conversion has less than 0.5ulp error
+// and rounds to even in case of ties.
+// See https://github.com/boostorg/multiprecision/issues/360.
+//
+#ifdef _MSC_VER
+#define _SCL_SECURE_NO_WARNINGS
+#endif
+
+#include <boost/multiprecision/cpp_int.hpp>
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/random/uniform_int.hpp>
+#include "test.hpp"
+
+using namespace boost::multiprecision;
+
+#ifdef BOOST_MSVC
+#pragma warning(disable : 4127)
+#endif
+
+template <class T>
+T generate_random(unsigned bits_wanted)
+{
+   static boost::random::mt19937               gen;
+   typedef boost::random::mt19937::result_type random_type;
+
+   T        max_val;
+   unsigned digits;
+   if (std::numeric_limits<T>::is_bounded && (bits_wanted == (unsigned)std::numeric_limits<T>::digits))
+   {
+      max_val = (std::numeric_limits<T>::max)();
+      digits  = std::numeric_limits<T>::digits;
+   }
+   else
+   {
+      max_val = T(1) << bits_wanted;
+      digits  = bits_wanted;
+   }
+
+   unsigned bits_per_r_val = std::numeric_limits<random_type>::digits - 1;
+   while ((random_type(1) << bits_per_r_val) > (gen.max)())
+      --bits_per_r_val;
+
+   unsigned terms_needed = digits / bits_per_r_val + 1;
+
+   T val = 0;
+   for (unsigned i = 0; i < terms_needed; ++i)
+   {
+      val *= (gen.max)();
+      val += gen();
+   }
+   val %= max_val;
+   return val;
+}
+
+template <class From, class To>
+void test_convert()
+{
+   boost::random::mt19937 gen;
+   boost::random::uniform_int_distribution<> d(20, (std::min)(200, std::numeric_limits<To>::max_exponent - 2));
+
+   for (unsigned i = 0; i < 10000; ++i)
+   {
+      int  bits = d(gen);
+      From from = generate_random<From>(bits);
+      To   t1(from);
+      From b(t1);
+      if (bits > std::numeric_limits<To>::digits)
+      {
+         // For error <= 1ulp
+         // Note msb(from) returns one less than the number of bits in from:
+         From max_error = (From(1) << (msb(from) - std::numeric_limits<To>::digits));
+         BOOST_TEST_GE(max_error, abs(b - from));
+         if (max_error < abs(b - from))
+            // debugging help:
+            std::cout << from << std::endl
+                      << b << std::endl
+                      << abs(b - from) << std::endl;
+         if (max_error == abs(b - from))
+         {
+            // Check we rounded to even in case of tie:
+            BOOST_TEST_GT(lsb(b), (1 + msb(from) - std::numeric_limits<To>::digits));
+            if (lsb(b) <= (1 + msb(from) - std::numeric_limits<To>::digits))
+            {
+               // debugging help:
+               std::cout << from << std::endl
+                         << b << std::endl
+                         << abs(b - from) << std::endl;
+            }
+         }
+      }
+      else
+      {
+         BOOST_TEST_EQ(b, from);
+      }
+   }
+}
+
+int main()
+{
+   test_convert<cpp_int, float>();
+   test_convert<cpp_int, double>();
+   return boost::report_errors();
+}


### PR DESCRIPTION
Ensures correct round to nearest regardless of value of floating point control flags.
Fixes https://github.com/boostorg/multiprecision/issues/360.