### PR TITLE
Non-functional adaptions prepare double-float

### DIFF
--- a/include/boost/multiprecision/cpp_dec_float.hpp
+++ b/include/boost/multiprecision/cpp_dec_float.hpp
@@ -3653,7 +3653,7 @@ struct precision<boost::multiprecision::number<boost::multiprecision::cpp_dec_fl
    static constexpr std::int32_t cpp_dec_float_digits10 = boost::multiprecision::cpp_dec_float<Digits10, ExponentType, Allocator>::cpp_dec_float_digits10;
 
    using precision_type = typename Policy::precision_type                           ;
-   using digits_2 = digits2<((cpp_dec_float_digits10 + 1LL) * 1000LL) / 301LL>;
+   using digits_2 = digits2<static_cast<int>(((cpp_dec_float_digits10 + 1LL) * 1000LL) / 301LL)>;
    using type = typename std::conditional<
        ((digits_2::value <= precision_type::value) || (Policy::precision_type::value <= 0)),
        // Default case, full precision for RealType:

--- a/include/boost/multiprecision/detail/float_string_cvt.hpp
+++ b/include/boost/multiprecision/detail/float_string_cvt.hpp
@@ -160,12 +160,12 @@ std::string convert_to_string(Backend b, std::streamsize digits, std::ios_base::
             // Bankers rounding:
             if ((*result.rbegin() - '0') & 1)
             {
-               round_string_up_at(result, result.size() - 1, expon);
+               round_string_up_at(result, static_cast<std::ptrdiff_t>(result.size() - 1u), expon);
             }
          }
          else if (cdigit >= 5)
          {
-            round_string_up_at(result, result.size() - 1, expon);
+            round_string_up_at(result, static_cast<std::ptrdiff_t>(result.size() - 1u), expon);
          }
       }
       eval_floor(t, b);
@@ -174,7 +174,7 @@ std::string convert_to_string(Backend b, std::streamsize digits, std::ios_base::
          // Input is an integer, sometimes we get a result which is not an integer here as a result of printing too
          // many digits, so lets round if required:
          round_string_up_at(result, expon + 1, expon);
-         result.erase(expon + 1);
+         result.erase(static_cast<std::string::size_type>(expon + 1));
       }
    }
    while ((static_cast<std::streamsize>(result.size()) > digits) && (result.size() != 0U))

--- a/include/boost/multiprecision/detail/functions/constants.hpp
+++ b/include/boost/multiprecision/detail/functions/constants.hpp
@@ -207,7 +207,7 @@ void calc_pi(T& result, unsigned digits)
          break;
       if (neg)
          result.negate();
-      eval_ldexp(result, result, k - 1);
+      eval_ldexp(result, result, static_cast<int>(k - 1u));
       eval_subtract(D, result);
       ++k;
       eval_ldexp(lim, lim, 1);

--- a/include/boost/multiprecision/detail/functions/pow.hpp
+++ b/include/boost/multiprecision/detail/functions/pow.hpp
@@ -116,7 +116,7 @@ void hyp0F0(T& H0F0, const T& x)
    eval_add(H0F0, x_pow_n_div_n_fact, ui_type(1));
 
    T lim;
-   eval_ldexp(lim, H0F0, 1 - tol);
+   eval_ldexp(lim, H0F0, static_cast<int>(1L - tol));
    if (eval_get_sign(lim) < 0)
       lim.negate();
 

