### PR TITLE
Correct static initialization.

### DIFF
--- a/include/boost/multiprecision/cpp_bin_float.hpp
+++ b/include/boost/multiprecision/cpp_bin_float.hpp
@@ -2064,52 +2064,87 @@ class numeric_limits<boost::multiprecision::number<boost::multiprecision::cpp_bi
 {
    using number_type = boost::multiprecision::number<boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>, ExpressionTemplates>;
 
- public:
-   static constexpr bool is_specialized = true;
-   static number_type(min)()
-   {
-      static std::pair<bool, number_type> value;
-      if (!value.first)
-      {
-         value.first = true;
-         using ui_type = typename std::tuple_element<0, typename number_type::backend_type::unsigned_types>::type;
-         value.second.backend()            = ui_type(1u);
-         value.second.backend().exponent() = boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::min_exponent;
-      }
-      return value.second;
-   }
+ private:
+    //
+    // Functions to calculate cached values stored in static values:
+    //
+    static number_type get_min()
+    {
+       using ui_type = typename std::tuple_element<0, typename number_type::backend_type::unsigned_types>::type;
+       number_type value(ui_type(1u));
+       value.backend().exponent() = boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::min_exponent;
+       return value;
+    }
 #ifdef BOOST_MSVC
 #pragma warning(push)
 #pragma warning(disable : 4127) // conditional expression is constant
 #endif
+    static number_type get_max()
+    {
+       number_type value;
+       BOOST_IF_CONSTEXPR(std::is_void<Allocator>::value)
+          eval_complement(value.backend().bits(), value.backend().bits());
+       else
+       {
+          // We jump through hoops here using the backend type directly just to keep VC12 happy
+          // (ie compiler workaround, for very strange compiler bug):
+          using boost::multiprecision::default_ops::eval_add;
+          using boost::multiprecision::default_ops::eval_decrement;
+          using boost::multiprecision::default_ops::eval_left_shift;
+          using int_backend_type = typename number_type::backend_type::rep_type;
+          using ui_type = typename std::tuple_element<0, typename int_backend_type::unsigned_types>::type;
+          int_backend_type                                                                    i;
+          i = ui_type(1u);
+          eval_left_shift(i, boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - 1);
+          int_backend_type j(i);
+          eval_decrement(i);
+          eval_add(j, i);
+          value.backend().bits() = j;
+       }
+       value.backend().exponent() = boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::max_exponent;
+       return value;
+    }
+#ifdef BOOST_MSVC
+#pragma warning(pop)
+#endif
+    static number_type get_epsilon()
+    {
+       using ui_type = typename std::tuple_element<0, typename number_type::backend_type::unsigned_types>::type;
+       number_type value(ui_type(1u));
+       return ldexp(value, 1 - static_cast<int>(digits));
+    }
+    // What value should this be????
+    static number_type get_round_error()
+    {
+       // returns 0.5
+       return ldexp(number_type(1u), -1);
+    }
+    static number_type get_infinity()
+    {
+       number_type value;
+       value.backend().exponent() = boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_infinity;
+       return value;
+    }
+    static number_type get_quiet_NaN()
+    {
+       number_type value;
+       value.backend().exponent() = boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_nan;
+       return value;
+    }
+
+ public:
+   static constexpr bool is_specialized = true;
+   static number_type(min)()
+   {
+      // C++11 thread safe static initialization:
+      static number_type value = get_min();
+      return value;
+   }
    static number_type(max)()
    {
-      static std::pair<bool, number_type> value;
-      if (!value.first)
-      {
-         value.first = true;
-         BOOST_IF_CONSTEXPR(std::is_void<Allocator>::value)
-            eval_complement(value.second.backend().bits(), value.second.backend().bits());
-         else
-         {
-            // We jump through hoops here using the backend type directly just to keep VC12 happy
-            // (ie compiler workaround, for very strange compiler bug):
-            using boost::multiprecision::default_ops::eval_add;
-            using boost::multiprecision::default_ops::eval_decrement;
-            using boost::multiprecision::default_ops::eval_left_shift;
-            using int_backend_type = typename number_type::backend_type::rep_type                               ;
-            using ui_type = typename std::tuple_element<0, typename int_backend_type::unsigned_types>::type;
-            int_backend_type                                                                    i;
-            i = ui_type(1u);
-            eval_left_shift(i, boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - 1);
-            int_backend_type j(i);
-            eval_decrement(i);
-            eval_add(j, i);
-            value.second.backend().bits() = j;
-         }
-         value.second.backend().exponent() = boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::max_exponent;
-      }
-      return value.second;
+      // C++11 thread safe static initialization:
+      static number_type value = get_max();
+      return value;
    }
 #ifdef BOOST_MSVC
 #pragma warning(pop)
@@ -2128,31 +2163,17 @@ class numeric_limits<boost::multiprecision::number<boost::multiprecision::cpp_bi
    static constexpr int  radix        = 2;
    static number_type          epsilon()
    {
-      static std::pair<bool, number_type> value;
-      if (!value.first)
-      {
-         // We jump through hoops here just to keep VC12 happy (ie compiler workaround, for very strange compiler bug):
-         using ui_type = typename std::tuple_element<0, typename number_type::backend_type::unsigned_types>::type;
-         value.first            = true;
-         value.second.backend() = ui_type(1u);
-         value.second           = ldexp(value.second, 1 - static_cast<int>(digits));
-      }
-      return value.second;
+      // C++11 thread safe static initialization:
+      static number_type value = get_epsilon();
+      return value;
    }
    // What value should this be????
    static number_type round_error()
    {
       // returns 0.5
-      static std::pair<bool, number_type> value;
-      if (!value.first)
-      {
-         value.first = true;
-         // We jump through hoops here just to keep VC12 happy (ie compiler workaround, for very strange compiler bug):
-         using ui_type = typename std::tuple_element<0, typename number_type::backend_type::unsigned_types>::type;
-         value.second.backend() = ui_type(1u);
-         value.second           = ldexp(value.second, -1);
-      }
-      return value.second;
+      // C++11 thread safe static initialization:
+      static number_type value = get_round_error();
+      return value;
    }
    static constexpr typename boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_type min_exponent      = boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::min_exponent;
    static constexpr typename boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_type min_exponent10    = (min_exponent / 1000) * 301L;
@@ -2163,25 +2184,17 @@ class numeric_limits<boost::multiprecision::number<boost::multiprecision::cpp_bi
    static constexpr bool                                                                                                             has_signaling_NaN = false;
    static constexpr float_denorm_style has_denorm                                                                                                      = denorm_absent;
    static constexpr bool               has_denorm_loss                                                                                                 = false;
-   static number_type                        infinity()
+   static number_type infinity()
    {
-      static std::pair<bool, number_type> value;
-      if (!value.first)
-      {
-         value.first                       = true;
-         value.second.backend().exponent() = boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_infinity;
-      }
-      return value.second;
+      // C++11 thread safe static initialization:
+      static number_type value = get_infinity();
+      return value;
    }
    static number_type quiet_NaN()
    {
-      static std::pair<bool, number_type> value;
-      if (!value.first)
-      {
-         value.first                       = true;
-         value.second.backend().exponent() = boost::multiprecision::cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_nan;
-      }
-      return value.second;
+      // C++11 thread safe static initialization:
+      static number_type value = get_quiet_NaN();
+      return value;
    }
    static constexpr number_type signaling_NaN()
    {

--- a/include/boost/multiprecision/mpfi.hpp
+++ b/include/boost/multiprecision/mpfi.hpp
@@ -2154,14 +2154,8 @@ struct constant_pi<boost::multiprecision::number<boost::multiprecision::backends
    template <int N>
    static inline const result_type& get(const std::integral_constant<int, N>&)
    {
-      static result_type result;
-      static bool        has_init = false;
-      if (!has_init)
-      {
-         has_init = true;
-         mpfi_const_pi(result.backend().value().data());
-         result.backend().update_view();
-      }
+      // C++11 thread safe static initialization:
+      static result_type result   = get(std::integral_constant<int, 0>());
       return result;
    }
    static inline result_type get(const std::integral_constant<int, 0>&)
@@ -2179,14 +2173,8 @@ struct constant_ln_two<boost::multiprecision::number<boost::multiprecision::back
    template <int N>
    static inline const result_type& get(const std::integral_constant<int, N>&)
    {
-      static result_type result;
-      static bool        has_init = false;
-      if (!has_init)
-      {
-         has_init = true;
-         mpfi_const_log2(result.backend().value().data());
-         result.backend().update_view();
-      }
+      // C++11 thread safe static initialization:
+      static result_type result = get(std::integral_constant<int, 0>());
       return result;
    }
    static inline result_type get(const std::integral_constant<int, 0>&)
@@ -2204,14 +2192,8 @@ struct constant_euler<boost::multiprecision::number<boost::multiprecision::backe
    template <int N>
    static inline const result_type& get(const std::integral_constant<int, N>&)
    {
-      static result_type result;
-      static bool        has_init = false;
-      if (!has_init)
-      {
-         has_init = true;
-         mpfi_const_euler(result.backend().value().data());
-         result.backend().update_view();
-      }
+      // C++11 thread safe static initialization:
+      static result_type result(get(std::integral_constant<int, 0>()));
       return result;
    }
    static inline result_type get(const std::integral_constant<int, 0>&)
@@ -2229,14 +2211,8 @@ struct constant_catalan<boost::multiprecision::number<boost::multiprecision::bac
    template <int N>
    static inline const result_type& get(const std::integral_constant<int, N>&)
    {
-      static result_type result;
-      static bool        has_init = false;
-      if (!has_init)
-      {
-         has_init = true;
-         mpfi_const_catalan(result.backend().value().data());
-         result.backend().update_view();
-      }
+      // C++11 thread safe static initialization:
+      static result_type result(std::integral_constant<int, 0>());
       return result;
    }
    static inline result_type get(const std::integral_constant<int, 0>&)
@@ -2257,13 +2233,8 @@ struct constant_pi<boost::multiprecision::number<boost::multiprecision::backends
    template <int N>
    static inline const result_type& get(const std::integral_constant<int, N>&)
    {
-      static result_type result;
-      static bool        has_init = false;
-      if (!has_init)
-      {
-         has_init = true;
-         mpfi_const_pi(result.backend().value().data());
-      }
+      // C++11 thread safe static initialization:
+      static result_type result(std::integral_constant<int, 0>());
       return result;
    }
    static inline result_type get(const std::integral_constant<int, 0>&)
@@ -2280,13 +2251,8 @@ struct constant_ln_two<boost::multiprecision::number<boost::multiprecision::back
    template <int N>
    static inline const result_type& get(const std::integral_constant<int, N>&)
    {
-      static result_type result;
-      static bool        has_init = false;
-      if (!has_init)
-      {
-         has_init = true;
-         mpfi_const_log2(result.backend().value().data());
-      }
+      // C++11 thread safe static initialization:
+      static result_type result(std::integral_constant<int, 0>());
       return result;
    }
    static inline result_type get(const std::integral_constant<int, 0>&)
@@ -2303,13 +2269,8 @@ struct constant_euler<boost::multiprecision::number<boost::multiprecision::backe
    template <int N>
    static inline const result_type& get(const std::integral_constant<int, N>&)
    {
-      static result_type result;
-      static bool        has_init = false;
-      if (!has_init)
-      {
-         has_init = true;
-         mpfi_const_euler(result.backend().value().data());
-      }
+      // C++11 thread safe static initialization:
+      static result_type result(std::integral_constant<int, 0>());
       return result;
    }
    static inline result_type get(const std::integral_constant<int, 0>&)
@@ -2326,13 +2287,8 @@ struct constant_catalan<boost::multiprecision::number<boost::multiprecision::bac
    template <int N>
    static inline const result_type& get(const std::integral_constant<int, N>&)
    {
-      static result_type result;
-      static bool        has_init = false;
-      if (!has_init)
-      {
-         has_init = true;
-         mpfi_const_catalan(result.backend().value().data());
-      }
+      // C++11 thread safe static initialization:
+      static result_type result(std::integral_constant<int, 0>());
       return result;
    }
    static inline result_type get(const std::integral_constant<int, 0>&)

--- a/include/boost/multiprecision/mpfr.hpp
+++ b/include/boost/multiprecision/mpfr.hpp
@@ -2381,13 +2381,8 @@ struct constant_pi<boost::multiprecision::number<boost::multiprecision::backends
    template <int N>
    static inline const result_type& get(const std::integral_constant<int, N>&)
    {
-      static result_type result;
-      static bool        has_init = false;
-      if (!has_init)
-      {
-         mpfr_const_pi(result.backend().value().data(), GMP_RNDN);
-         has_init = true;
-      }
+      // C++11 thread safe static initialization:
+      static result_type result(std::integral_constant<int, 0>());
       return result;
    }
    static inline const result_type get(const std::integral_constant<int, 0>&)
@@ -2404,13 +2399,8 @@ struct constant_ln_two<boost::multiprecision::number<boost::multiprecision::back
    template <int N>
    static inline const result_type& get(const std::integral_constant<int, N>&)
    {
-      static result_type result;
-      static bool        init = false;
-      if (!init)
-      {
-         mpfr_const_log2(result.backend().value().data(), GMP_RNDN);
-         init = true;
-      }
+      // C++11 thread safe static initialization:
+      static result_type result(std::integral_constant<int, 0>());
       return result;
    }
    static inline const result_type get(const std::integral_constant<int, 0>&)
@@ -2427,13 +2417,8 @@ struct constant_euler<boost::multiprecision::number<boost::multiprecision::backe
    template <int N>
    static inline const result_type& get(const std::integral_constant<int, N>&)
    {
-      static result_type result;
-      static bool        init = false;
-      if (!init)
-      {
-         mpfr_const_euler(result.backend().value().data(), GMP_RNDN);
-         init = true;
-      }
+      // C++11 thread safe static initialization:
+      static result_type result(std::integral_constant<int, 0>());
       return result;
    }
    static inline const result_type get(const std::integral_constant<int, 0>&)
@@ -2450,13 +2435,8 @@ struct constant_catalan<boost::multiprecision::number<boost::multiprecision::bac
    template <int N>
    static inline const result_type& get(const std::integral_constant<int, N>&)
    {
-      static result_type result;
-      static bool        init = false;
-      if (!init)
-      {
-         mpfr_const_catalan(result.backend().value().data(), GMP_RNDN);
-         init = true;
-      }
+      // C++11 thread safe static initialization:
+      static result_type result(std::integral_constant<int, 0>());
       return result;
    }
    static inline const result_type get(const std::integral_constant<int, 0>&)


### PR DESCRIPTION
Previous changes to use C++11 thread safe statics mangled a few static variables leaving them non-thread-safe initialized. Do a quick review through the code to fix the remaining issues. Fixes https://github.com/boostorg/multiprecision/issues/497.