### PR TITLE
Add missing copyright notice

### DIFF
--- a/test/git_issue_506.cpp
+++ b/test/git_issue_506.cpp
@@ -1,3 +1,8 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright 2022 John Maddock. Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
 #include <boost/multiprecision/cpp_int.hpp>
 #include "test.hpp"
 


### PR DESCRIPTION
CircleCI currently complains about missing license and copyright notice. See:
https://app.circleci.com/pipelines/github/boostorg/multiprecision/1188/workflows/e429bd30-7c99-4f22-9405-3c5bbd0ed348/jobs/4646
