### PR TITLE
Fix for issue 499

### DIFF
--- a/include/boost/multiprecision/cpp_dec_float.hpp
+++ b/include/boost/multiprecision/cpp_dec_float.hpp
@@ -2106,11 +2106,7 @@ bool cpp_dec_float<Digits10, ExponentType, Allocator>::rd_string(const char* con
       if (((pos = str.find('e')) != std::string::npos) || ((pos = str.find('E')) != std::string::npos))
       {
          // Remove the exponent part from the string.
-         #ifndef BOOST_MP_STANDALONE
-         exp = boost::lexical_cast<exponent_type>(static_cast<const char*>(str.c_str() + (pos + 1u)));
-         #else
          exp = static_cast<exponent_type>(std::atoll(static_cast<const char*>(str.c_str() + (pos + 1u))));
-         #endif
          
          str = str.substr(static_cast<std::size_t>(0u), pos);
       }
@@ -2373,11 +2369,7 @@ bool cpp_dec_float<Digits10, ExponentType, Allocator>::rd_string(const char* con
 
 #ifndef BOOST_NO_EXCEPTIONS
    }
-   #ifndef BOOST_MP_STANDALONE
-   catch (const bad_lexical_cast&)
-   #else
    catch (const std::exception&)
-   #endif
    {
       // Rethrow with better error message:
       std::string msg = "Unable to parse the string \"";

--- a/include/boost/multiprecision/cpp_dec_float.hpp
+++ b/include/boost/multiprecision/cpp_dec_float.hpp
@@ -2133,8 +2133,15 @@ bool cpp_dec_float<Digits10, ExponentType, Allocator>::rd_string(const char* con
 
       // See git issue 499
       // Example: 12a3.4 should throw as malformed
-      std::size_t malformed = str.find_first_not_of("0123456789eElLfF.+-");
+      std::size_t malformed = str.find_first_not_of("0123456789eE.+-");
       if (malformed != std::string::npos)
+      {
+         BOOST_MP_THROW_EXCEPTION(std::runtime_error("Malformed expression"));
+      }
+
+      std::size_t literal = str.find_last_of("lLfF");
+      if (literal != std::string::npos &&
+          literal != str.size())
       {
          BOOST_MP_THROW_EXCEPTION(std::runtime_error("Malformed expression"));
       }

--- a/include/boost/multiprecision/cpp_dec_float.hpp
+++ b/include/boost/multiprecision/cpp_dec_float.hpp
@@ -2095,6 +2095,22 @@ bool cpp_dec_float<Digits10, ExponentType, Allocator>::rd_string(const char* con
 
       std::string str(s);
 
+      // Get a possible +/- sign and remove it.
+      neg = false;
+
+      if (str.size())
+      {
+         if (str[0] == '-')
+         {
+            neg = true;
+            str.erase(0, 1);
+         }
+         else if (str[0] == '+')
+         {
+            str.erase(0, 1);
+         }
+      }
+
       //
       // Special cases for infinities and NaN's:
       //
@@ -2145,22 +2161,6 @@ bool cpp_dec_float<Digits10, ExponentType, Allocator>::rd_string(const char* con
          }
 
          str = str.substr(static_cast<std::size_t>(0u), pos);
-      }
-
-      // Get a possible +/- sign and remove it.
-      neg = false;
-
-      if (str.size())
-      {
-         if (str[0] == '-')
-         {
-            neg = true;
-            str.erase(0, 1);
-         }
-         else if (str[0] == '+')
-         {
-            str.erase(0, 1);
-         }
       }
 
       // Remove the leading zeros for all input types.

--- a/include/boost/multiprecision/cpp_dec_float.hpp
+++ b/include/boost/multiprecision/cpp_dec_float.hpp
@@ -2106,8 +2106,13 @@ bool cpp_dec_float<Digits10, ExponentType, Allocator>::rd_string(const char* con
       if (((pos = str.find('e')) != std::string::npos) || ((pos = str.find('E')) != std::string::npos))
       {
          // Remove the exponent part from the string.
-         exp = static_cast<exponent_type>(std::atoll(static_cast<const char*>(str.c_str() + (pos + 1u))));
-         
+         std::size_t num_chars {};
+         exp = static_cast<exponent_type>(std::stoll(str.substr(pos + 1u), &num_chars));
+         if ((pos + num_chars + 1u) != str.size())
+         {
+            BOOST_MP_THROW_EXCEPTION(std::runtime_error("Malformed expression"));
+         }
+
          str = str.substr(static_cast<std::size_t>(0u), pos);
       }
 

--- a/include/boost/multiprecision/cpp_dec_float.hpp
+++ b/include/boost/multiprecision/cpp_dec_float.hpp
@@ -2134,7 +2134,7 @@ bool cpp_dec_float<Digits10, ExponentType, Allocator>::rd_string(const char* con
          return true;
       }
 
-      const std::regex valid {R"(/^(-?(0|[1-9]\d*)?(\.\d+)?(e-?(0|[1-9]\d*))?|0x[0-9a-f]+)$/i)"};
+      const std::regex valid {R"(/^(-?(0|[1-9]\d*)?(\.\d+)?(e-?(0|[0-9]\d*))?|0x[0-9a-f]+)$/i)"};
       if (!std::regex_search(str, valid))
       {
          BOOST_MP_THROW_EXCEPTION(std::invalid_argument("Malformed expression"));

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -1218,6 +1218,7 @@ test-suite misc :
       [ run git_issue_277.cpp ]
       [ run git_issue_313.cpp ]
       [ run git_issue_488.cpp ]
+      [ run git_issue_499.cpp ]
       [ compile git_issue_98.cpp : 
          [ check-target-builds ../config//has_float128 : <define>TEST_FLOAT128 <source>quadmath : ]
          [ check-target-builds ../config//has_gmp : <define>TEST_GMP <source>gmp : ]

--- a/test/git_issue_499.cpp
+++ b/test/git_issue_499.cpp
@@ -100,6 +100,20 @@ int main()
         ++counter;
     }
 
+    try
+    {
+        cpp_dec_float_50 val5{"23.5-3e-26"};
+        std::cout << "no exception. val=" << val5 << "\n";
+    }
+    catch (const std::runtime_error& e)
+    {
+        std::cout << "std::runtime_error. what():" << e.what() << "\n";
+    }
+    catch (...)
+    {
+        ++counter;
+    }
+
     if (counter != 0)
     {
         return 1;

--- a/test/git_issue_499.cpp
+++ b/test/git_issue_499.cpp
@@ -5,11 +5,15 @@
 
 #include <iostream>
 #include <boost/multiprecision/cpp_dec_float.hpp>
+#include <boost/core/lightweight_test.hpp>
 
 using boost::multiprecision::cpp_dec_float_50;
 
 int main()
 {
+    std::size_t counter {};
+    
+    // All character strings case
     try
     {
         cpp_dec_float_50 val {"wrong"};
@@ -18,11 +22,32 @@ int main()
     catch (const std::runtime_error& error)
     {
         std::cout << "std::runtime_error. what():" << error.what() << "\n";
-        return 0;
     }
     catch (const std::invalid_argument& error)
     {
         std::cout << "std::invalid_argument. what():" << error.what() << "\n";
+        ++counter;
+    }
+
+    // Malformed expressions
+    try
+    {
+        cpp_dec_float_50 malformed {"3.4e1a2"};
+        std::cout << "no exception. val=" << malformed << "\n";
+    }
+    catch (const std::runtime_error& e)
+    {
+        std::cout << "std::runtime_error. what():" << e.what() << "\n";
+    }
+    catch (...)
+    {
+        ++counter;
+    }
+
+    if (counter != 0)
+    {
         return 1;
     }
+    
+    return 0;
 }

--- a/test/git_issue_499.cpp
+++ b/test/git_issue_499.cpp
@@ -1,0 +1,28 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright Matthew Borland 2022.
+// Distributed under the Boost Software License, Version 1.0. (See accompanying file
+// LICENSE or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <iostream>
+#include <boost/multiprecision/cpp_dec_float.hpp>
+
+using boost::multiprecision::cpp_dec_float_50;
+
+int main()
+{
+    try
+    {
+        cpp_dec_float_50 val {"wrong"};
+        std::cout << "no exception. val=" << val << "\n";
+    }
+    catch (const std::runtime_error& error)
+    {
+        std::cout << "std::runtime_error. what():" << error.what() << "\n";
+        return 0;
+    }
+    catch (const std::invalid_argument& error)
+    {
+        std::cout << "std::invalid_argument. what():" << error.what() << "\n";
+        return 1;
+    }
+}

--- a/test/git_issue_499.cpp
+++ b/test/git_issue_499.cpp
@@ -72,6 +72,34 @@ int main()
         ++counter;
     }
 
+    try
+    {
+        cpp_dec_float_50 val3{"12L3.4"};
+        std::cout << "no exception. val=" << val3 << "\n";
+    }
+    catch (const std::runtime_error& e)
+    {
+        std::cout << "std::runtime_error. what():" << e.what() << "\n";
+    }
+    catch (...)
+    {
+        ++counter;
+    }
+
+    try
+    {
+        cpp_dec_float_50 val4{"1.2f34"};
+        std::cout << "no exception. val=" << val4 << "\n";
+    }
+    catch (const std::runtime_error& e)
+    {
+        std::cout << "std::runtime_error. what():" << e.what() << "\n";
+    }
+    catch (...)
+    {
+        ++counter;
+    }
+
     if (counter != 0)
     {
         return 1;

--- a/test/git_issue_499.cpp
+++ b/test/git_issue_499.cpp
@@ -44,10 +44,38 @@ int main()
         ++counter;
     }
 
+    try
+    {
+        cpp_dec_float_50 val1{"12a3.4"};
+        std::cout << "no exception. val=" << val1 << "\n";
+    }
+    catch (const std::runtime_error& e)
+    {
+        std::cout << "std::runtime_error. what():" << e.what() << "\n";
+    }
+    catch (...)
+    {
+        ++counter;
+    }
+
+    try
+    {
+        cpp_dec_float_50 val2{"1.2a34"};
+        std::cout << "no exception. val=" << val2 << "\n";
+    }
+    catch (const std::runtime_error& e)
+    {
+        std::cout << "std::runtime_error. what():" << e.what() << "\n";
+    }
+    catch (...)
+    {
+        ++counter;
+    }
+
     if (counter != 0)
     {
         return 1;
     }
-    
+
     return 0;
 }


### PR DESCRIPTION
Replaced boost::lexical_cast with std::stol without updating the type of exception being caught