### PR TITLE
Enable GHA to kill in progress builds on new push

### DIFF
--- a/.github/workflows/multiprecision.yml
+++ b/.github/workflows/multiprecision.yml
@@ -14,6 +14,11 @@ on:
   pull_request:
   release:
     types: [published, created, edited]
+
+concurrency:
+   group: ${{ github.head_ref || github.run_id }}
+   cancel-in-progress: true
+
 jobs:
   ubuntu-jammy:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
If a new push is made on a branch/PR that is already in the CI cycle kill the existing build to prioritize the new push.