### PR TITLE
Enhanced gcc clang warnings

### DIFF
--- a/include/boost/multiprecision/cpp_dec_float.hpp
+++ b/include/boost/multiprecision/cpp_dec_float.hpp
@@ -382,11 +382,18 @@ class cpp_dec_float
    {
       using default_ops::eval_add;
       using default_ops::eval_multiply;
-      static constexpr unsigned          bit_shift = sizeof(unsigned long long) * CHAR_BIT;
+
+      static constexpr unsigned     bit_shift = sizeof(unsigned long long) * CHAR_BIT;
       static constexpr uint128_type mask      = (static_cast<uint128_type>(1u) << bit_shift) - 1;
-      unsigned                           shift     = bit_shift;
-      *this                                        = static_cast<unsigned long long>(v & mask);
+
+      unsigned shift = bit_shift;
+
+      static_cast<void>(shift);
+
+      *this = static_cast<unsigned long long>(v & mask);
+
       v >>= bit_shift;
+
       while (v)
       {
          cpp_dec_float t(static_cast<unsigned long long>(v & mask));

--- a/include/boost/multiprecision/mpfr.hpp
+++ b/include/boost/multiprecision/mpfr.hpp
@@ -1440,7 +1440,7 @@ template <unsigned digits10, mpfr_allocation_type AllocationType>
 inline void eval_subtract(mpfr_float_backend<digits10, AllocationType>& result, long i)
 {
    if (i > 0)
-      mpfr_sub_ui(result.data(), result.data(), static_cast<std::make_unsigned_t<long>>(i), GMP_RNDN);
+      mpfr_sub_ui(result.data(), result.data(), static_cast<typename std::make_unsigned<long>::type>(i), GMP_RNDN);
    else
       mpfr_add_ui(result.data(), result.data(), boost::multiprecision::detail::unsigned_abs(i), GMP_RNDN);
 }
@@ -1511,7 +1511,7 @@ inline void eval_subtract(mpfr_float_backend<D1, A1>& a, const mpfr_float_backen
    if (y < 0)
       mpfr_add_ui(a.data(), x.data(), boost::multiprecision::detail::unsigned_abs(y), GMP_RNDN);
    else
-      mpfr_sub_ui(a.data(), x.data(), static_cast<std::make_unsigned_t<long>>(y), GMP_RNDN);
+      mpfr_sub_ui(a.data(), x.data(), static_cast<typename std::make_unsigned<long>::type>(y), GMP_RNDN);
 }
 template <unsigned D1, unsigned D2, mpfr_allocation_type A1, mpfr_allocation_type A2>
 inline void eval_subtract(mpfr_float_backend<D1, A1>& a, unsigned long x, const mpfr_float_backend<D2, A2>& y)
@@ -2076,7 +2076,7 @@ inline boost::multiprecision::mpfr_float
 max_value<boost::multiprecision::mpfr_float>()
 {
    boost::multiprecision::mpfr_float result(0.5);
-   mpfr_mul_2exp(result.backend().data(), result.backend().data(), static_cast<std::make_unsigned_t<mpfr_exp_t>>(mpfr_get_emax()), GMP_RNDN);
+   mpfr_mul_2exp(result.backend().data(), result.backend().data(), static_cast<typename std::make_unsigned<mpfr_exp_t>::type>(mpfr_get_emax()), GMP_RNDN);
    BOOST_MP_ASSERT(mpfr_number_p(result.backend().data()));
    return result;
 }
@@ -2086,7 +2086,7 @@ inline boost::multiprecision::mpfr_float
 min_value<boost::multiprecision::mpfr_float>()
 {
    boost::multiprecision::mpfr_float result(0.5);
-   mpfr_div_2exp(result.backend().data(), result.backend().data(), static_cast<std::make_unsigned_t<mpfr_exp_t>>(-mpfr_get_emin()), GMP_RNDN);
+   mpfr_div_2exp(result.backend().data(), result.backend().data(), static_cast<typename std::make_unsigned<mpfr_exp_t>::type>(-mpfr_get_emin()), GMP_RNDN);
    BOOST_MP_ASSERT(mpfr_number_p(result.backend().data()));
    return result;
 }
@@ -2096,7 +2096,7 @@ inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0
 max_value<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0>, boost::multiprecision::et_off> >()
 {
    boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0>, boost::multiprecision::et_off> result(0.5);
-   mpfr_mul_2exp(result.backend().data(), result.backend().data(), static_cast<std::make_unsigned_t<mpfr_exp_t>>(mpfr_get_emax()), GMP_RNDN);
+   mpfr_mul_2exp(result.backend().data(), result.backend().data(), static_cast<typename std::make_unsigned<mpfr_exp_t>::type>(mpfr_get_emax()), GMP_RNDN);
    BOOST_MP_ASSERT(mpfr_number_p(result.backend().data()));
    return result;
 }
@@ -2106,7 +2106,7 @@ inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0
 min_value<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0>, boost::multiprecision::et_off> >()
 {
    boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0>, boost::multiprecision::et_off> result(0.5);
-   mpfr_div_2exp(result.backend().data(), result.backend().data(), static_cast<std::make_unsigned_t<mpfr_exp_t>>(-mpfr_get_emin()), GMP_RNDN);
+   mpfr_div_2exp(result.backend().data(), result.backend().data(), static_cast<typename std::make_unsigned<mpfr_exp_t>::type>(-mpfr_get_emin()), GMP_RNDN);
    BOOST_MP_ASSERT(mpfr_number_p(result.backend().data()));
    return result;
 }

--- a/include/boost/multiprecision/mpfr.hpp
+++ b/include/boost/multiprecision/mpfr.hpp
@@ -136,7 +136,7 @@ struct mpfr_float_imp<digits10, allocate_dynamic>
 
    mpfr_float_imp()
    {
-      mpfr_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : (unsigned)get_default_precision()));
+      mpfr_init2(m_data, static_cast<mpfr_prec_t>(multiprecision::detail::digits10_2_2(digits10 ? digits10 : static_cast<unsigned>(get_default_precision()))));
       mpfr_set_ui(m_data, 0u, GMP_RNDN);
    }
    mpfr_float_imp(unsigned digits2)