--- a/test/test_arithmetic.hpp
+++ b/test/test_arithmetic.hpp
@@ -1483,14 +1483,60 @@ void test_float_ops(const std::integral_constant<int, boost::multiprecision::num
    BOOST_CHECK_EQUAL(r, boost::math::pow<2>(3.25));
    r = pow(v, 3);
    BOOST_CHECK_EQUAL(r, boost::math::pow<3>(3.25));
-   r = pow(v, 4);
-   BOOST_CHECK_EQUAL(r, boost::math::pow<4>(3.25));
-   r = pow(v, 5);
-   BOOST_CHECK_EQUAL(r, boost::math::pow<5>(3.25));
-   r = pow(v, 6);
-   BOOST_CHECK_EQUAL(r, boost::math::pow<6>(3.25));
-   r = pow(v, 25);
-   BOOST_CHECK_EQUAL(r, boost::math::pow<25>(Real(3.25)));
+
+   BOOST_IF_CONSTEXPR(std::numeric_limits<Real>::digits10 > 11)
+   {
+      // (13/4)^4
+      // 28561 / 256
+      // 111.56640625
+      r = pow(v, 4);
+      BOOST_CHECK_EQUAL(r, boost::math::pow<4>(Real(3.25)));
+   }
+
+   BOOST_IF_CONSTEXPR(std::numeric_limits<Real>::digits10 > 13)
+   {
+      // (13/4)^5
+      // 371293 / 1024
+      // 362.5908203125
+      r = pow(v, 5);
+      BOOST_CHECK_EQUAL(r, boost::math::pow<5>(Real(3.25)));
+   }
+
+   BOOST_IF_CONSTEXPR(std::numeric_limits<Real>::digits10 > 16)
+   {
+      // (13/4)^6
+      // 4826809 / 4096
+      // 1178.420166015625
+      r = pow(v, 6);
+      BOOST_CHECK_EQUAL(r, boost::math::pow<6>(Real(3.25)));
+   }
+
+   BOOST_IF_CONSTEXPR(std::numeric_limits<Real>::digits10 > 26)
+   {
+      // (13/4)^10
+      // 137858491849 / 1048576
+      // 131472.10297489166259765625
+      r = pow(v, 10);
+      BOOST_CHECK_EQUAL(r, boost::math::pow<10>(Real(3.25)));
+   }
+
+   BOOST_IF_CONSTEXPR(std::numeric_limits<Real>::digits10 > 38)
+   {
+      // (13/4)^15
+      // 51185893014090757 / 1073741824
+      // 47670577.665875439532101154327392578125
+      r = pow(v, 15);
+      BOOST_CHECK_EQUAL(r, boost::math::pow<15>(Real(3.25)));
+   }
+
+   BOOST_IF_CONSTEXPR(std::numeric_limits<Real>::digits10 > 63)
+   {
+      // (13/4)^25
+      // 7056410014866816666030739693 / 1125899906842624
+      // 6267351095760.54642313524184960016327750054188072681427001953125
+      r = pow(v, 25);
+      BOOST_CHECK_EQUAL(r, boost::math::pow<25>(Real(3.25)));
+   }
    #endif
 
 #ifndef BOOST_NO_EXCEPTIONS

--- a/test/test_sqrt.cpp
+++ b/test/test_sqrt.cpp
@@ -1,6 +1,7 @@
 ///////////////////////////////////////////////////////////////
-//  Copyright Christopher Kormanyos 2002 - 2011.
-//  Copyright 2011 John Maddock. Distributed under the Boost
+//  Copyright 2011 John Maddock.
+//  Copyright Christopher Kormanyos 2002 - 2011, 2021 - 2023.
+//  Distributed under the Boost
 //  Software License, Version 1.0. (See accompanying file
 //  LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt
 //
@@ -176,6 +177,9 @@ void test()
       {
          max_err = err;
       }
+
+      if(k == 0u)
+         BOOST_TEST(val == 0);
    }
    std::cout << "Max error was: " << max_err << std::endl;
 #if defined(BOOST_INTEL) && defined(TEST_FLOAT128)


### PR DESCRIPTION
The purpose of this pull request is to  handle some non-functional test-adaptions that I found necessary while preparing the `double-float` work.

The big change to the arithmetic tests handles a case of the `pow()` function when low digit counts are being tested. It only makes sense to test the digits that are actually present in the type.

The change in the `sqrt()` test includes explicit check of `sqrt(0) == 0`, which should be no problem.

Then I made a few casts that should be correct but hopefully meaningless regarding functionality.

Cc: @jzmaddock and @mborland 