### PR TITLE
Various Warning Fixes

### DIFF
--- a/include/boost/multiprecision/detail/default_ops.hpp
+++ b/include/boost/multiprecision/detail/default_ops.hpp
@@ -2810,7 +2810,7 @@ inline BOOST_MP_CXX14_CONSTEXPR int itrunc(const detail::expression<tag, A1, A2,
    using number_type = typename detail::expression<tag, A1, A2, A3, A4>::result_type;
    number_type                                                           r(trunc(v, pol));
    if ((r > (std::numeric_limits<int>::max)()) || r < (std::numeric_limits<int>::min)() || !BOOST_MP_ISFINITE(v))
-      return boost::math::policies::raise_rounding_error("boost::multiprecision::itrunc<%1%>(%1%)", 0, number_type(v), 0, pol);
+      return boost::math::policies::raise_rounding_error("boost::multiprecision::itrunc<%1%>(%1%)", nullptr, number_type(v), 0, pol);
    return r.template convert_to<int>();
 }
 template <class tag, class A1, class A2, class A3, class A4>
@@ -2823,7 +2823,7 @@ inline BOOST_MP_CXX14_CONSTEXPR int itrunc(const number<Backend, ExpressionTempl
 {
    number<Backend, ExpressionTemplates> r(trunc(v, pol));
    if ((r > (std::numeric_limits<int>::max)()) || r < (std::numeric_limits<int>::min)() || !BOOST_MP_ISFINITE(v))
-      return boost::math::policies::raise_rounding_error("boost::multiprecision::itrunc<%1%>(%1%)", 0, v, 0, pol);
+      return boost::math::policies::raise_rounding_error("boost::multiprecision::itrunc<%1%>(%1%)", nullptr, v, 0, pol);
    return r.template convert_to<int>();
 }
 template <class Backend, expression_template_option ExpressionTemplates>
@@ -2837,7 +2837,7 @@ inline BOOST_MP_CXX14_CONSTEXPR long ltrunc(const detail::expression<tag, A1, A2
    using number_type = typename detail::expression<tag, A1, A2, A3, A4>::result_type;
    number_type                                                           r(trunc(v, pol));
    if ((r > (std::numeric_limits<long>::max)()) || r < (std::numeric_limits<long>::min)() || !BOOST_MP_ISFINITE(v))
-      return boost::math::policies::raise_rounding_error("boost::multiprecision::ltrunc<%1%>(%1%)", 0, number_type(v), 0L, pol);
+      return boost::math::policies::raise_rounding_error("boost::multiprecision::ltrunc<%1%>(%1%)", nullptr, number_type(v), 0L, pol);
    return r.template convert_to<long>();
 }
 template <class tag, class A1, class A2, class A3, class A4>
@@ -2850,7 +2850,7 @@ inline BOOST_MP_CXX14_CONSTEXPR long ltrunc(const number<T, ExpressionTemplates>
 {
    number<T, ExpressionTemplates> r(trunc(v, pol));
    if ((r > (std::numeric_limits<long>::max)()) || r < (std::numeric_limits<long>::min)() || !BOOST_MP_ISFINITE(v))
-      return boost::math::policies::raise_rounding_error("boost::multiprecision::ltrunc<%1%>(%1%)", 0, v, 0L, pol);
+      return boost::math::policies::raise_rounding_error("boost::multiprecision::ltrunc<%1%>(%1%)", nullptr, v, 0L, pol);
    return r.template convert_to<long>();
 }
 template <class T, expression_template_option ExpressionTemplates>
@@ -2865,7 +2865,7 @@ inline BOOST_MP_CXX14_CONSTEXPR long long lltrunc(const detail::expression<tag, 
    using number_type = typename detail::expression<tag, A1, A2, A3, A4>::result_type;
    number_type                                                           r(trunc(v, pol));
    if ((r > (std::numeric_limits<long long>::max)()) || r < (std::numeric_limits<long long>::min)() || !BOOST_MP_ISFINITE(v))
-      return boost::math::policies::raise_rounding_error("boost::multiprecision::lltrunc<%1%>(%1%)", 0, number_type(v), 0LL, pol);
+      return boost::math::policies::raise_rounding_error("boost::multiprecision::lltrunc<%1%>(%1%)", nullptr, number_type(v), 0LL, pol);
    return r.template convert_to<long long>();
 }
 template <class tag, class A1, class A2, class A3, class A4>
@@ -2878,7 +2878,7 @@ inline BOOST_MP_CXX14_CONSTEXPR long long lltrunc(const number<T, ExpressionTemp
 {
    number<T, ExpressionTemplates> r(trunc(v, pol));
    if ((r > (std::numeric_limits<long long>::max)()) || r < (std::numeric_limits<long long>::min)() || !BOOST_MP_ISFINITE(v))
-      return boost::math::policies::raise_rounding_error("boost::multiprecision::lltrunc<%1%>(%1%)", 0, v, 0LL, pol);
+      return boost::math::policies::raise_rounding_error("boost::multiprecision::lltrunc<%1%>(%1%)", nullptr, v, 0LL, pol);
    return r.template convert_to<long long>();
 }
 template <class T, expression_template_option ExpressionTemplates>
@@ -2909,7 +2909,7 @@ inline BOOST_MP_CXX14_CONSTEXPR int iround(const detail::expression<tag, A1, A2,
    using number_type = typename detail::expression<tag, A1, A2, A3, A4>::result_type;
    number_type                                                           r(round(v, pol));
    if ((r > (std::numeric_limits<int>::max)()) || r < (std::numeric_limits<int>::min)() || !BOOST_MP_ISFINITE(v))
-      return boost::math::policies::raise_rounding_error("boost::multiprecision::iround<%1%>(%1%)", 0, number_type(v), 0, pol);
+      return boost::math::policies::raise_rounding_error("boost::multiprecision::iround<%1%>(%1%)", nullptr, number_type(v), 0, pol);
    return r.template convert_to<int>();
 }
 template <class tag, class A1, class A2, class A3, class A4>
@@ -2922,7 +2922,7 @@ inline BOOST_MP_CXX14_CONSTEXPR int iround(const number<T, ExpressionTemplates>&
 {
    number<T, ExpressionTemplates> r(round(v, pol));
    if ((r > (std::numeric_limits<int>::max)()) || r < (std::numeric_limits<int>::min)() || !BOOST_MP_ISFINITE(v))
-      return boost::math::policies::raise_rounding_error("boost::multiprecision::iround<%1%>(%1%)", 0, v, 0, pol);
+      return boost::math::policies::raise_rounding_error("boost::multiprecision::iround<%1%>(%1%)", nullptr, v, 0, pol);
    return r.template convert_to<int>();
 }
 template <class T, expression_template_option ExpressionTemplates>
@@ -2936,7 +2936,7 @@ inline BOOST_MP_CXX14_CONSTEXPR long lround(const detail::expression<tag, A1, A2
    using number_type = typename detail::expression<tag, A1, A2, A3, A4>::result_type;
    number_type                                                           r(round(v, pol));
    if ((r > (std::numeric_limits<long>::max)()) || r < (std::numeric_limits<long>::min)() || !BOOST_MP_ISFINITE(v))
-      return boost::math::policies::raise_rounding_error("boost::multiprecision::lround<%1%>(%1%)", 0, number_type(v), 0L, pol);
+      return boost::math::policies::raise_rounding_error("boost::multiprecision::lround<%1%>(%1%)", nullptr, number_type(v), 0L, pol);
    return r.template convert_to<long>();
 }
 template <class tag, class A1, class A2, class A3, class A4>
@@ -2949,7 +2949,7 @@ inline BOOST_MP_CXX14_CONSTEXPR long lround(const number<T, ExpressionTemplates>
 {
    number<T, ExpressionTemplates> r(round(v, pol));
    if ((r > (std::numeric_limits<long>::max)()) || r < (std::numeric_limits<long>::min)() || !BOOST_MP_ISFINITE(v))
-      return boost::math::policies::raise_rounding_error("boost::multiprecision::lround<%1%>(%1%)", 0, v, 0L, pol);
+      return boost::math::policies::raise_rounding_error("boost::multiprecision::lround<%1%>(%1%)", nullptr, v, 0L, pol);
    return r.template convert_to<long>();
 }
 template <class T, expression_template_option ExpressionTemplates>
@@ -2964,7 +2964,7 @@ inline BOOST_MP_CXX14_CONSTEXPR long long llround(const detail::expression<tag, 
    using number_type = typename detail::expression<tag, A1, A2, A3, A4>::result_type;
    number_type                                                           r(round(v, pol));
    if ((r > (std::numeric_limits<long long>::max)()) || r < (std::numeric_limits<long long>::min)() || !BOOST_MP_ISFINITE(v))
-      return boost::math::policies::raise_rounding_error("boost::multiprecision::iround<%1%>(%1%)", 0, number_type(v), 0LL, pol);
+      return boost::math::policies::raise_rounding_error("boost::multiprecision::iround<%1%>(%1%)", nullptr, number_type(v), 0LL, pol);
    return r.template convert_to<long long>();
 }
 template <class tag, class A1, class A2, class A3, class A4>
@@ -2977,7 +2977,7 @@ inline BOOST_MP_CXX14_CONSTEXPR long long llround(const number<T, ExpressionTemp
 {
    number<T, ExpressionTemplates> r(round(v, pol));
    if ((r > (std::numeric_limits<long long>::max)()) || r < (std::numeric_limits<long long>::min)() || !BOOST_MP_ISFINITE(v))
-      return boost::math::policies::raise_rounding_error("boost::multiprecision::iround<%1%>(%1%)", 0, v, 0LL, pol);
+      return boost::math::policies::raise_rounding_error("boost::multiprecision::iround<%1%>(%1%)", nullptr, v, 0LL, pol);
    return r.template convert_to<long long>();
 }
 template <class T, expression_template_option ExpressionTemplates>
@@ -3092,7 +3092,7 @@ sqrt(const number<B, ExpressionTemplates>& x)
    return s;
 }
 template <class tag, class A1, class A2, class A3, class A4>
-inline BOOST_MP_CXX14_CONSTEXPR typename std::enable_if<number_category<typename detail::expression<tag, A1, A2, A3, A4>::result_type>::value == number_kind_integer, typename detail::expression<tag, A1, A2, A3, A4>::result_type>::type 
+inline BOOST_MP_CXX14_CONSTEXPR typename std::enable_if<number_category<typename detail::expression<tag, A1, A2, A3, A4>::result_type>::value == number_kind_integer, typename detail::expression<tag, A1, A2, A3, A4>::result_type>::type
          sqrt(const detail::expression<tag, A1, A2, A3, A4>& arg)
 {
    using default_ops::eval_integer_sqrt;
@@ -3339,8 +3339,8 @@ sqrt(const detail::expression<tag, Arg1, Arg2, Arg3, Arg4>& arg, number<B, Expre
 
 // clang-format off
 //
-// Regrettably, when the argument to a function is an rvalue we must return by value, and not return an 
-// expression template, otherwise we can end up with dangling references.  
+// Regrettably, when the argument to a function is an rvalue we must return by value, and not return an
+// expression template, otherwise we can end up with dangling references.
 // See https://github.com/boostorg/multiprecision/issues/175.
 //
 #define UNARY_OP_FUNCTOR_CXX11_RVALUE(func, category)\

--- a/include/boost/multiprecision/detail/default_ops.hpp
+++ b/include/boost/multiprecision/detail/default_ops.hpp
@@ -3066,7 +3066,7 @@ inline BOOST_MP_CXX14_CONSTEXPR typename std::enable_if<number_category<T>::valu
    using default_ops::eval_modf;
    detail::scoped_default_precision<multiprecision::number<T, ExpressionTemplates> > precision_guard(v);
    number<T, ExpressionTemplates>                                                    result;
-   eval_modf(result.backend(), v.backend(), pipart ? &pipart->backend() : 0);
+   eval_modf(result.backend(), v.backend(), pipart ? &pipart->backend() : nullptr);
    return result;
 }
 template <class T, expression_template_option ExpressionTemplates, class tag, class A1, class A2, class A3, class A4>
@@ -3075,7 +3075,7 @@ inline BOOST_MP_CXX14_CONSTEXPR typename std::enable_if<number_category<T>::valu
    using default_ops::eval_modf;
    detail::scoped_default_precision<multiprecision::number<T, ExpressionTemplates> > precision_guard(v);
    number<T, ExpressionTemplates>                                                    result, arg(v);
-   eval_modf(result.backend(), arg.backend(), pipart ? &pipart->backend() : 0);
+   eval_modf(result.backend(), arg.backend(), pipart ? &pipart->backend() : nullptr);
    return result;
 }
 

--- a/include/boost/multiprecision/float128.hpp
+++ b/include/boost/multiprecision/float128.hpp
@@ -193,7 +193,7 @@ struct float128_backend
       return *this;
    }
    template <class T>
-   constexpr float128_backend(const T& i, const typename std::enable_if<std::is_convertible<T, float128_type>::value>::type* = 0) noexcept(noexcept(std::declval<float128_type&>() = std::declval<const T&>()))
+   constexpr float128_backend(const T& i, const typename std::enable_if<std::is_convertible<T, float128_type>::value>::type* = nullptr) noexcept(noexcept(std::declval<float128_type&>() = std::declval<const T&>()))
        : m_value(i) {}
    template <class T>
    BOOST_MP_CXX14_CONSTEXPR typename std::enable_if<boost::multiprecision::detail::is_arithmetic<T>::value || std::is_convertible<T, float128_type>::value, float128_backend&>::type operator=(const T& i) noexcept(noexcept(std::declval<float128_type&>() = std::declval<const T&>()))
@@ -440,7 +440,7 @@ inline void eval_rsqrt(float128_backend& result, const float128_backend& arg)
 #endif
 }
 #ifndef BOOST_MP_NO_CONSTEXPR_DETECTION
-inline BOOST_MP_CXX14_CONSTEXPR 
+inline BOOST_MP_CXX14_CONSTEXPR
 #else
 inline
 #endif
@@ -556,7 +556,7 @@ inline void eval_trunc(float128_backend& result, const float128_backend& arg)
    result.value() = truncq(arg.value());
 }
 /*
-// 
+//
 // This doesn't actually work... rely on our own default version instead.
 //
 inline void eval_round(float128_backend& result, const float128_backend& arg)
@@ -564,9 +564,9 @@ inline void eval_round(float128_backend& result, const float128_backend& arg)
    if(isnanq(arg.value()) || isinf(arg.value()))
    {
       result = boost::math::policies::raise_rounding_error(
-            "boost::multiprecision::trunc<%1%>(%1%)", 0, 
-            number<float128_backend, et_off>(arg), 
-            number<float128_backend, et_off>(arg), 
+            "boost::multiprecision::trunc<%1%>(%1%)", nullptr,
+            number<float128_backend, et_off>(arg),
+            number<float128_backend, et_off>(arg),
             boost::math::policies::policy<>()).backend();
       return;
    }

--- a/include/boost/multiprecision/gmp.hpp
+++ b/include/boost/multiprecision/gmp.hpp
@@ -566,7 +566,7 @@ public:
    {
       mp_get_memory_functions(&alloc_func_ptr, &realloc_func_ptr, &free_func_ptr);
    }
-   ~gmp_char_ptr() noexcept 
+   ~gmp_char_ptr() noexcept
    {
       (*free_func_ptr)((void*)ptr_val, sizeof(*ptr_val));
       ptr_val = nullptr;
@@ -588,9 +588,9 @@ struct gmp_float : public detail::gmp_float_imp<digits10>
    }
    gmp_float(const gmp_float& o) : detail::gmp_float_imp<digits10>(o) {}
    template <unsigned D>
-   gmp_float(const gmp_float<D>& o, typename std::enable_if<D <= digits10>::type* = 0);
+   gmp_float(const gmp_float<D>& o, typename std::enable_if<D <= digits10>::type* = nullptr);
    template <unsigned D>
-   explicit gmp_float(const gmp_float<D>& o, typename std::enable_if<!(D <= digits10)>::type* = 0);
+   explicit gmp_float(const gmp_float<D>& o, typename std::enable_if<!(D <= digits10)>::type* = nullptr);
    gmp_float(const gmp_int& o);
    gmp_float(const gmp_rational& o);
    gmp_float(const mpf_t val)
@@ -829,7 +829,7 @@ struct gmp_float<0> : public detail::gmp_float_imp<0>
    }
    //
    // Variable precision options:
-   // 
+   //
    static variable_precision_options default_variable_precision_options()noexcept
    {
       return get_global_default_options();
@@ -3010,7 +3010,7 @@ inline void eval_convert_to(float128_type* result, const gmp_rational& val)
 
    eval_convert_to(&fn, n);
    eval_convert_to(&fd, d);
-   
+
    *result = fn / fd;
 }
 #endif
@@ -3340,7 +3340,7 @@ struct transcendental_reduction_type<boost::multiprecision::backends::gmp_float<
    // As a practical measure the largest argument supported is 1/eps, as supporting larger
    // arguments requires the division of argument by PI/2 to also be done at higher precision,
    // otherwise the result (an integer) can not be represented exactly.
-   // 
+   //
    // See ARGUMENT REDUCTION FOR HUGE ARGUMENTS. K C Ng.
    //
    using type = boost::multiprecision::backends::gmp_float<Digits10 * 3>;

--- a/include/boost/multiprecision/mpc.hpp
+++ b/include/boost/multiprecision/mpc.hpp
@@ -422,13 +422,13 @@ struct mpc_complex_backend : public detail::mpc_complex_imp<digits10>
    mpc_complex_backend(mpc_complex_backend&& o) : detail::mpc_complex_imp<digits10>(static_cast<detail::mpc_complex_imp<digits10>&&>(o))
    {}
    template <unsigned D>
-   mpc_complex_backend(const mpc_complex_backend<D>& val, typename std::enable_if<D <= digits10>::type* = 0)
+   mpc_complex_backend(const mpc_complex_backend<D>& val, typename std::enable_if<D <= digits10>::type* = nullptr)
        : detail::mpc_complex_imp<digits10>()
    {
       mpc_set(this->m_data, val.data(), GMP_RNDN);
    }
    template <unsigned D>
-   explicit mpc_complex_backend(const mpc_complex_backend<D>& val, typename std::enable_if<!(D <= digits10)>::type* = 0)
+   explicit mpc_complex_backend(const mpc_complex_backend<D>& val, typename std::enable_if<!(D <= digits10)>::type* = nullptr)
        : detail::mpc_complex_imp<digits10>()
    {
       mpc_set(this->m_data, val.data(), GMP_RNDN);
@@ -519,12 +519,12 @@ struct mpc_complex_backend : public detail::mpc_complex_imp<digits10>
       return *this;
    }
    template <unsigned D10, mpfr_allocation_type AllocationType>
-   mpc_complex_backend(mpfr_float_backend<D10, AllocationType> const& val, typename std::enable_if<D10 <= digits10>::type* = 0) : detail::mpc_complex_imp<digits10>()
+   mpc_complex_backend(mpfr_float_backend<D10, AllocationType> const& val, typename std::enable_if<D10 <= digits10>::type* = nullptr) : detail::mpc_complex_imp<digits10>()
    {
       mpc_set_fr(this->m_data, val.data(), GMP_RNDN);
    }
    template <unsigned D10, mpfr_allocation_type AllocationType>
-   explicit mpc_complex_backend(mpfr_float_backend<D10, AllocationType> const& val, typename std::enable_if<!(D10 <= digits10)>::type* = 0) : detail::mpc_complex_imp<digits10>()
+   explicit mpc_complex_backend(mpfr_float_backend<D10, AllocationType> const& val, typename std::enable_if<!(D10 <= digits10)>::type* = nullptr) : detail::mpc_complex_imp<digits10>()
    {
       mpc_set_fr(this->m_data, val.data(), GMP_RNDN);
    }

--- a/include/boost/multiprecision/mpfi.hpp
+++ b/include/boost/multiprecision/mpfi.hpp
@@ -507,17 +507,17 @@ struct mpfi_float_backend : public detail::mpfi_float_imp<digits10>
    mpfi_float_backend(mpfi_float_backend&& o) : detail::mpfi_float_imp<digits10>(static_cast<detail::mpfi_float_imp<digits10>&&>(o))
    {}
    template <unsigned D>
-   mpfi_float_backend(const mpfi_float_backend<D>& val, typename std::enable_if<D <= digits10>::type* = 0)
+   mpfi_float_backend(const mpfi_float_backend<D>& val, typename std::enable_if<D <= digits10>::type* = nullptr)
        : detail::mpfi_float_imp<digits10>()
    {
       mpfi_set(this->m_data, val.data());
    }
    template <unsigned D, mpfr_allocation_type AllocationType>
-   mpfi_float_backend(const mpfr_float_backend<D, AllocationType>& val, typename std::enable_if<D <= digits10>::type* = 0)
+   mpfi_float_backend(const mpfr_float_backend<D, AllocationType>& val, typename std::enable_if<D <= digits10>::type* = nullptr)
        : detail::mpfi_float_imp<digits10>(val) {}
 
    template <unsigned D>
-   explicit mpfi_float_backend(const mpfi_float_backend<D>& val, typename std::enable_if<!(D <= digits10)>::type* = 0)
+   explicit mpfi_float_backend(const mpfi_float_backend<D>& val, typename std::enable_if<!(D <= digits10)>::type* = nullptr)
        : detail::mpfi_float_imp<digits10>()
    {
       mpfi_set(this->m_data, val.data());
@@ -533,7 +533,7 @@ struct mpfi_float_backend : public detail::mpfi_float_imp<digits10>
       return *this;
    }
    template <unsigned D>
-   mpfi_float_backend(const mpfr_float_backend<D>& val, typename std::enable_if<D <= digits10>::type* = 0)
+   mpfi_float_backend(const mpfr_float_backend<D>& val, typename std::enable_if<D <= digits10>::type* = nullptr)
        : detail::mpfi_float_imp<digits10>()
    {
       mpfi_set_fr(this->m_data, val.data());
@@ -545,7 +545,7 @@ struct mpfi_float_backend : public detail::mpfi_float_imp<digits10>
       return *this;
    }
    template <unsigned D>
-   explicit mpfi_float_backend(const mpfr_float_backend<D>& val, typename std::enable_if<!(D <= digits10)>::type* = 0)
+   explicit mpfi_float_backend(const mpfr_float_backend<D>& val, typename std::enable_if<!(D <= digits10)>::type* = nullptr)
        : detail::mpfi_float_imp<digits10>()
    {
       mpfi_set_fr(this->m_data, val.data());

--- a/include/boost/multiprecision/mpfi.hpp
+++ b/include/boost/multiprecision/mpfi.hpp
@@ -123,7 +123,7 @@ struct mpfi_float_imp
       if ((this->get_default_options() != variable_precision_options::preserve_target_precision) || (mpfi_get_prec(o.data()) == binary_default_precision))
       {
          m_data[0]                = o.m_data[0];
-         o.m_data[0].left._mpfr_d = 0;
+         o.m_data[0].left._mpfr_d = nullptr;
       }
       else
       {

--- a/include/boost/multiprecision/mpfr.hpp
+++ b/include/boost/multiprecision/mpfr.hpp
@@ -953,25 +953,25 @@ struct mpfr_float_backend : public detail::mpfr_float_imp<digits10, AllocationTy
    mpfr_float_backend(mpfr_float_backend&& o) noexcept : detail::mpfr_float_imp<digits10, AllocationType>(static_cast<detail::mpfr_float_imp<digits10, AllocationType>&&>(o))
    {}
    template <unsigned D, mpfr_allocation_type AT>
-   mpfr_float_backend(const mpfr_float_backend<D, AT>& val, typename std::enable_if<D <= digits10>::type* = 0)
+   mpfr_float_backend(const mpfr_float_backend<D, AT>& val, typename std::enable_if<D <= digits10>::type* = nullptr)
        : detail::mpfr_float_imp<digits10, AllocationType>()
    {
       mpfr_set(this->m_data, val.data(), GMP_RNDN);
    }
    template <unsigned D, mpfr_allocation_type AT>
-   explicit mpfr_float_backend(const mpfr_float_backend<D, AT>& val, typename std::enable_if<!(D <= digits10)>::type* = 0)
+   explicit mpfr_float_backend(const mpfr_float_backend<D, AT>& val, typename std::enable_if<!(D <= digits10)>::type* = nullptr)
        : detail::mpfr_float_imp<digits10, AllocationType>()
    {
       mpfr_set(this->m_data, val.data(), GMP_RNDN);
    }
    template <unsigned D>
-   mpfr_float_backend(const gmp_float<D>& val, typename std::enable_if<D <= digits10>::type* = 0)
+   mpfr_float_backend(const gmp_float<D>& val, typename std::enable_if<D <= digits10>::type* = nullptr)
        : detail::mpfr_float_imp<digits10, AllocationType>()
    {
       mpfr_set_f(this->m_data, val.data(), GMP_RNDN);
    }
    template <unsigned D>
-   mpfr_float_backend(const gmp_float<D>& val, typename std::enable_if<!(D <= digits10)>::type* = 0)
+   mpfr_float_backend(const gmp_float<D>& val, typename std::enable_if<!(D <= digits10)>::type* = nullptr)
        : detail::mpfr_float_imp<digits10, AllocationType>()
    {
       mpfr_set_f(this->m_data, val.data(), GMP_RNDN);
@@ -1322,7 +1322,7 @@ struct mpfr_float_backend<0, allocate_dynamic> : public detail::mpfr_float_imp<0
    }
    //
    // Variable precision options:
-   // 
+   //
    static variable_precision_options default_variable_precision_options()noexcept
    {
       return get_global_default_options();
@@ -2778,7 +2778,7 @@ inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<D
    boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
    mpfr_asinh(result.backend().data(), arg.backend().data(), GMP_RNDN);
    if (mpfr_inf_p(result.backend().data()))
-      return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("asinh<%1%>(%1%)", 0, Policy());
+      return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("asinh<%1%>(%1%)", nullptr, Policy());
    if (mpfr_nan_p(result.backend().data()))
       return policies::raise_evaluation_error("asinh<%1%>(%1%)", "Unknown error, result is a NaN", result, Policy());
    return result;
@@ -2797,7 +2797,7 @@ inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<D
    boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
    mpfr_acosh(result.backend().data(), arg.backend().data(), GMP_RNDN);
    if (mpfr_inf_p(result.backend().data()))
-      return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("acosh<%1%>(%1%)", 0, Policy());
+      return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("acosh<%1%>(%1%)", nullptr, Policy());
    if (mpfr_nan_p(result.backend().data()))
       return policies::raise_evaluation_error("acosh<%1%>(%1%)", "Unknown error, result is a NaN", result, Policy());
    return result;
@@ -2816,7 +2816,7 @@ inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<D
    boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
    mpfr_atanh(result.backend().data(), arg.backend().data(), GMP_RNDN);
    if (mpfr_inf_p(result.backend().data()))
-      return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("atanh<%1%>(%1%)", 0, Policy());
+      return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("atanh<%1%>(%1%)", nullptr, Policy());
    if (mpfr_nan_p(result.backend().data()))
       return policies::raise_evaluation_error("atanh<%1%>(%1%)", "Unknown error, result is a NaN", result, Policy());
    return result;
@@ -2835,7 +2835,7 @@ inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<D
    boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
    mpfr_cbrt(result.backend().data(), arg.backend().data(), GMP_RNDN);
    if (mpfr_inf_p(result.backend().data()))
-      return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("cbrt<%1%>(%1%)", 0, Policy());
+      return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("cbrt<%1%>(%1%)", nullptr, Policy());
    if (mpfr_nan_p(result.backend().data()))
       return policies::raise_evaluation_error("cbrt<%1%>(%1%)", "Unknown error, result is a NaN", result, Policy());
    return result;
@@ -2854,7 +2854,7 @@ inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<D
    boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
    mpfr_erf(result.backend().data(), arg.backend().data(), GMP_RNDN);
    if (mpfr_inf_p(result.backend().data()))
-      return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("erf<%1%>(%1%)", 0, pol);
+      return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("erf<%1%>(%1%)", nullptr, pol);
    if (mpfr_nan_p(result.backend().data()))
       return policies::raise_evaluation_error("erf<%1%>(%1%)", "Unknown error, result is a NaN", result, pol);
    return result;
@@ -2873,7 +2873,7 @@ inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<D
    boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
    mpfr_erfc(result.backend().data(), arg.backend().data(), GMP_RNDN);
    if (mpfr_inf_p(result.backend().data()))
-      return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("erfc<%1%>(%1%)", 0, pol);
+      return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("erfc<%1%>(%1%)", nullptr, pol);
    if (mpfr_nan_p(result.backend().data()))
       return policies::raise_evaluation_error("erfc<%1%>(%1%)", "Unknown error, result is a NaN", result, pol);
    return result;
@@ -2892,7 +2892,7 @@ inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<D
    boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
    mpfr_expm1(result.backend().data(), arg.backend().data(), GMP_RNDN);
    if (mpfr_inf_p(result.backend().data()))
-      return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("expm1<%1%>(%1%)", 0, pol);
+      return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("expm1<%1%>(%1%)", nullptr, pol);
    if (mpfr_nan_p(result.backend().data()))
       return policies::raise_evaluation_error("expm1<%1%>(%1%)", "Unknown error, result is a NaN", result, pol);
    return result;
@@ -2941,7 +2941,7 @@ inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<D
       }
    }
    if (mpfr_inf_p(result.backend().data()))
-      return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("lgamma<%1%>(%1%)", 0, pol);
+      return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("lgamma<%1%>(%1%)", nullptr, pol);
    if (mpfr_nan_p(result.backend().data()))
       return policies::raise_evaluation_error("lgamma<%1%>(%1%)", "Unknown error, result is a NaN", result, pol);
    return result;
@@ -2971,7 +2971,7 @@ inline typename std::enable_if<boost::math::policies::is_policy<Policy>::value, 
    boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
    mpfr_gamma(result.backend().data(), arg.backend().data(), GMP_RNDN);
    if (mpfr_inf_p(result.backend().data()))
-      return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("tgamma<%1%>(%1%)", 0, pol);
+      return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("tgamma<%1%>(%1%)", nullptr, pol);
    if (mpfr_nan_p(result.backend().data()))
       return policies::raise_evaluation_error("tgamma<%1%>(%1%)", "Unknown error, result is a NaN", result, pol);
    return result;
@@ -2990,7 +2990,7 @@ inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<D
    boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
    mpfr_log1p(result.backend().data(), arg.backend().data(), GMP_RNDN);
    if (mpfr_inf_p(result.backend().data()))
-      return (arg == -1 ? -1 : 1) * policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("log1p<%1%>(%1%)", 0, pol);
+      return (arg == -1 ? -1 : 1) * policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("log1p<%1%>(%1%)", nullptr, pol);
    if (mpfr_nan_p(result.backend().data()))
       return policies::raise_evaluation_error("log1p<%1%>(%1%)", "Unknown error, result is a NaN", result, pol);
    return result;
@@ -3009,7 +3009,7 @@ inline boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<D
    boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> result;
    mpfr_rec_sqrt(result.backend().data(), arg.backend().data(), GMP_RNDN);
    if (mpfr_inf_p(result.backend().data()))
-      return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("rsqrt<%1%>(%1%)", 0, pol);
+      return policies::raise_overflow_error<boost::multiprecision::number<boost::multiprecision::mpfr_float_backend<Digits10, AllocateType>, ExpressionTemplates> >("rsqrt<%1%>(%1%)", nullptr, pol);
    if (mpfr_nan_p(result.backend().data()))
       return policies::raise_evaluation_error("rsqrt<%1%>(%1%)", "Negative argument, result is a NaN", result, pol);
    return result;

--- a/include/boost/multiprecision/mpfr.hpp
+++ b/include/boost/multiprecision/mpfr.hpp
@@ -1915,7 +1915,7 @@ inline void eval_log2(mpfr_float_backend<Digits10, AllocateType>& result, const 
 template <unsigned Digits10, mpfr_allocation_type AllocateType>
 inline void eval_modf(mpfr_float_backend<Digits10, AllocateType>& result, const mpfr_float_backend<Digits10, AllocateType>& arg, mpfr_float_backend<Digits10, AllocateType>* pipart)
 {
-   if (0 == pipart)
+   if (pipart == nullptr)
    {
       mpfr_float_backend<Digits10, AllocateType> ipart;
       mpfr_modf(ipart.data(), result.data(), arg.data(), GMP_RNDN);

--- a/include/boost/multiprecision/tommath.hpp
+++ b/include/boost/multiprecision/tommath.hpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////////
-//  Copyright 2011 John Maddock. 
+//  Copyright 2011 John Maddock.
 //  Copyright 2021 Matt Borland. Distributed under the Boost
 //  Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
@@ -77,7 +77,7 @@ struct tommath_int
    }
    tommath_int& operator=(const tommath_int& o)
    {
-      if (m_data.dp == 0)
+      if (m_data.dp == nullptr)
          detail::check_tommath_result(mp_init(&m_data));
       if (o.m_data.dp)
          detail::check_tommath_result(mp_copy(const_cast< ::mp_int*>(&o.m_data), &m_data));
@@ -87,7 +87,7 @@ struct tommath_int
    // Pick off 32 bit chunks for mp_set_int:
    tommath_int& operator=(unsigned long long i)
    {
-      if (m_data.dp == 0)
+      if (m_data.dp == nullptr)
          detail::check_tommath_result(mp_init(&m_data));
       unsigned long long mask = ((1uLL << 32) - 1);
       unsigned shift = 0;
@@ -110,7 +110,7 @@ struct tommath_int
    // Pick off 64 bit chunks for mp_set_u64:
    tommath_int& operator=(unsigned long long i)
    {
-      if (m_data.dp == 0)
+      if (m_data.dp == nullptr)
          detail::check_tommath_result(mp_init(&m_data));
       if(sizeof(unsigned long long) * CHAR_BIT == 64)
       {
@@ -137,7 +137,7 @@ struct tommath_int
 #else
    tommath_int& operator=(unsigned long long i)
    {
-      if (m_data.dp == 0)
+      if (m_data.dp == nullptr)
          detail::check_tommath_result(mp_init(&m_data));
       mp_set_u64(&m_data, i);
       return *this;
@@ -145,7 +145,7 @@ struct tommath_int
 #endif
    tommath_int& operator=(long long i)
    {
-      if (m_data.dp == 0)
+      if (m_data.dp == nullptr)
          detail::check_tommath_result(mp_init(&m_data));
       bool neg = i < 0;
       *this    = boost::multiprecision::detail::unsigned_abs(i);
@@ -157,7 +157,7 @@ struct tommath_int
    // Pick off 64 bit chunks for mp_set_u64:
    tommath_int& operator=(uint128_type i)
    {
-      if (m_data.dp == 0)
+      if (m_data.dp == nullptr)
          detail::check_tommath_result(mp_init(&m_data));
 
       int128_type  mask  = ((static_cast<uint128_type>(1u) << 64) - 1);
@@ -183,7 +183,7 @@ struct tommath_int
    }
    tommath_int& operator=(int128_type i)
    {
-      if (m_data.dp == 0)
+      if (m_data.dp == nullptr)
          detail::check_tommath_result(mp_init(&m_data));
       bool neg = i < 0;
       *this    = boost::multiprecision::detail::unsigned_abs(i);
@@ -199,7 +199,7 @@ struct tommath_int
    //
    tommath_int& operator=(std::uint32_t i)
    {
-      if (m_data.dp == 0)
+      if (m_data.dp == nullptr)
          detail::check_tommath_result(mp_init(&m_data));
 #ifndef mp_get_u32
       detail::check_tommath_result((mp_set_int(&m_data, i)));
@@ -210,7 +210,7 @@ struct tommath_int
    }
    tommath_int& operator=(std::int32_t i)
    {
-      if (m_data.dp == 0)
+      if (m_data.dp == nullptr)
          detail::check_tommath_result(mp_init(&m_data));
       bool neg = i < 0;
       *this    = boost::multiprecision::detail::unsigned_abs(i);
@@ -223,7 +223,7 @@ struct tommath_int
    {
       BOOST_MP_FLOAT128_USING using std::floor; using std::frexp; using std::ldexp;
 
-      if (m_data.dp == 0)
+      if (m_data.dp == nullptr)
          detail::check_tommath_result(mp_init(&m_data));
 
       if (a == 0)
@@ -321,7 +321,7 @@ struct tommath_int
       //
       // We don't use libtommath's own routine because it doesn't error check the input :-(
       //
-      if (m_data.dp == 0)
+      if (m_data.dp == nullptr)
          detail::check_tommath_result(mp_init(&m_data));
       std::size_t n  = s ? std::strlen(s) : 0;
       *this          = static_cast<std::uint32_t>(0u);
@@ -441,7 +441,7 @@ struct tommath_int
       //
       if ((base != 10) && m_data.sign)
          BOOST_MP_THROW_EXCEPTION(std::runtime_error("Formatted output in bases 8 or 16 is only available for positive numbers"));
-      
+
       int s;
       detail::check_tommath_result(mp_radix_size(const_cast< ::mp_int*>(&m_data), base, &s));
       std::unique_ptr<char[]> a(new char[s + 1]);
@@ -695,8 +695,8 @@ inline void eval_complement(tommath_int& result, const tommath_int& u)
    //
    unsigned shift = result.data().used * DIGIT_BIT;    // How many bits we're actually using
    // How many bits we actually need, reduced by one to account for a mythical sign bit:
-   int padding = result.data().used * std::numeric_limits<mp_digit>::digits - shift - 1; 
-   while(padding >= std::numeric_limits<mp_digit>::digits) 
+   int padding = result.data().used * std::numeric_limits<mp_digit>::digits - shift - 1;
+   while(padding >= std::numeric_limits<mp_digit>::digits)
       padding -= std::numeric_limits<mp_digit>::digits;
 
    // Create a mask providing the extra bits we need and add to result:

--- a/performance/arithmetic_backend.hpp
+++ b/performance/arithmetic_backend.hpp
@@ -114,18 +114,29 @@ struct arithmetic_backend
 template <class R, class Arithmetic>
 inline BOOST_MP_CXX14_CONSTEXPR typename std::enable_if<boost::multiprecision::detail::is_integral<R>::value>::type eval_convert_to(R* result, const arithmetic_backend<Arithmetic>& backend)
 {
-   typedef typename std::common_type<R, Arithmetic>::type c_type;
-   constexpr const c_type                             max = static_cast<c_type>((std::numeric_limits<R>::max)());
-   constexpr const c_type                             min = static_cast<c_type>((std::numeric_limits<R>::min)());
-   c_type                                                   ct  = static_cast<c_type>(backend.data());
+   using c_type = typename std::common_type<R, Arithmetic>::type;
+
+   constexpr const c_type max = static_cast<c_type>((std::numeric_limits<R>::max)());
+   constexpr const c_type min = static_cast<c_type>((std::numeric_limits<R>::min)());
+   c_type ct  = static_cast<c_type>(backend.data());
+
    if ((backend.data() < 0) && !std::numeric_limits<R>::is_signed)
+   {
       BOOST_THROW_EXCEPTION(std::range_error("Attempt to convert negative number to unsigned type."));
+   }
+
    if (ct > max)
-      *result = boost::multiprecision::detail::is_signed<R>::value ? (std::numeric_limits<R>::max)() : backend.data();
+   {
+      *result = boost::multiprecision::detail::is_signed<R>::value ? (std::numeric_limits<R>::max)() : static_cast<R>(backend.data());
+   }
    else if (std::numeric_limits<Arithmetic>::is_signed && (ct < min))
+   {
       *result = (std::numeric_limits<R>::min)();
+   }
    else
+   {
       *result = backend.data();
+   }
 }
 
 template <class R, class Arithmetic>

--- a/performance/arithmetic_backend.hpp
+++ b/performance/arithmetic_backend.hpp
@@ -36,7 +36,7 @@ struct arithmetic_backend
    BOOST_MP_CXX14_CONSTEXPR arithmetic_backend() : m_value(0) {}
    BOOST_MP_CXX14_CONSTEXPR arithmetic_backend(const arithmetic_backend& o) : m_value(o.m_value) {}
    template <class A>
-   BOOST_MP_CXX14_CONSTEXPR arithmetic_backend(const A& o, const typename std::enable_if<boost::multiprecision::detail::is_arithmetic<A>::value && std::numeric_limits<A>::is_specialized>::type* = 0) : m_value(o) {}
+   BOOST_MP_CXX14_CONSTEXPR arithmetic_backend(const A& o, const typename std::enable_if<boost::multiprecision::detail::is_arithmetic<A>::value && std::numeric_limits<A>::is_specialized>::type* = nullptr) : m_value(o) {}
    template <class A>
    BOOST_MP_CXX14_CONSTEXPR arithmetic_backend(const arithmetic_backend<A>& o) : m_value(o.data()) {}
    BOOST_MP_CXX14_CONSTEXPR arithmetic_backend& operator=(const arithmetic_backend& o)

--- a/test/constexpr_arithmetric_test.hpp
+++ b/test/constexpr_arithmetric_test.hpp
@@ -60,12 +60,12 @@ BOOST_CXX14_CONSTEXPR T test_constexpr_add_subtract(T a)
    a += do_test_constexpr_add_subtract(a, static_cast<long long>(2));
    a += do_test_constexpr_add_subtract(a, static_cast<unsigned long long>(2));
 #if defined(BOOST_HAS_INT128) && !defined(BOOST_NO_CXX17_IF_CONSTEXPR)
-   if constexpr (std::is_constructible<T, __int128>::value)
+   if constexpr (std::is_constructible<T, boost::int128_type>::value)
    {
-      a += do_test_constexpr_add_subtract(a, static_cast<__int128>(2));
-      a += do_test_constexpr_add_subtract(a, static_cast<unsigned __int128>(2));
-      a -= do_test_constexpr_add_subtract(a, static_cast<__int128>(2));
-      a -= do_test_constexpr_add_subtract(a, static_cast<unsigned __int128>(2));
+      a += do_test_constexpr_add_subtract(a, static_cast<boost::int128_type>(2));
+      a += do_test_constexpr_add_subtract(a, static_cast<boost::uint128_type>(2));
+      a -= do_test_constexpr_add_subtract(a, static_cast<boost::int128_type>(2));
+      a -= do_test_constexpr_add_subtract(a, static_cast<boost::uint128_type>(2));
    }
 #endif
 
@@ -124,12 +124,12 @@ BOOST_CXX14_CONSTEXPR T test_constexpr_mul_divide(T a)
    a += do_test_constexpr_mul_divide(a, static_cast<long long>(2));
    a += do_test_constexpr_mul_divide(a, static_cast<unsigned long long>(2));
 #if defined(BOOST_HAS_INT128) && !defined(BOOST_NO_CXX17_IF_CONSTEXPR)
-   if constexpr (std::is_constructible<T, __int128>::value)
+   if constexpr (std::is_constructible<T, boost::int128_type>::value)
    {
-      a += do_test_constexpr_mul_divide(a, static_cast<__int128>(2));
-      a += do_test_constexpr_mul_divide(a, static_cast<unsigned __int128>(2));
-      a -= do_test_constexpr_mul_divide(a, static_cast<__int128>(2));
-      a -= do_test_constexpr_mul_divide(a, static_cast<unsigned __int128>(2));
+      a += do_test_constexpr_mul_divide(a, static_cast<boost::int128_type>(2));
+      a += do_test_constexpr_mul_divide(a, static_cast<boost::uint128_type>(2));
+      a -= do_test_constexpr_mul_divide(a, static_cast<boost::int128_type>(2));
+      a -= do_test_constexpr_mul_divide(a, static_cast<boost::uint128_type>(2));
    }
 #endif
 
@@ -169,7 +169,7 @@ BOOST_CXX14_CONSTEXPR T do_test_constexpr_bitwise(T a, U b)
    a = a >> 2;
 
    return a;
-} 
+}
 
 template <class T>
 BOOST_CXX14_CONSTEXPR T test_constexpr_bitwise(T a)
@@ -187,10 +187,10 @@ BOOST_CXX14_CONSTEXPR T test_constexpr_bitwise(T a)
    a += do_test_constexpr_bitwise(a, static_cast<long long>(2));
    a += do_test_constexpr_bitwise(a, static_cast<unsigned long long>(2));
 #if defined(BOOST_HAS_INT128) && !defined(BOOST_NO_CXX17_IF_CONSTEXPR)
-   if constexpr (std::is_constructible<T, __int128>::value)
+   if constexpr (std::is_constructible<T, boost::int128_type>::value)
    {
-      a += do_test_constexpr_bitwise(a, static_cast<__int128>(2));
-      a += do_test_constexpr_bitwise(a, static_cast<unsigned __int128>(2));
+      a += do_test_constexpr_bitwise(a, static_cast<boost::int128_type>(2));
+      a += do_test_constexpr_bitwise(a, static_cast<boost::uint128_type>(2));
    }
 #endif
 
@@ -214,7 +214,7 @@ BOOST_CXX14_CONSTEXPR T do_test_constexpr_logical(T a, U b)
    if(!a)
       ++result;
    return result;
-} 
+}
 
 template <class T>
 BOOST_CXX14_CONSTEXPR T test_constexpr_logical(T a)
@@ -232,12 +232,12 @@ BOOST_CXX14_CONSTEXPR T test_constexpr_logical(T a)
    a += do_test_constexpr_logical(a, static_cast<long long>(2));
    a += do_test_constexpr_logical(a, static_cast<unsigned long long>(2));
 #if defined(BOOST_HAS_INT128) && !defined(BOOST_NO_CXX17_IF_CONSTEXPR)
-   if constexpr (std::is_constructible<T, __int128>::value)
+   if constexpr (std::is_constructible<T, boost::int128_type>::value)
    {
-      a += do_test_constexpr_logical(a, static_cast<__int128>(2));
-      a += do_test_constexpr_logical(a, static_cast<unsigned __int128>(2));
-      a -= do_test_constexpr_logical(a, static_cast<__int128>(2));
-      a -= do_test_constexpr_logical(a, static_cast<unsigned __int128>(2));
+      a += do_test_constexpr_logical(a, static_cast<boost::int128_type>(2));
+      a += do_test_constexpr_logical(a, static_cast<boost::uint128_type>(2));
+      a -= do_test_constexpr_logical(a, static_cast<boost::int128_type>(2));
+      a -= do_test_constexpr_logical(a, static_cast<boost::uint128_type>(2));
    }
 #endif
 
@@ -278,7 +278,7 @@ BOOST_CXX14_CONSTEXPR T do_test_constexpr_compare(T a, U b)
       ++result;
 
    return result;
-} 
+}
 
 template <class T>
 BOOST_CXX14_CONSTEXPR T test_constexpr_compare(T a)
@@ -296,12 +296,12 @@ BOOST_CXX14_CONSTEXPR T test_constexpr_compare(T a)
    a += do_test_constexpr_compare(a, static_cast<long long>(2));
    a += do_test_constexpr_compare(a, static_cast<unsigned long long>(2));
 #if defined(BOOST_HAS_INT128) && !defined(BOOST_NO_CXX17_IF_CONSTEXPR)
-   if constexpr (std::is_constructible<T, __int128>::value)
+   if constexpr (std::is_constructible<T, boost::int128_type>::value)
    {
-      a += do_test_constexpr_compare(a, static_cast<__int128>(2));
-      a += do_test_constexpr_compare(a, static_cast<unsigned __int128>(2));
-      a -= do_test_constexpr_compare(a, static_cast<__int128>(2));
-      a -= do_test_constexpr_compare(a, static_cast<unsigned __int128>(2));
+      a += do_test_constexpr_compare(a, static_cast<boost::int128_type>(2));
+      a += do_test_constexpr_compare(a, static_cast<boost::uint128_type>(2));
+      a -= do_test_constexpr_compare(a, static_cast<boost::int128_type>(2));
+      a -= do_test_constexpr_compare(a, static_cast<boost::uint128_type>(2));
    }
 #endif
 

--- a/test/constexpr_test_arithmetic_backend.cpp
+++ b/test/constexpr_test_arithmetic_backend.cpp
@@ -10,7 +10,7 @@ template <class T>
 constexpr int expected_1()
 {
 #ifdef BOOST_HAS_INT128
-   if constexpr (std::is_constructible<T, __int128>::value)
+   if constexpr (std::is_constructible<T, boost::int128_type>::value)
       return 230;
    else
 #endif
@@ -20,7 +20,7 @@ template <class T>
 constexpr int expected_2()
 {
 #ifdef BOOST_HAS_INT128
-   if constexpr (std::is_constructible<T, __int128>::value)
+   if constexpr (std::is_constructible<T, boost::int128_type>::value)
       return 120;
    else
 #endif

--- a/test/constexpr_test_cpp_int_5.cpp
+++ b/test/constexpr_test_cpp_int_5.cpp
@@ -264,7 +264,7 @@ int main()
       nc = sqrt(nc);
       BOOST_CHECK_EQUAL(nc, r);
       constexpr int_backend r2 = sqrt(si1 * 1);
-      BOOST_CHECK_EQUAL(nc, r);
+      BOOST_CHECK_EQUAL(nc, r2);
 
       constexpr int jj = boost::multiprecision::sqrt(i);
       int           k  = i;

--- a/test/test.hpp
+++ b/test/test.hpp
@@ -14,6 +14,7 @@
 #include <boost/detail/lightweight_test.hpp>
 #include <boost/current_function.hpp>
 #include <boost/multiprecision/number.hpp>
+#include <boost/multiprecision/detail/standalone_config.hpp>
 
 namespace detail {
 
@@ -152,14 +153,14 @@ void report_unexpected_exception(const E& e, int severity, const char* file, int
 
 #ifdef BOOST_HAS_INT128
 
-std::ostream& operator<<(std::ostream& os, __int128 val)
+std::ostream& operator<<(std::ostream& os, boost::int128_type val)
 {
    std::stringstream ss;
-   ss << std::hex << "0x" << static_cast<std::uint64_t>(static_cast<unsigned __int128>(val) >> 64) << static_cast<std::uint64_t>(val);
+   ss << std::hex << "0x" << static_cast<std::uint64_t>(static_cast<boost::uint128_type>(val) >> 64) << static_cast<std::uint64_t>(val);
    return os << ss.str();
 }
 
-std::ostream& operator<<(std::ostream& os, unsigned __int128 val)
+std::ostream& operator<<(std::ostream& os, boost::uint128_type val)
 {
    std::stringstream ss;
    ss << std::hex << "0x" << static_cast<std::uint64_t>(val >> 64) << static_cast<std::uint64_t>(val);

--- a/test/test_arithmetic.hpp
+++ b/test/test_arithmetic.hpp
@@ -39,7 +39,7 @@ struct is_checked_cpp_int : public std::integral_constant<bool, false>
 
 //
 // This works around some platforms which have missing typeinfo
-// for __int128 and/or __float128:
+// for boost::int128_type and/or __float128:
 //
 template <class T>
 inline const char* name_of()
@@ -48,14 +48,14 @@ inline const char* name_of()
 }
 #ifdef BOOST_HAS_INT128
 template <>
-inline const char* name_of<__int128>()
+inline const char* name_of<boost::int128_type>()
 {
-   return "__int128";
+   return "boost::int128_type";
 }
 template <>
-inline const char* name_of<unsigned __int128>()
+inline const char* name_of<boost::uint128_type>()
 {
-   return "unsigned __int128";
+   return "boost::uint128_type";
 }
 #endif
 #ifdef BOOST_HAS_FLOAT128
@@ -157,7 +157,7 @@ typename std::enable_if<boost::multiprecision::is_number<Real>::value>::type tes
 }
 
 template <class Real>
-typename std::enable_if<!boost::multiprecision::is_number<Real>::value>::type test_enum_conversions() 
+typename std::enable_if<!boost::multiprecision::is_number<Real>::value>::type test_enum_conversions()
 {}
 
 template <class Real, class Val>
@@ -1581,7 +1581,7 @@ void test_float_ops(const std::integral_constant<int, boost::multiprecision::num
    {
       v = 20.25;
       r = std::numeric_limits<Real>::infinity();
-      
+
       #ifndef BOOST_MP_STANDALONE
       BOOST_CHECK((boost::math::isinf)(v + r));
       BOOST_CHECK((boost::math::isinf)(r + v));
@@ -2116,7 +2116,7 @@ struct is_definitely_unsigned_int
 {};
 #ifdef BOOST_HAS_INT128
 template <>
-struct is_definitely_unsigned_int<unsigned __int128>
+struct is_definitely_unsigned_int<boost::uint128_type>
     : public std::true_type
 {};
 #endif
@@ -2263,9 +2263,9 @@ void test_mixed(const std::integral_constant<bool, true>&)
    r = static_cast<cast_type>(Num(4) * n4) / Real(4);
    BOOST_CHECK_EQUAL(r, static_cast<cast_type>(n4));
 
-   typedef std::integral_constant<bool, 
-       (!std::numeric_limits<Num>::is_specialized || std::numeric_limits<Num>::is_signed) 
-      && (!std::numeric_limits<Real>::is_specialized || std::numeric_limits<Real>::is_signed) 
+   typedef std::integral_constant<bool,
+       (!std::numeric_limits<Num>::is_specialized || std::numeric_limits<Num>::is_signed)
+      && (!std::numeric_limits<Real>::is_specialized || std::numeric_limits<Real>::is_signed)
       && !is_definitely_unsigned_int<Num>::value>
        signed_tag;
 
@@ -3143,10 +3143,10 @@ void test()
    test_mixed<Real, unsigned long long>(tag);
 #endif
 #if defined(BOOST_HAS_INT128) && !defined(BOOST_NO_CXX17_IF_CONSTEXPR)
-   if constexpr (std::is_constructible<Real, __int128>::value)
+   if constexpr (std::is_constructible<Real, boost::int128_type>::value)
    {
-      test_mixed<Real, __int128>(tag);
-      test_mixed<Real, unsigned __int128>(tag);
+      test_mixed<Real, boost::int128_type>(tag);
+      test_mixed<Real, boost::uint128_type>(tag);
    }
 #endif
    test_mixed<Real, float>(tag);

--- a/test/test_fixed_zero_precision_io.cpp
+++ b/test/test_fixed_zero_precision_io.cpp
@@ -182,7 +182,7 @@ void test_fixed_io()
 
 int main()
 {
-#ifdef BOOST_MSVC && (BOOST_MSVC < 1920)
+#if defined(BOOST_MSVC) && (BOOST_MSVC < 1920)
    std::cout << "MSVC prior to 14.2 does not perform bankers rounding for double IO, as a result all our test cases are incorrect, so there's nothing we can productively test here." << std::endl;
 #else
    using namespace boost::multiprecision;

--- a/test/test_mixed_move_cpp_int.cpp
+++ b/test/test_mixed_move_cpp_int.cpp
@@ -37,14 +37,23 @@ void* operator new[](std::size_t count)
    ++alloc_count;
    return std::malloc(count);
 }
-void operator delete(void * p)noexcept
+void operator delete(void* p)noexcept
 {
    return std::free(p);
+}
+void operator delete(void* p, std::size_t)
+{
+   return ::operator delete(p);
 }
 void operator delete[](void* p)noexcept
 {
    return std::free(p);
 }
+void operator delete[](void* p, std::size_t)
+{
+   return ::operator delete[](p);
+}
+
 
 
 template <class From, class To>
@@ -204,8 +213,8 @@ int main()
 {
    using namespace boost::multiprecision;
    //
-   // Our "From" type has the MinBits argument as small as possible, 
-   // should it be larger than the default used in cpp_int then we 
+   // Our "From" type has the MinBits argument as small as possible,
+   // should it be larger than the default used in cpp_int then we
    // may get allocations causing the tests above to fail since the
    // internal cache in type From is larger than that of cpp_int and so
    // allocation may be needed even on a move.


### PR DESCRIPTION
Fixes warnings for: Non-ISO (__int128) type usage, 0 as null pointer constant, unused variable, implicit conversion, and ill-formed macro.