### PR TITLE
number: fix multiplication and division when precision differs

### DIFF
--- a/include/boost/multiprecision/number.hpp
+++ b/include/boost/multiprecision/number.hpp
@@ -721,7 +721,7 @@ class number
       BOOST_MP_CONSTEXPR_IF_VARIABLE_PRECISION(number)
       if (precision_guard.precision() != boost::multiprecision::detail::current_precision_of<self_type>(*this))
          {
-            number t(*this + v);
+            number t(*this * v);
             return *this = std::move(t);
          }
 
@@ -891,7 +891,7 @@ class number
       BOOST_MP_CONSTEXPR_IF_VARIABLE_PRECISION(number)
       if (precision_guard.precision() != boost::multiprecision::detail::current_precision_of<self_type>(*this))
          {
-            number t(*this + v);
+            number t(*this / v);
             return *this = std::move(t);
          }
 


### PR DESCRIPTION
This is clearly a copy-paste bug, as there is addition in both places
now. Fix that.

Fixes: 26ab08df2ed0 ("Test and fix mixed precision arithmetic with
  component types.")