@@ -198,14 +198,14 @@ struct mpfr_float_imp<digits10, allocate_dynamic>
    mpfr_float_imp& operator=(unsigned long long i)
    {
       if (m_data[0]._mpfr_d == nullptr)
-         mpfr_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : (unsigned)get_default_precision()));
+         mpfr_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : static_cast<unsigned>(get_default_precision())));
       mpfr_set_uj(m_data, i, GMP_RNDN);
       return *this;
    }
    mpfr_float_imp& operator=(long long i)
    {
       if (m_data[0]._mpfr_d == nullptr)
-         mpfr_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : (unsigned)get_default_precision()));
+         mpfr_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : static_cast<unsigned>(get_default_precision())));
       mpfr_set_sj(m_data, i, GMP_RNDN);
       return *this;
    }
@@ -213,7 +213,7 @@ struct mpfr_float_imp<digits10, allocate_dynamic>
    mpfr_float_imp& operator=(unsigned long long i)
    {
       if (m_data[0]._mpfr_d == nullptr)
-         mpfr_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : (unsigned)get_default_precision()));
+         mpfr_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : static_cast<unsigned>(get_default_precision())));
       unsigned long long mask  = ((((1uLL << (std::numeric_limits<unsigned long>::digits - 1)) - 1) << 1) | 1uLL);
       unsigned               shift = 0;
       mpfr_t                 t;
@@ -234,7 +234,7 @@ struct mpfr_float_imp<digits10, allocate_dynamic>
    mpfr_float_imp& operator=(long long i)
    {
       if (m_data[0]._mpfr_d == nullptr)
-         mpfr_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : (unsigned)get_default_precision()));
+         mpfr_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : static_cast<unsigned>(get_default_precision())));
       bool neg = i < 0;
       *this    = boost::multiprecision::detail::unsigned_abs(i);
       if (neg)
@@ -247,7 +247,7 @@ struct mpfr_float_imp<digits10, allocate_dynamic>
    mpfr_float_imp& operator=(uint128_type i)
    {
       if (m_data[0]._mpfr_d == nullptr)
-         mpfr_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : (unsigned)get_default_precision()));
+         mpfr_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : static_cast<unsigned>(get_default_precision())));
       unsigned long long mask  = ((((1uLL << (std::numeric_limits<unsigned long>::digits - 1)) - 1) << 1) | 1uLL);
       unsigned           shift = 0;
       mpfr_t             t;
@@ -268,7 +268,7 @@ struct mpfr_float_imp<digits10, allocate_dynamic>
    mpfr_float_imp& operator=(int128_type i)
    {
       if (m_data[0]._mpfr_d == nullptr)
-         mpfr_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : (unsigned)get_default_precision()));
+         mpfr_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : static_cast<unsigned>(get_default_precision())));
       bool neg = i < 0;
       *this    = boost::multiprecision::detail::unsigned_abs(i);
       if (neg)
