### PR TITLE
Fix for C4193: #pragma warning(pop): no matching '#pragma warning(push)'

### DIFF
--- a/include/boost/multiprecision/cpp_bin_float.hpp
+++ b/include/boost/multiprecision/cpp_bin_float.hpp
@@ -2146,9 +2146,7 @@ class numeric_limits<boost::multiprecision::number<boost::multiprecision::cpp_bi
       static number_type value = get_max();
       return value;
    }
-#ifdef BOOST_MSVC
-#pragma warning(pop)
-#endif
+
    static constexpr number_type lowest()
    {
       return -(max)();


### PR DESCRIPTION
There were 4 instances of push and 5 instances of pop.