### PR TITLE
Fix some mpq rational arithmetic errors:

### DIFF
--- a/include/boost/multiprecision/gmp.hpp
+++ b/include/boost/multiprecision/gmp.hpp
@@ -2754,19 +2754,19 @@ inline void eval_add(gmp_rational& result, gmp_rational const& a, long b)
    // no need to normalize, there can be no common divisor as long as a is already normalized.
 }
 template <class T>
-inline void eval_add(gmp_rational& result, gmp_rational const& a, const T& b)
+inline typename std::enable_if<boost::multiprecision::detail::is_integral<T>::value>::type eval_add(gmp_rational& result, gmp_rational const& a, const T& b)
 {
    gmp_int t;
    t = b;
    eval_add(result, a, t);
 }
 template <class T>
-inline void eval_add(gmp_rational& result, const T& b, gmp_rational const& a)
+inline typename std::enable_if<boost::multiprecision::detail::is_integral<T>::value>::type eval_add(gmp_rational& result, const T& b, gmp_rational const& a)
 {
    eval_add(result, a, b);
 }
 template <class T>
-inline void eval_add(gmp_rational& result, const T& b)
+inline typename std::enable_if<boost::multiprecision::detail::is_integral<T>::value>::type eval_add(gmp_rational& result, const T& b)
 {
    eval_add(result, result, b);
 }
@@ -2807,20 +2807,20 @@ inline void eval_subtract(gmp_rational& result, gmp_rational const& a, long b)
    // no need to normalize, there can be no common divisor as long as a is already normalized.
 }
 template <class T>
-inline void eval_subtract(gmp_rational& result, gmp_rational const& a, const T& b)
+inline typename std::enable_if<boost::multiprecision::detail::is_integral<T>::value>::type eval_subtract(gmp_rational& result, gmp_rational const& a, const T& b)
 {
    gmp_int t;
    t = b;
    eval_subtract(result, a, t);
 }
 template <class T>
-inline void eval_subtract(gmp_rational& result, const T& b, gmp_rational const& a)
+inline typename std::enable_if<boost::multiprecision::detail::is_integral<T>::value>::type eval_subtract(gmp_rational& result, const T& b, gmp_rational const& a)
 {
    eval_subtract(result, a, b);
    result.negate();
 }
 template <class T>
-inline void eval_subtract(gmp_rational& result, const T& b)
+inline typename std::enable_if<boost::multiprecision::detail::is_integral<T>::value>::type eval_subtract(gmp_rational& result, const T& b)
 {
    eval_subtract(result, result, b);
 }
