### PR TITLE
Fix redundant redeclaration when build with C++ >= 17.

### DIFF
--- a/include/boost/multiprecision/cpp_int/literals.hpp
+++ b/include/boost/multiprecision/cpp_int/literals.hpp
@@ -212,8 +212,10 @@ struct make_backend_from_pack
    static constexpr B value = p;
 };
 
+#if !defined(__cpp_inline_variables)
 template <class Pack, class B>
 constexpr B make_backend_from_pack<Pack, B>::value;
+#endif
 
 template <unsigned Digits>
 struct signed_cpp_int_literal_result_type


### PR DESCRIPTION
This fixes the following error when using C++ >= 17 and gcc 11:

```
/data/mwrep/res/osp/Boost/21-0-0-9/include/boost/multiprecision/cpp_int/literals.hpp:220:13: error: redundant redeclaration of 'constexpr' static data member 'boost::multiprecision::literals::detail::make_backend_from_pack<Pack, B>::value' [-Werror=deprecated]
```