### PR TITLE
Consistently use BOOST_MSCV to guard warning(push/pop) pragmas

### DIFF
--- a/include/boost/multiprecision/cpp_int.hpp
+++ b/include/boost/multiprecision/cpp_int.hpp
@@ -2330,7 +2330,7 @@ using checked_int1024_t = number<cpp_int_backend<1024, 1024, signed_magnitude, c
 // and https://github.com/boostorg/multiprecision/issues/431
 #pragma GCC diagnostic pop
 #endif
-#ifdef _MSC_VER
+#ifdef BOOST_MSVC
 #pragma warning(pop)
 #endif
 

--- a/include/boost/multiprecision/cpp_int/bitwise.hpp
+++ b/include/boost/multiprecision/cpp_int/bitwise.hpp
@@ -14,7 +14,7 @@
 #include <boost/multiprecision/detail/no_exceptions_support.hpp>
 #include <boost/multiprecision/detail/assert.hpp>
 
-#ifdef _MSC_VER
+#ifdef BOOST_MSVC
 #pragma warning(push)
 #pragma warning(disable : 4319)
 #endif
@@ -882,7 +882,7 @@ eval_bitwise_xor(
 
 }}} // namespace boost::multiprecision::backends
 
-#ifdef _MSC_VER
+#ifdef BOOST_MSVC
 #pragma warning(pop)
 #endif
 

--- a/include/boost/multiprecision/cpp_int/import_export.hpp
+++ b/include/boost/multiprecision/cpp_int/import_export.hpp
@@ -211,7 +211,7 @@ template <std::size_t MinBits, std::size_t MaxBits, cpp_integer_type SignType, c
 OutputIterator export_bits(
     const number<cpp_int_backend<MinBits, MaxBits, SignType, Checked, Allocator>, ExpressionTemplates>& val, OutputIterator out, std::size_t chunk_size, bool msv_first = true)
 {
-#ifdef _MSC_VER
+#ifdef BOOST_MSVC
 #pragma warning(push)
 #pragma warning(disable : 4244)
 #endif
@@ -240,7 +240,7 @@ OutputIterator export_bits(
    } while ((bit_location >= 0) && (bit_location < static_cast<int>(bitcount)));
 
    return out;
-#ifdef _MSC_VER
+#ifdef BOOST_MSVC
 #pragma warning(pop)
 #endif
 }

--- a/include/boost/multiprecision/cpp_int/limits.hpp
+++ b/include/boost/multiprecision/cpp_int/limits.hpp
@@ -14,7 +14,7 @@ namespace std {
 
 namespace detail {
 
-#ifdef _MSC_VER
+#ifdef BOOST_MSVC
 #pragma warning(push)
 #pragma warning(disable : 4307)
 #endif
@@ -259,7 +259,7 @@ constexpr bool numeric_limits<boost::multiprecision::number<boost::multiprecisio
 template <std::size_t MinBits, std::size_t MaxBits, boost::multiprecision::cpp_integer_type SignType, boost::multiprecision::cpp_int_check_type Checked, class Allocator, boost::multiprecision::expression_template_option ExpressionTemplates>
 constexpr float_round_style numeric_limits<boost::multiprecision::number<boost::multiprecision::cpp_int_backend<MinBits, MaxBits, SignType, Checked, Allocator>, ExpressionTemplates> >::round_style;
 
-#ifdef _MSC_VER
+#ifdef BOOST_MSVC
 #pragma warning(pop)
 #endif
 

--- a/include/boost/multiprecision/cpp_int/multiply.hpp
+++ b/include/boost/multiprecision/cpp_int/multiply.hpp
@@ -18,7 +18,7 @@
 
 namespace boost { namespace multiprecision { namespace backends {
 
-#ifdef _MSC_VER
+#ifdef BOOST_MSVC
 #pragma warning(push)
 #pragma warning(disable : 4127) // conditional expression is constant
 #endif
@@ -839,7 +839,7 @@ eval_multiply(
    result = static_cast<double_limb_type>(a) * static_cast<double_limb_type>(b);
 }
 
-#ifdef _MSC_VER
+#ifdef BOOST_MSVC
 #pragma warning(pop)
 #endif
 


### PR DESCRIPTION
There was some inconsistency as in some places _MSC_VER was used
instead, plus there was a bug on cpp_int.hpp where BOOST_MSVC was
used for warning(push) while _MSC_VER was used for warning(pop).