@@ -2831,12 +2831,15 @@ inline void eval_multiply(gmp_rational& result, gmp_rational const& a, gmp_int c
    mpz_gcd(g.data(), mpq_denref(a.data()), b.data());
    if (!mpz_fits_uint_p(g.data()) || (mpz_get_ui(g.data()) != 1))
    {
+      // We get here if the gcd is not unity, this is true if the number is
+      // too large for an unsigned long, or if we get an unsigned long and check against 1.
       eval_divide(t, b, g);
       mpz_mul(mpq_numref(result.data()), t.data(), mpq_numref(a.data()));
-      mpz_div(mpq_denref(result.data()), mpq_denref(a.data()), g.data());
+      mpz_divexact(mpq_denref(result.data()), mpq_denref(a.data()), g.data());
    }
    else
    {
+      // gcd is 1.
       mpz_mul(mpq_numref(result.data()), mpq_numref(a.data()), b.data());
       if (&result != &a)
          mpz_set(mpq_denref(result.data()), mpq_denref(a.data()));
@@ -2844,13 +2847,23 @@ inline void eval_multiply(gmp_rational& result, gmp_rational const& a, gmp_int c
 }
 inline void eval_multiply(gmp_rational& result, gmp_rational const& a, unsigned long b)
 {
-   gmp_int g;
-   mpz_gcd_ui(g.data(), mpq_denref(a.data()), b);
-   if (!mpz_fits_uint_p(g.data()) || (mpz_get_ui(g.data()) != 1))
+   if (b == 0)
    {
-      b /= mpz_get_ui(g.data());
+      mpq_set_ui(result.data(), b, 1);
+      return;
+   }
+   if (mpz_sgn(mpq_numref(a.data())) == 0)
+   {
+      result = a;
+      return;
+   }
+   unsigned long g = mpz_gcd_ui(nullptr, mpq_denref(a.data()), b);
+   if (g != 1)
+   {
+      BOOST_ASSERT(g);
+      b /= g;
       mpz_mul_ui(mpq_numref(result.data()), mpq_numref(a.data()), b);
-      mpz_div(mpq_denref(result.data()), mpq_denref(a.data()), g.data());
+      mpz_divexact_ui(mpq_denref(result.data()), mpq_denref(a.data()), g);
    }
    else
    {
@@ -2866,19 +2879,19 @@ inline void eval_multiply(gmp_rational& result, gmp_rational const& a, long b)
       result.negate();
 }
 template <class T>
-inline void eval_multiply(gmp_rational& result, gmp_rational const& a, const T& b)
+inline typename std::enable_if<boost::multiprecision::detail::is_integral<T>::value>::type eval_multiply(gmp_rational& result, gmp_rational const& a, const T& b)
 {
    gmp_int t;
    t = b;
    eval_multiply(result, a, t);
 }
 template <class T>
-inline void eval_multiply(gmp_rational& result, const T& b, gmp_rational const& a)
+inline typename std::enable_if<boost::multiprecision::detail::is_integral<T>::value>::type eval_multiply(gmp_rational& result, const T& b, gmp_rational const& a)
 {
    eval_multiply(result, a, b);
 }
 template <class T>
-inline void eval_multiply(gmp_rational& result, const T& b)
+inline typename std::enable_if<boost::multiprecision::detail::is_integral<T>::value>::type eval_multiply(gmp_rational& result, const T& b)
 {
    eval_multiply(result, result, b);
 }
@@ -2994,11 +3007,11 @@ inline std::size_t hash_value(const gmp_rational& val)
 //
 // Some useful helpers:
 //
-inline unsigned used_gmp_int_bits(const gmp_int& val)
+inline std::size_t used_gmp_int_bits(const gmp_int& val)
 {
    return eval_msb(val) - eval_lsb(val) + 1;
 }
-inline unsigned used_gmp_rational_bits(const gmp_rational& val)
+inline std::size_t used_gmp_rational_bits(const gmp_rational& val)
 {
    unsigned d2_d = static_cast<unsigned>(mpz_sizeinbase(mpq_denref(val.data()), 2) - mpz_scan1(mpq_denref(val.data()), 0));
    unsigned d2_n = static_cast<unsigned>(mpz_sizeinbase(mpq_numref(val.data()), 2) - mpz_scan1(mpq_numref(val.data()), 0));
@@ -3063,10 +3076,10 @@ inline gmp_float<0>::gmp_float(const gmp_int& o) : requested_precision(get_defau
 {
    if (thread_default_variable_precision_options() >= variable_precision_options::preserve_all_precision)
    {
-      unsigned d2 = used_gmp_int_bits(o);
-      unsigned d10 = 1 + multiprecision::detail::digits2_2_10(d2);
+      std::size_t d2 = used_gmp_int_bits(o);
+      std::size_t d10 = 1 + multiprecision::detail::digits2_2_10(d2);
       if (d10 > requested_precision)
-         requested_precision = d10;
+         requested_precision = static_cast<unsigned>(d10);
    }
    mpf_init2(this->m_data, multiprecision::detail::digits10_2_2(requested_precision));
    mpf_set_z(this->data(), o.data());
@@ -3075,9 +3088,9 @@ inline gmp_float<0>::gmp_float(const gmp_rational& o) : requested_precision(get_
 {
    if (thread_default_variable_precision_options() >= variable_precision_options::preserve_all_precision)
    {
-      unsigned d10 = 1 + multiprecision::detail::digits2_2_10(used_gmp_rational_bits(o));
+      std::size_t d10 = 1 + multiprecision::detail::digits2_2_10(used_gmp_rational_bits(o));
       if (d10 > requested_precision)
-         requested_precision = d10;
+         requested_precision = static_cast<unsigned>(d10);
    }
    mpf_init2(this->m_data, multiprecision::detail::digits10_2_2(requested_precision));
    mpf_set_q(this->data(), o.data());
@@ -3089,19 +3102,19 @@ inline gmp_float<0>& gmp_float<0>::operator=(const gmp_int& o)
       requested_precision = this->get_default_precision();
       if (thread_default_variable_precision_options() >= variable_precision_options::preserve_all_precision)
       {
-         unsigned d2 = used_gmp_int_bits(o);
-         unsigned d10 = 1 + multiprecision::detail::digits2_2_10(d2);
+         std::size_t d2 = used_gmp_int_bits(o);
+         std::size_t d10 = 1 + multiprecision::detail::digits2_2_10(d2);
          if (d10 > requested_precision)
-            requested_precision = d10;
+            requested_precision = static_cast<unsigned>(d10);
       }
       mpf_init2(this->m_data, multiprecision::detail::digits10_2_2(requested_precision));
    }
    else if (thread_default_variable_precision_options() >= variable_precision_options::preserve_all_precision)
    {
-      unsigned d2 = used_gmp_int_bits(o);
-      unsigned d10 = 1 + multiprecision::detail::digits2_2_10(d2);
+      std::size_t d2 = used_gmp_int_bits(o);
+      std::size_t d10 = 1 + multiprecision::detail::digits2_2_10(d2);
       if (d10 > requested_precision)
-         this->precision(d10);
+         this->precision(static_cast<unsigned>(d10));
    }
    mpf_set_z(this->data(), o.data());
    return *this;
@@ -3113,17 +3126,17 @@ inline gmp_float<0>& gmp_float<0>::operator=(const gmp_rational& o)
       requested_precision = this->get_default_precision();
       if (thread_default_variable_precision_options() >= variable_precision_options::preserve_all_precision)
       {
-         unsigned d10 = 1 + multiprecision::detail::digits2_2_10(used_gmp_rational_bits(o));
+         std::size_t d10 = 1 + multiprecision::detail::digits2_2_10(used_gmp_rational_bits(o));
          if (d10 > requested_precision)
-            requested_precision = d10;
+            requested_precision = static_cast<unsigned>(d10);
       }
       mpf_init2(this->m_data, multiprecision::detail::digits10_2_2(requested_precision));
    }
    else if (thread_default_variable_precision_options() >= variable_precision_options::preserve_all_precision)
    {
-      unsigned d10 = 1 + multiprecision::detail::digits2_2_10(used_gmp_rational_bits(o));
+      std::size_t d10 = 1 + multiprecision::detail::digits2_2_10(used_gmp_rational_bits(o));
       if (d10 > requested_precision)
-         this->precision(d10);
+         this->precision(static_cast<unsigned>(d10));
    }
    mpf_set_q(this->data(), o.data());
    return *this;

--- a/test/test_arithmetic.hpp
+++ b/test/test_arithmetic.hpp
@@ -2049,6 +2049,7 @@ void test_mixed_rational(const std::true_type&)
    rat *= zero;
    BOOST_CHECK_EQUAL(rat, zero);
    rat = Real(2, 3);
+#ifndef BOOST_NO_CXX17_IF_CONSTEXPR
    BOOST_IF_CONSTEXPR(std::is_floating_point<Num>::value)
    {
       Real rat2;
@@ -2071,6 +2072,7 @@ void test_mixed_rational(const std::true_type&)
       rat2 = f - rat;
       BOOST_CHECK_EQUAL(rat2, Real(3, 2) - rat);
    }
+#endif
 }
 template <class Real, class Num>
 void test_mixed_rational(const std::false_type&)

--- a/test/test_arithmetic.hpp
+++ b/test/test_arithmetic.hpp
@@ -2041,6 +2041,43 @@ struct is_definitely_unsigned_int<unsigned __int128>
 #endif
 
 template <class Real, class Num>
+void test_mixed_rational(const std::true_type&)
+{
+   Real rat(2, 3);
+   Num  zero(0);
+   BOOST_CHECK_EQUAL(rat * zero, zero);
+   rat *= zero;
+   BOOST_CHECK_EQUAL(rat, zero);
+   rat = Real(2, 3);
+   BOOST_IF_CONSTEXPR(std::is_floating_point<Num>::value)
+   {
+      Real rat2;
+      Num  f = 0.5f;
+      rat2   = rat * f;
+      BOOST_CHECK_EQUAL(rat2, rat * Real(1, 2));
+      rat2   = f * rat;
+      BOOST_CHECK_EQUAL(rat2, rat * Real(1, 2));
+      rat2   = rat / f;
+      BOOST_CHECK_EQUAL(rat2, rat / Real(1, 2));
+      rat2   = f / rat;
+      BOOST_CHECK_EQUAL(rat2, Real(1, 2) / rat);
+      rat2 = rat + f;
+      BOOST_CHECK_EQUAL(rat2, rat + Real(1, 2));
+      rat2 = f + rat;
+      BOOST_CHECK_EQUAL(rat2, rat + Real(1, 2));
+      rat2 = rat - f;
+      BOOST_CHECK_EQUAL(rat2, rat - Real(1, 2));
+      f    = 1.5f;
+      rat2 = f - rat;
+      BOOST_CHECK_EQUAL(rat2, Real(3, 2) - rat);
+   }
+}
+template <class Real, class Num>
+void test_mixed_rational(const std::false_type&)
+{
+}
+
+template <class Real, class Num>
 void test_mixed(const std::integral_constant<bool, true>&)
 {
    typedef typename std::conditional<
@@ -2223,6 +2260,7 @@ void test_mixed(const std::integral_constant<bool, true>&)
    BOOST_CHECK_EQUAL(d, 3 * 4 - 2);
 
    test_mixed_numeric_limits<Real, Num>(std::integral_constant < bool, std::numeric_limits<Real>::is_specialized && std::numeric_limits<Num>::is_specialized > ());
+   test_mixed_rational<Real, Num>(std::integral_constant<bool, boost::multiprecision::number_category<Real>::value == boost::multiprecision::number_kind_rational>());
 }
 
 template <class Real>


### PR DESCRIPTION
Multiplication by zero should not proceed via gcd.
Multiplication by scalar should be restricted to integer types (not floats).
Add some more tests to catch these cases.