### PR TITLE
Correct import_bits when importing just the leading bits from each va…

### DIFF
--- a/include/boost/multiprecision/cpp_int/import_export.hpp
+++ b/include/boost/multiprecision/cpp_int/import_export.hpp
@@ -172,7 +172,7 @@ import_bits(
     number<cpp_int_backend<MinBits, MaxBits, SignType, Checked, Allocator>, ExpressionTemplates>& val, T* i, T* j, std::size_t chunk_size = 0, bool msv_first = true)
 {
 #if BOOST_MP_ENDIAN_LITTLE_BYTE
-   if (((chunk_size % CHAR_BIT) == 0) && !msv_first)
+   if (((chunk_size % CHAR_BIT) == 0) && !msv_first && (sizeof(*i) * CHAR_BIT == chunk_size))
       return detail::import_bits_fast(val, i, j, chunk_size);
 #endif
    return detail::import_bits_generic(val, i, j, chunk_size, msv_first);

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -1217,6 +1217,7 @@ test-suite misc :
       [ run git_issue_426.cpp : : : [ check-target-builds ../config//has_mpfr : <source>gmp <source>mpfr <define>TEST_MPFR ] [ check-target-builds ../config//has_float128 : <source>quadmath <define>TEST_FLOAT128 ] ]
       [ run git_issue_277.cpp ]
       [ run git_issue_313.cpp ]
+      [ run git_issue_488.cpp ]
       [ compile git_issue_98.cpp : 
          [ check-target-builds ../config//has_float128 : <define>TEST_FLOAT128 <source>quadmath : ]
          [ check-target-builds ../config//has_gmp : <define>TEST_GMP <source>gmp : ]

--- a/test/git_issue_488.cpp
+++ b/test/git_issue_488.cpp
@@ -1,0 +1,45 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright 2022 John Maddock. Distributed under the Boost
+//  Copyright 2022 Christopher Kormanyos. Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <array>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+
+#include <boost/multiprecision/cpp_int.hpp>
+
+#include "test.hpp"
+
+int main()
+{
+   using local_uint265_type = boost::multiprecision::uint256_t;
+
+   std::uint16_t bits[16] = { };
+   std::uint8_t  result_bits[16] = { };
+
+   std::fill(std::begin(bits), std::end(bits), static_cast<std::uint16_t>(UINT16_C(0x5678)));
+   std::fill(std::begin(result_bits), std::end(result_bits), static_cast<std::uint8_t>(bits[0] & 0xFF));
+
+   local_uint265_type u{}, v{};
+
+   const std::array<bool, static_cast<std::size_t>(UINT8_C(2))> msv_values{ true, false };
+
+   const auto flg = std::cout.flags();
+
+   for (const auto msv_first : msv_values)
+   {
+      static_cast<void>(import_bits(u, std::cbegin(bits), std::cend(bits), 8u, msv_first));
+      static_cast<void>(import_bits(v, std::cbegin(result_bits), std::cend(result_bits), 8u, msv_first));
+
+      std::cout << std::hex << std::uppercase << u << std::endl;
+
+      BOOST_CHECK_EQUAL(u, v);
+   }
+
+   std::cout.flags(flg);
+
+   return boost::report_errors();
+}


### PR DESCRIPTION
…lue.

Add test case.
Fixes https://github.com/boostorg/multiprecision/issues/488.