### PR TITLE
Add missing contains_self overload.

### DIFF
--- a/include/boost/multiprecision/number.hpp
+++ b/include/boost/multiprecision/number.hpp
@@ -2174,6 +2174,15 @@ class number
       using child2_type = typename Exp::right_type ;
       return contains_self(e.left(), typename child0_type::arity()) || contains_self(e.middle(), typename child1_type::arity()) || contains_self(e.right(), typename child2_type::arity());
    }
+   template <class Exp>
+   BOOST_MP_FORCEINLINE BOOST_MP_CXX14_CONSTEXPR bool contains_self(const Exp& e, std::integral_constant<int, 4> const&) const noexcept
+   {
+      using child0_type = typename Exp::left_type;
+      using child1_type = typename Exp::left_middle_type;
+      using child2_type = typename Exp::right_middle_type;
+      using child3_type = typename Exp::right_type;
+      return contains_self(e.left(), typename child0_type::arity()) || contains_self(e.left_middle(), typename child1_type::arity()) || contains_self(e.right_middle(), typename child2_type::arity()) || contains_self(e.right(), typename child3_type::arity());
+   }
 
    // Test if the expression is a reference to *this:
    template <class Exp>

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -1218,6 +1218,7 @@ test-suite misc :
       [ run git_issue_277.cpp ]
       [ run git_issue_313.cpp ]
       [ run git_issue_488.cpp ]
+      [ run git_issue_506.cpp ]
       [ compile git_issue_98.cpp : 
          [ check-target-builds ../config//has_float128 : <define>TEST_FLOAT128 <source>quadmath : ]
          [ check-target-builds ../config//has_gmp : <define>TEST_GMP <source>gmp : ]

--- a/test/git_issue_506.cpp
+++ b/test/git_issue_506.cpp
@@ -1,0 +1,16 @@
+#include <boost/multiprecision/cpp_int.hpp>
+#include "test.hpp"
+
+using namespace std;
+namespace mp = boost::multiprecision;
+
+int main()
+{
+   mp::cpp_int ten(10);
+   mp::cpp_int ran(5);
+   mp::cpp_int pmod = mp::powm(ten, 5, 13) * 5;
+   BOOST_CHECK(pmod == (100000 % 13) * 5);
+   pmod = mp::powm(ten, 5, 13) * ran;
+   BOOST_CHECK(pmod == (100000 % 13) * 5);
+   return 0;
+}


### PR DESCRIPTION
Needed for powm.
Fixes https://github.com/boostorg/multiprecision/issues/506.