### PR TITLE
Fix warning C4804: '>': unsafe use of type 'bool' in operation

### DIFF
--- a/include/boost/multiprecision/cpp_bin_float.hpp
+++ b/include/boost/multiprecision/cpp_bin_float.hpp
@@ -377,7 +377,7 @@ class cpp_bin_float
       {
       case FP_ZERO:
          m_data     = limb_type(0);
-         m_sign     = ((signbit)(f) > 0);
+         m_sign     = ((signbit)(f));
          m_exponent = exponent_zero;
          return *this;
       case FP_NAN:


### PR DESCRIPTION
@ckormanyos. Scrolling through the CI logs I didn't see any other major issues.