@@ -279,28 +279,28 @@ struct mpfr_float_imp<digits10, allocate_dynamic>
    mpfr_float_imp& operator=(unsigned long i)
    {
       if (m_data[0]._mpfr_d == nullptr)
-         mpfr_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : (unsigned)get_default_precision()));
+         mpfr_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : static_cast<unsigned>(get_default_precision())));
       mpfr_set_ui(m_data, i, GMP_RNDN);
       return *this;
    }
    mpfr_float_imp& operator=(long i)
    {
       if (m_data[0]._mpfr_d == nullptr)
-         mpfr_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : (unsigned)get_default_precision()));
+         mpfr_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : static_cast<unsigned>(get_default_precision())));
       mpfr_set_si(m_data, i, GMP_RNDN);
       return *this;
    }
    mpfr_float_imp& operator=(double d)
    {
       if (m_data[0]._mpfr_d == nullptr)
-         mpfr_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : (unsigned)get_default_precision()));
+         mpfr_init2(m_data, static_cast<mpfr_prec_t>(multiprecision::detail::digits10_2_2(digits10 ? digits10 : static_cast<unsigned>(get_default_precision()))));
       mpfr_set_d(m_data, d, GMP_RNDN);
       return *this;
    }
    mpfr_float_imp& operator=(long double a)
    {
       if (m_data[0]._mpfr_d == nullptr)
-         mpfr_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : (unsigned)get_default_precision()));
+         mpfr_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : static_cast<unsigned>(get_default_precision())));
       mpfr_set_ld(m_data, a, GMP_RNDN);
       return *this;
    }
@@ -309,7 +309,7 @@ struct mpfr_float_imp<digits10, allocate_dynamic>
    {
       BOOST_MP_FLOAT128_USING
       if (m_data[0]._mpfr_d == nullptr)
-         mpfr_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : (unsigned)get_default_precision()));
+         mpfr_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : static_cast<unsigned>(get_default_precision())));
 
       if (a == 0)
       {
@@ -357,7 +357,7 @@ struct mpfr_float_imp<digits10, allocate_dynamic>
    mpfr_float_imp& operator=(const char* s)
    {
       if (m_data[0]._mpfr_d == nullptr)
-         mpfr_init2(m_data, multiprecision::detail::digits10_2_2(digits10 ? digits10 : (unsigned)get_default_precision()));
+         mpfr_init2(m_data, static_cast<mpfr_prec_t>(multiprecision::detail::digits10_2_2(digits10 ? digits10 : static_cast<unsigned>(get_default_precision()))));
       if (mpfr_set_str(m_data, s, 10, GMP_RNDN) != 0)
       {
          BOOST_MP_THROW_EXCEPTION(std::runtime_error(std::string("Unable to parse string \"") + s + std::string("\"as a valid floating point number.")));
@@ -1210,7 +1210,7 @@ struct mpfr_float_backend<0, allocate_dynamic> : public detail::mpfr_float_imp<0
       if (this->m_data[0]._mpfr_d == nullptr)
          mpfr_init2(this->m_data, preserve_all_precision() ? static_cast<mpfr_prec_t>(mpf_get_prec(val)) : static_cast<mpfr_prec_t>(boost::multiprecision::detail::digits10_2_2(get_default_precision())));
       else if(preserve_all_precision())
-         mpfr_set_prec(this->m_data, (unsigned)mpf_get_prec(val));
+         mpfr_set_prec(this->m_data, static_cast<mpfr_prec_t>(mpf_get_prec(val)));
       mpfr_set_f(this->m_data, val, GMP_RNDN);
       return *this;
    }
@@ -1440,7 +1440,7 @@ template <unsigned digits10, mpfr_allocation_type AllocationType>
 inline void eval_subtract(mpfr_float_backend<digits10, AllocationType>& result, long i)
 {
    if (i > 0)
-      mpfr_sub_ui(result.data(), result.data(), i, GMP_RNDN);
+      mpfr_sub_ui(result.data(), result.data(), static_cast<std::make_unsigned_t<long>>(i), GMP_RNDN);
    else
       mpfr_add_ui(result.data(), result.data(), boost::multiprecision::detail::unsigned_abs(i), GMP_RNDN);
 }
@@ -1511,7 +1511,7 @@ inline void eval_subtract(mpfr_float_backend<D1, A1>& a, const mpfr_float_backen
    if (y < 0)
       mpfr_add_ui(a.data(), x.data(), boost::multiprecision::detail::unsigned_abs(y), GMP_RNDN);
    else
-      mpfr_sub_ui(a.data(), x.data(), y, GMP_RNDN);
+      mpfr_sub_ui(a.data(), x.data(), static_cast<std::make_unsigned_t<long>>(y), GMP_RNDN);
 }
 template <unsigned D1, unsigned D2, mpfr_allocation_type A1, mpfr_allocation_type A2>
 inline void eval_subtract(mpfr_float_backend<D1, A1>& a, unsigned long x, const mpfr_float_backend<D2, A2>& y)
@@ -2051,7 +2051,7 @@ inline T min_value();
 
 inline void set_output_precision(const boost::multiprecision::mpfr_float& val, std::ostream& os)
 {
-   os << std::setprecision(val.precision());
+   os << std::setprecision(static_cast<int>(val.precision()));
 }
 
 template <>
@@ -2076,7 +2076,7 @@ inline boost::multiprecision::mpfr_float
 max_value<boost::multiprecision::mpfr_float>()
 {
    boost::multiprecision::mpfr_float result(0.5);
-   mpfr_mul_2exp(result.backend().data(), result.backend().data(), mpfr_get_emax(), GMP_RNDN);
+   mpfr_mul_2exp(result.backend().data(), result.backend().data(), static_cast<std::make_unsigned_t<mpfr_exp_t>>(mpfr_get_emax()), GMP_RNDN);
    BOOST_MP_ASSERT(mpfr_number_p(result.backend().data()));
    return result;
 }
@@ -2086,7 +2086,7 @@ inline boost::multiprecision::mpfr_float
 min_value<boost::multiprecision::mpfr_float>()
 {
    boost::multiprecision::mpfr_float result(0.5);
-   mpfr_div_2exp(result.backend().data(), result.backend().data(), -mpfr_get_emin(), GMP_RNDN);
+   mpfr_div_2exp(result.backend().data(), result.backend().data(), static_cast<std::make_unsigned_t<mpfr_exp_t>>(-mpfr_get_emin()), GMP_RNDN);
    BOOST_MP_ASSERT(mpfr_number_p(result.backend().data()));
    return result;
 }
@@ -2096,7 +2096,7 @@ inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0
 max_value<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0>, boost::multiprecision::et_off> >()
 {
    boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0>, boost::multiprecision::et_off> result(0.5);
-   mpfr_mul_2exp(result.backend().data(), result.backend().data(), mpfr_get_emax(), GMP_RNDN);
+   mpfr_mul_2exp(result.backend().data(), result.backend().data(), static_cast<std::make_unsigned_t<mpfr_exp_t>>(mpfr_get_emax()), GMP_RNDN);
    BOOST_MP_ASSERT(mpfr_number_p(result.backend().data()));
    return result;
 }
@@ -2106,7 +2106,7 @@ inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0
 min_value<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0>, boost::multiprecision::et_off> >()
 {
    boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0>, boost::multiprecision::et_off> result(0.5);
-   mpfr_div_2exp(result.backend().data(), result.backend().data(), -mpfr_get_emin(), GMP_RNDN);
+   mpfr_div_2exp(result.backend().data(), result.backend().data(), static_cast<std::make_unsigned_t<mpfr_exp_t>>(-mpfr_get_emin()), GMP_RNDN);
    BOOST_MP_ASSERT(mpfr_number_p(result.backend().data()));
    return result;
 }
@@ -3424,7 +3424,7 @@ class numeric_limits<boost::multiprecision::number<boost::multiprecision::mpfr_f
    static constexpr int digits   = static_cast<int>((Digits10 * 1000L) / 301L + ((Digits10 * 1000L) % 301 ? 2 : 1));
    static constexpr int digits10 = Digits10;
    // Is this really correct???
-   static constexpr int  max_digits10 = boost::multiprecision::detail::calc_max_digits10<digits>::value;
+   static constexpr int  max_digits10 = static_cast<int>(boost::multiprecision::detail::calc_max_digits10<static_cast<unsigned>(digits)>::value);
    static constexpr bool is_signed    = true;
    static constexpr bool is_integer   = false;
    static constexpr bool is_exact     = false;

--- a/include/boost/multiprecision/mpfr.hpp
+++ b/include/boost/multiprecision/mpfr.hpp
@@ -147,14 +147,14 @@ struct mpfr_float_imp<digits10, allocate_dynamic>
 
    mpfr_float_imp(const mpfr_float_imp& o)
    {
-      mpfr_init2(m_data, preserve_source_precision() ? mpfr_get_prec(o.data()) : boost::multiprecision::detail::digits10_2_2(get_default_precision()));
+      mpfr_init2(m_data, preserve_source_precision() ? mpfr_get_prec(o.data()) : static_cast<mpfr_prec_t>(boost::multiprecision::detail::digits10_2_2(get_default_precision())));
       if (o.m_data[0]._mpfr_d)
          mpfr_set(m_data, o.m_data, GMP_RNDN);
    }
    // rvalue copy
    mpfr_float_imp(mpfr_float_imp&& o) noexcept
    {
-      mpfr_prec_t binary_default_precision = boost::multiprecision::detail::digits10_2_2(get_default_precision());
+      mpfr_prec_t binary_default_precision = static_cast<mpfr_prec_t>(boost::multiprecision::detail::digits10_2_2(get_default_precision()));
       if ((this->get_default_options() != variable_precision_options::preserve_target_precision) || (mpfr_get_prec(o.data()) == binary_default_precision))
       {
          m_data[0] = o.m_data[0];
@@ -821,7 +821,7 @@ struct mpfr_float_imp<digits10, allocate_stack>
       }
       else
       {
-         char* ps = mpfr_get_str(0, &e, 10, static_cast<std::size_t>(digits), m_data, GMP_RNDN);
+         char* ps = mpfr_get_str(nullptr, &e, 10, static_cast<std::size_t>(digits), m_data, GMP_RNDN);
          --e; // To match with what our formatter expects.
          if (fixed && e != -1)
          {
@@ -832,7 +832,7 @@ struct mpfr_float_imp<digits10, allocate_stack>
             {
                // We need to get *all* the digits and then possibly round up,
                // we end up with either "0" or "1" as the result.
-               ps = mpfr_get_str(0, &e, 10, 0, m_data, GMP_RNDN);
+               ps = mpfr_get_str(nullptr, &e, 10, 0, m_data, GMP_RNDN);
                --e;
                unsigned offset = *ps == '-' ? 1 : 0;
                if (ps[offset] > '5')
@@ -873,12 +873,12 @@ struct mpfr_float_imp<digits10, allocate_stack>
             }
             else if (digits > 0)
             {
-               ps = mpfr_get_str(0, &e, 10, static_cast<std::size_t>(digits), m_data, GMP_RNDN);
+               ps = mpfr_get_str(nullptr, &e, 10, static_cast<std::size_t>(digits), m_data, GMP_RNDN);
                --e; // To match with what our formatter expects.
             }
             else
             {
-               ps = mpfr_get_str(0, &e, 10, 1, m_data, GMP_RNDN);
+               ps = mpfr_get_str(nullptr, &e, 10, 1, m_data, GMP_RNDN);
                --e;
                unsigned offset = *ps == '-' ? 1 : 0;
                ps[offset]      = '0';
@@ -1095,12 +1095,12 @@ struct mpfr_float_backend<0, allocate_dynamic> : public detail::mpfr_float_imp<0
 {
    mpfr_float_backend() : detail::mpfr_float_imp<0, allocate_dynamic>() {}
    mpfr_float_backend(const mpfr_t val)
-       : detail::mpfr_float_imp<0, allocate_dynamic>(preserve_all_precision() ? (unsigned)mpfr_get_prec(val) : boost::multiprecision::detail::digits10_2_2(get_default_precision()))
+       : detail::mpfr_float_imp<0, allocate_dynamic>(preserve_all_precision() ? static_cast<unsigned>(mpfr_get_prec(val)) : static_cast<unsigned>(boost::multiprecision::detail::digits10_2_2(get_default_precision())))
    {
       mpfr_set(this->m_data, val, GMP_RNDN);
    }
    mpfr_float_backend(const mpf_t val)
-       : detail::mpfr_float_imp<0, allocate_dynamic>(preserve_all_precision() ? (unsigned)mpf_get_prec(val) : boost::multiprecision::detail::digits10_2_2(get_default_precision()))
+       : detail::mpfr_float_imp<0, allocate_dynamic>(preserve_all_precision() ? static_cast<unsigned>(mpf_get_prec(val)) : static_cast<unsigned>(boost::multiprecision::detail::digits10_2_2(get_default_precision())))
    {
       mpfr_set_f(this->m_data, val, GMP_RNDN);
    }
@@ -1120,13 +1120,13 @@ struct mpfr_float_backend<0, allocate_dynamic> : public detail::mpfr_float_imp<0
    {}
    template <class V>
    mpfr_float_backend(const V& o, unsigned digits10)
-       : detail::mpfr_float_imp<0, allocate_dynamic>(multiprecision::detail::digits10_2_2(digits10))
+       : detail::mpfr_float_imp<0, allocate_dynamic>(static_cast<unsigned>(multiprecision::detail::digits10_2_2(digits10)))
    {
       *this = o;
    }
 #ifndef BOOST_NO_CXX17_HDR_STRING_VIEW
    mpfr_float_backend(const std::string_view& o, unsigned digits10)
-       : detail::mpfr_float_imp<0, allocate_dynamic>(multiprecision::detail::digits10_2_2(digits10))
+       : detail::mpfr_float_imp<0, allocate_dynamic>(static_cast<unsigned>(multiprecision::detail::digits10_2_2(digits10)))
    {
       std::string s(o);
       *this = s.c_str();
@@ -1134,35 +1134,35 @@ struct mpfr_float_backend<0, allocate_dynamic> : public detail::mpfr_float_imp<0
 #endif
    template <unsigned D>
    mpfr_float_backend(const gmp_float<D>& val, unsigned digits10)
-       : detail::mpfr_float_imp<0, allocate_dynamic>(multiprecision::detail::digits10_2_2(digits10))
+       : detail::mpfr_float_imp<0, allocate_dynamic>(static_cast<unsigned>(multiprecision::detail::digits10_2_2(digits10)))
    {
       mpfr_set_f(this->m_data, val.data(), GMP_RNDN);
    }
    template <unsigned D>
    mpfr_float_backend(const mpfr_float_backend<D>& val, unsigned digits10)
-       : detail::mpfr_float_imp<0, allocate_dynamic>(multiprecision::detail::digits10_2_2(digits10))
+       : detail::mpfr_float_imp<0, allocate_dynamic>(static_cast<unsigned>(multiprecision::detail::digits10_2_2(digits10)))
    {
       mpfr_set(this->m_data, val.data(), GMP_RNDN);
    }
    template <unsigned D>
    mpfr_float_backend(const mpfr_float_backend<D>& val)
-       : detail::mpfr_float_imp<0, allocate_dynamic>(preserve_related_precision() ? (unsigned)mpfr_get_prec(val.data()) : boost::multiprecision::detail::digits10_2_2(get_default_precision()))
+       : detail::mpfr_float_imp<0, allocate_dynamic>(preserve_related_precision() ? static_cast<unsigned>(mpfr_get_prec(val.data())) : static_cast<unsigned>(boost::multiprecision::detail::digits10_2_2(get_default_precision())))
    {
       mpfr_set(this->m_data, val.data(), GMP_RNDN);
    }
    template <unsigned D>
    mpfr_float_backend(const gmp_float<D>& val)
-       : detail::mpfr_float_imp<0, allocate_dynamic>(preserve_all_precision() ? (unsigned)mpf_get_prec(val.data()) : boost::multiprecision::detail::digits10_2_2(get_default_precision()))
+       : detail::mpfr_float_imp<0, allocate_dynamic>(preserve_all_precision() ? static_cast<unsigned>(mpf_get_prec(val.data())) : static_cast<unsigned>(boost::multiprecision::detail::digits10_2_2(get_default_precision())))
    {
       mpfr_set_f(this->m_data, val.data(), GMP_RNDN);
    }
    mpfr_float_backend(const gmp_int& val)
-       : detail::mpfr_float_imp<0, allocate_dynamic>(preserve_all_precision() ? static_cast<unsigned>(used_gmp_int_bits(val)) : boost::multiprecision::detail::digits10_2_2(thread_default_precision()))
+       : detail::mpfr_float_imp<0, allocate_dynamic>(preserve_all_precision() ? static_cast<unsigned>(used_gmp_int_bits(val)) : static_cast<unsigned>(boost::multiprecision::detail::digits10_2_2(thread_default_precision())))
    {
       mpfr_set_z(this->m_data, val.data(), GMP_RNDN);
    }
    mpfr_float_backend(const gmp_rational& val)
-       : detail::mpfr_float_imp<0, allocate_dynamic>(preserve_all_precision() ? static_cast<unsigned>(used_gmp_rational_bits(val)) : boost::multiprecision::detail::digits10_2_2(thread_default_precision()))
+       : detail::mpfr_float_imp<0, allocate_dynamic>(preserve_all_precision() ? static_cast<unsigned>(used_gmp_rational_bits(val)) : static_cast<unsigned>(boost::multiprecision::detail::digits10_2_2(thread_default_precision())))
    {
       mpfr_set_q(this->m_data, val.data(), GMP_RNDN);
    }
@@ -1199,7 +1199,7 @@ struct mpfr_float_backend<0, allocate_dynamic> : public detail::mpfr_float_imp<0
    mpfr_float_backend& operator=(const mpfr_t val)
    {
       if (this->m_data[0]._mpfr_d == nullptr)
-         mpfr_init2(this->m_data, preserve_all_precision() ? mpfr_get_prec(val) : boost::multiprecision::detail::digits10_2_2(get_default_precision()));
+         mpfr_init2(this->m_data, preserve_all_precision() ? static_cast<mpfr_prec_t>(mpfr_get_prec(val)) : static_cast<mpfr_prec_t>(boost::multiprecision::detail::digits10_2_2(get_default_precision())));
       else if(preserve_all_precision())
          mpfr_set_prec(this->m_data, mpfr_get_prec(val));
       mpfr_set(this->m_data, val, GMP_RNDN);
@@ -1208,7 +1208,7 @@ struct mpfr_float_backend<0, allocate_dynamic> : public detail::mpfr_float_imp<0
    mpfr_float_backend& operator=(const mpf_t val)
    {
       if (this->m_data[0]._mpfr_d == nullptr)
-         mpfr_init2(this->m_data, preserve_all_precision() ? static_cast<mpfr_prec_t>(mpf_get_prec(val)) : boost::multiprecision::detail::digits10_2_2(get_default_precision()));
+         mpfr_init2(this->m_data, preserve_all_precision() ? static_cast<mpfr_prec_t>(mpf_get_prec(val)) : static_cast<mpfr_prec_t>(boost::multiprecision::detail::digits10_2_2(get_default_precision())));
       else if(preserve_all_precision())
          mpfr_set_prec(this->m_data, (unsigned)mpf_get_prec(val));
       mpfr_set_f(this->m_data, val, GMP_RNDN);
@@ -1217,14 +1217,14 @@ struct mpfr_float_backend<0, allocate_dynamic> : public detail::mpfr_float_imp<0
    mpfr_float_backend& operator=(const mpz_t val)
    {
       if (this->m_data[0]._mpfr_d == nullptr)
-         mpfr_init2(this->m_data, multiprecision::detail::digits10_2_2(get_default_precision()));
+         mpfr_init2(this->m_data, static_cast<mpfr_prec_t>(multiprecision::detail::digits10_2_2(get_default_precision())));
       mpfr_set_z(this->m_data, val, GMP_RNDN);
       return *this;
    }
    mpfr_float_backend& operator=(const mpq_t val)
    {
       if (this->m_data[0]._mpfr_d == nullptr)
-         mpfr_init2(this->m_data, multiprecision::detail::digits10_2_2(get_default_precision()));
+         mpfr_init2(this->m_data, static_cast<mpfr_prec_t>(multiprecision::detail::digits10_2_2(get_default_precision())));
       mpfr_set_q(this->m_data, val, GMP_RNDN);
       return *this;
    }
@@ -1255,18 +1255,18 @@ struct mpfr_float_backend<0, allocate_dynamic> : public detail::mpfr_float_imp<0
          unsigned requested_precision = this->thread_default_precision();
          if (thread_default_variable_precision_options() >= variable_precision_options::preserve_all_precision)
          {
-            unsigned d2 = static_cast<unsigned>(used_gmp_int_bits(val));
-            unsigned d10 = 1 + multiprecision::detail::digits2_2_10(d2);
+            unsigned d2  = static_cast<unsigned>(used_gmp_int_bits(val));
+            unsigned d10 = static_cast<unsigned>(1ULL + multiprecision::detail::digits2_2_10(d2));
             if (d10 > requested_precision)
                requested_precision = d10;
          }
-         mpfr_init2(this->m_data, multiprecision::detail::digits10_2_2(requested_precision));
+         mpfr_init2(this->m_data, static_cast<mpfr_prec_t>(multiprecision::detail::digits10_2_2(requested_precision)));
       }
       else if (thread_default_variable_precision_options() >= variable_precision_options::preserve_all_precision)
       {
          unsigned requested_precision = this->thread_default_precision();
-         unsigned d2 = static_cast<unsigned>(used_gmp_int_bits(val));
-         unsigned d10 = 1 + multiprecision::detail::digits2_2_10(d2);
+         unsigned d2  = static_cast<unsigned>(used_gmp_int_bits(val));
+         unsigned d10 = static_cast<unsigned>(1ULL + multiprecision::detail::digits2_2_10(d2));
          if (d10 > requested_precision)
             this->precision(d10);
       }
@@ -1284,7 +1284,7 @@ struct mpfr_float_backend<0, allocate_dynamic> : public detail::mpfr_float_imp<0
             if (d10 > requested_precision)
                requested_precision = d10;
          }
-         mpfr_init2(this->m_data, multiprecision::detail::digits10_2_2(requested_precision));
+         mpfr_init2(this->m_data, static_cast<mpfr_prec_t>(multiprecision::detail::digits10_2_2(requested_precision)));
       }
       else if (thread_default_variable_precision_options() >= variable_precision_options::preserve_all_precision)
       {
@@ -1314,11 +1314,11 @@ struct mpfr_float_backend<0, allocate_dynamic> : public detail::mpfr_float_imp<0
    }
    unsigned precision() const noexcept
    {
-      return multiprecision::detail::digits2_2_10(mpfr_get_prec(this->m_data));
+      return static_cast<unsigned>(multiprecision::detail::digits2_2_10(static_cast<unsigned long>(mpfr_get_prec(this->m_data))));
    }
    void precision(unsigned digits10) noexcept
    {
-      mpfr_prec_round(this->m_data, multiprecision::detail::digits10_2_2((digits10)), GMP_RNDN);
+      mpfr_prec_round(this->m_data, static_cast<mpfr_prec_t>(multiprecision::detail::digits10_2_2((digits10))), GMP_RNDN);
    }
    //
    // Variable precision options:
@@ -1755,7 +1755,7 @@ inline void eval_frexp(mpfr_float_backend<Digits10, AllocateType>& result, const
       return;
    }
    mp_exp_t v = mpfr_get_exp(val.data());
-   *e = v;
+   *e = static_cast<int>(v);
    if (v)
       eval_ldexp(result, val, -v);
    else
@@ -1936,7 +1936,7 @@ inline void eval_remquo(mpfr_float_backend<Digits10, AllocateType>& result, cons
    long l;
    mpfr_remquo(result.data(), &l, a.data(), b.data(), GMP_RNDN);
    if (pi)
-      *pi = l;
+      *pi = static_cast<int>(l);
 }
 
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
@@ -2060,7 +2060,7 @@ inline int digits<boost::multiprecision::mpfr_float>()
     noexcept
 #endif
 {
-   return multiprecision::detail::digits10_2_2(boost::multiprecision::mpfr_float::thread_default_precision());
+   return static_cast<int>(multiprecision::detail::digits10_2_2(boost::multiprecision::mpfr_float::thread_default_precision()));
 }
 template <>
 inline int digits<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<0>, boost::multiprecision::et_off> >()
@@ -2068,7 +2068,7 @@ inline int digits<boost::multiprecision::number<boost::multiprecision::mpfr_floa
     noexcept
 #endif
 {
-   return multiprecision::detail::digits10_2_2(boost::multiprecision::mpfr_float::thread_default_precision());
+   return static_cast<int>(multiprecision::detail::digits10_2_2(boost::multiprecision::mpfr_float::thread_default_precision()));
 }
 
 template <>
@@ -2119,7 +2119,7 @@ inline int digits<boost::multiprecision::number<boost::multiprecision::debug_ada
     noexcept
 #endif
 {
-   return multiprecision::detail::digits10_2_2(boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpfr_float::backend_type> >::thread_default_precision());
+   return static_cast<int>(multiprecision::detail::digits10_2_2(boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpfr_float::backend_type> >::thread_default_precision()));
 }
 template <>
 inline int digits<boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpfr_float_backend<0> >, boost::multiprecision::et_off> >()
@@ -2127,7 +2127,7 @@ inline int digits<boost::multiprecision::number<boost::multiprecision::debug_ada
     noexcept
 #endif
 {
-   return multiprecision::detail::digits10_2_2(boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpfr_float::backend_type> >::thread_default_precision());
+   return static_cast<int>(multiprecision::detail::digits10_2_2(boost::multiprecision::number<boost::multiprecision::debug_adaptor<boost::multiprecision::mpfr_float::backend_type> >::thread_default_precision()));
 }
 
 template <>
@@ -2167,7 +2167,7 @@ inline int digits<boost::multiprecision::number<boost::multiprecision::backends:
     noexcept
 #endif
 {
-   return multiprecision::detail::digits10_2_2(boost::multiprecision::number<boost::multiprecision::backends::logged_adaptor<boost::multiprecision::mpfr_float::backend_type> >::default_precision());
+   return static_cast<int>(multiprecision::detail::digits10_2_2(boost::multiprecision::number<boost::multiprecision::backends::logged_adaptor<boost::multiprecision::mpfr_float::backend_type> >::default_precision()));
 }
 template <>
 inline int digits<boost::multiprecision::number<boost::multiprecision::backends::logged_adaptor<boost::multiprecision::mpfr_float_backend<0> >, boost::multiprecision::et_off> >()
@@ -2175,7 +2175,7 @@ inline int digits<boost::multiprecision::number<boost::multiprecision::backends:
     noexcept
 #endif
 {
-   return multiprecision::detail::digits10_2_2(boost::multiprecision::number<boost::multiprecision::backends::logged_adaptor<boost::multiprecision::mpfr_float::backend_type> >::default_precision());
+   return static_cast<int>(multiprecision::detail::digits10_2_2(boost::multiprecision::number<boost::multiprecision::backends::logged_adaptor<boost::multiprecision::mpfr_float::backend_type> >::default_precision()));
 }
 
 template <>


### PR DESCRIPTION
This PR attempts to handle the remaining conversion warnings on the MPFR backend. This will wrap up the effort to handle enhanced GCC/clang/MSVC warnings in this trimester, as the other backends are finished.

Some remaining work is probably lurking around, undiscovered, in various less-well-used parts of Multiprecision. The entire warning-hardening drive, however, has resulted in hundreds of edits and running tests.

Let's see how this goes in CI...?

Cc: @jzmaddock and @mborland and @NAThompson 