### PR TITLE
Make expression templates implicitly convert...

### DIFF
--- a/include/boost/multiprecision/detail/number_base.hpp
+++ b/include/boost/multiprecision/detail/number_base.hpp
@@ -600,10 +600,20 @@ struct expression<tag, Arg1, void, void, void>
    template <class T
 #ifndef __SUNPRO_CC
              ,
-             typename std::enable_if<!is_number<T>::value && !std::is_convertible<result_type, T const&>::value && std::is_constructible<T, result_type>::value, int>::type = 0
+             typename std::enable_if<!is_number<T>::value && !std::is_convertible<result_type, T const&>::value && std::is_constructible<T, result_type>::value && std::is_copy_constructible<T>::value && std::is_destructible<T>::value, int>::type = 0
 #endif
              >
    explicit BOOST_MP_CXX14_CONSTEXPR operator T() const
+   {
+      return static_cast<T>(static_cast<result_type>(*this));
+   }
+   template <class T
+#ifndef __SUNPRO_CC
+             ,
+             typename std::enable_if<!is_number<T>::value && std::is_convertible<result_type, T const&>::value && std::is_copy_constructible<T>::value && std::is_destructible<T>::value, int>::type = 0
+#endif
+             >
+   BOOST_MP_CXX14_CONSTEXPR operator T() const
    {
       return static_cast<T>(static_cast<result_type>(*this));
    }
@@ -751,10 +761,20 @@ struct expression<terminal, Arg1, void, void, void>
    template <class T
 #ifndef __SUNPRO_CC
              ,
-             typename std::enable_if<!is_number<T>::value && !std::is_convertible<result_type, T const&>::value && std::is_constructible<T, result_type>::value, int>::type = 0
+             typename std::enable_if<!is_number<T>::value && !std::is_convertible<result_type, T const&>::value && std::is_constructible<T, result_type>::value && std::is_copy_constructible<T>::value && std::is_destructible<T>::value, int>::type = 0
 #endif
              >
    explicit BOOST_MP_CXX14_CONSTEXPR operator T() const
+   {
+      return static_cast<T>(static_cast<result_type>(*this));
+   }
+   template <class T
+#ifndef __SUNPRO_CC
+      ,
+      typename std::enable_if<!is_number<T>::value&& std::is_convertible<result_type, T const&>::value && std::is_copy_constructible<T>::value && std::is_destructible<T>::value, int>::type = 0
+#endif
+   >
+   BOOST_MP_CXX14_CONSTEXPR operator T() const
    {
       return static_cast<T>(static_cast<result_type>(*this));
    }
@@ -907,10 +927,20 @@ struct expression<tag, Arg1, Arg2, void, void>
    template <class T
 #ifndef __SUNPRO_CC
              ,
-             typename std::enable_if<!is_number<T>::value && !std::is_convertible<result_type, T const&>::value && std::is_constructible<T, result_type>::value, int>::type = 0
+             typename std::enable_if<!is_number<T>::value && !std::is_convertible<result_type, T const&>::value && std::is_constructible<T, result_type>::value && std::is_copy_constructible<T>::value && std::is_destructible<T>::value, int>::type = 0
 #endif
              >
    explicit BOOST_MP_CXX14_CONSTEXPR operator T() const
+   {
+      return static_cast<T>(static_cast<result_type>(*this));
+   }
+   template <class T
+#ifndef __SUNPRO_CC
+      ,
+      typename std::enable_if<!is_number<T>::value&& std::is_convertible<result_type, T const&>::value&& std::is_copy_constructible<T>::value&& std::is_destructible<T>::value, int>::type = 0
+#endif
+   >
+   BOOST_MP_CXX14_CONSTEXPR operator T() const
    {
       return static_cast<T>(static_cast<result_type>(*this));
    }
@@ -1073,10 +1103,20 @@ struct expression<tag, Arg1, Arg2, Arg3, void>
    template <class T
 #ifndef __SUNPRO_CC
              ,
-             typename std::enable_if<!is_number<T>::value && !std::is_convertible<result_type, T const&>::value && std::is_constructible<T, result_type>::value, int>::type = 0
+             typename std::enable_if<!is_number<T>::value && !std::is_convertible<result_type, T const&>::value && std::is_constructible<T, result_type>::value && std::is_copy_constructible<T>::value && std::is_destructible<T>::value, int>::type = 0
 #endif
              >
    explicit BOOST_MP_CXX14_CONSTEXPR operator T() const
+   {
+      return static_cast<T>(static_cast<result_type>(*this));
+   }
+   template <class T
+#ifndef __SUNPRO_CC
+      ,
+      typename std::enable_if<!is_number<T>::value&& std::is_convertible<result_type, T const&>::value && std::is_copy_constructible<T>::value && std::is_destructible<T>::value, int>::type = 0
+#endif
+   >
+   BOOST_MP_CXX14_CONSTEXPR operator T() const
    {
       return static_cast<T>(static_cast<result_type>(*this));
    }
@@ -1247,10 +1287,20 @@ struct expression
    template <class T
 #ifndef __SUNPRO_CC
              ,
-             typename std::enable_if<!is_number<T>::value && !std::is_convertible<result_type, T const&>::value && std::is_constructible<T, result_type>::value, int>::type = 0
+             typename std::enable_if<!is_number<T>::value && !std::is_convertible<result_type, T const&>::value && std::is_constructible<T, result_type>::value && std::is_copy_constructible<T>::value && std::is_destructible<T>::value, int>::type = 0
 #endif
              >
    explicit BOOST_MP_CXX14_CONSTEXPR operator T() const
+   {
+      return static_cast<T>(static_cast<result_type>(*this));
+   }
+   template <class T
+#ifndef __SUNPRO_CC
+      ,
+      typename std::enable_if<!is_number<T>::value&& std::is_convertible<result_type, T const&>::value && std::is_copy_constructible<T>::value && std::is_destructible<T>::value, int>::type = 0
+#endif
+   >
+   BOOST_MP_CXX14_CONSTEXPR operator T() const
    {
       return static_cast<T>(static_cast<result_type>(*this));
    }

--- a/include/boost/multiprecision/detail/number_base.hpp
+++ b/include/boost/multiprecision/detail/number_base.hpp
@@ -607,6 +607,7 @@ struct expression<tag, Arg1, void, void, void>
    {
       return static_cast<T>(static_cast<result_type>(*this));
    }
+#if BOOST_CXX_VERSION >= 201703L
    template <class T
 #ifndef __SUNPRO_CC
              ,
@@ -617,6 +618,7 @@ struct expression<tag, Arg1, void, void, void>
    {
       return static_cast<T>(static_cast<result_type>(*this));
    }
+#endif
    BOOST_MP_FORCEINLINE explicit BOOST_MP_CXX14_CONSTEXPR operator bool() const
    {
       result_type r(*this);
@@ -768,6 +770,7 @@ struct expression<terminal, Arg1, void, void, void>
    {
       return static_cast<T>(static_cast<result_type>(*this));
    }
+#if BOOST_CXX_VERSION >= 201703L
    template <class T
 #ifndef __SUNPRO_CC
       ,
@@ -778,6 +781,7 @@ struct expression<terminal, Arg1, void, void, void>
    {
       return static_cast<T>(static_cast<result_type>(*this));
    }
+#endif
    BOOST_MP_FORCEINLINE explicit BOOST_MP_CXX14_CONSTEXPR operator bool() const
    {
       result_type r(*this);
@@ -934,16 +938,18 @@ struct expression<tag, Arg1, Arg2, void, void>
    {
       return static_cast<T>(static_cast<result_type>(*this));
    }
+#if BOOST_CXX_VERSION >= 201703L
    template <class T
 #ifndef __SUNPRO_CC
       ,
-      typename std::enable_if<!is_number<T>::value&& std::is_convertible<result_type, T const&>::value&& std::is_copy_constructible<T>::value&& std::is_destructible<T>::value, int>::type = 0
+      typename std::enable_if<!is_number<T>::value && std::is_convertible<result_type, T const&>::value && std::is_copy_constructible<T>::value && std::is_destructible<T>::value, int>::type = 0
 #endif
    >
    BOOST_MP_CXX14_CONSTEXPR operator T() const
    {
       return static_cast<T>(static_cast<result_type>(*this));
    }
+#endif
    BOOST_MP_FORCEINLINE explicit BOOST_MP_CXX14_CONSTEXPR operator bool() const
    {
       result_type r(*this);
@@ -1110,6 +1116,7 @@ struct expression<tag, Arg1, Arg2, Arg3, void>
    {
       return static_cast<T>(static_cast<result_type>(*this));
    }
+#if BOOST_CXX_VERSION >= 201703L
    template <class T
 #ifndef __SUNPRO_CC
       ,
@@ -1120,6 +1127,7 @@ struct expression<tag, Arg1, Arg2, Arg3, void>
    {
       return static_cast<T>(static_cast<result_type>(*this));
    }
+#endif
    BOOST_MP_FORCEINLINE explicit BOOST_MP_CXX14_CONSTEXPR operator bool() const
    {
       result_type r(*this);
@@ -1294,6 +1302,7 @@ struct expression
    {
       return static_cast<T>(static_cast<result_type>(*this));
    }
+#if BOOST_CXX_VERSION >= 201703L
    template <class T
 #ifndef __SUNPRO_CC
       ,
@@ -1304,6 +1313,7 @@ struct expression
    {
       return static_cast<T>(static_cast<result_type>(*this));
    }
+#endif
    BOOST_MP_FORCEINLINE explicit BOOST_MP_CXX14_CONSTEXPR operator bool() const
    {
       result_type r(*this);

--- a/include/boost/multiprecision/detail/number_base.hpp
+++ b/include/boost/multiprecision/detail/number_base.hpp
@@ -102,6 +102,18 @@
 #  define BOOST_CXX14_CONSTEXPR_IF_DETECTION constexpr
 #endif
 
+#if BOOST_CXX_VERSION < 201703L
+#  define BOOST_MP_NO_ET_IMPLICIT_CONVERSIONS
+#endif
+
+#if defined(__MINGW32__) && (defined(__GNUC__) && (__GNUC__ < 9)) && !defined(__clang__) && !defined(BOOST_MP_NO_ET_IMPLICIT_CONVERSIONS)
+//
+// For some reason gcc-8 on Mingw (but not Linux for example) has a problem with overload resolution:
+//
+#  define BOOST_MP_NO_ET_IMPLICIT_CONVERSIONS
+#endif
+
+
 #ifdef BOOST_MSVC
 #pragma warning(push)
 #pragma warning(disable : 6326)
@@ -607,7 +619,7 @@ struct expression<tag, Arg1, void, void, void>
    {
       return static_cast<T>(static_cast<result_type>(*this));
    }
-#if BOOST_CXX_VERSION >= 201703L
+#ifndef BOOST_MP_NO_ET_IMPLICIT_CONVERSIONS
    template <class T
 #ifndef __SUNPRO_CC
              ,
@@ -770,7 +782,7 @@ struct expression<terminal, Arg1, void, void, void>
    {
       return static_cast<T>(static_cast<result_type>(*this));
    }
-#if BOOST_CXX_VERSION >= 201703L
+#ifndef BOOST_MP_NO_ET_IMPLICIT_CONVERSIONS
    template <class T
 #ifndef __SUNPRO_CC
       ,
@@ -938,7 +950,7 @@ struct expression<tag, Arg1, Arg2, void, void>
    {
       return static_cast<T>(static_cast<result_type>(*this));
    }
-#if BOOST_CXX_VERSION >= 201703L
+#ifndef BOOST_MP_NO_ET_IMPLICIT_CONVERSIONS
    template <class T
 #ifndef __SUNPRO_CC
       ,
@@ -1116,7 +1128,7 @@ struct expression<tag, Arg1, Arg2, Arg3, void>
    {
       return static_cast<T>(static_cast<result_type>(*this));
    }
-#if BOOST_CXX_VERSION >= 201703L
+#ifndef BOOST_MP_NO_ET_IMPLICIT_CONVERSIONS
    template <class T
 #ifndef __SUNPRO_CC
       ,
@@ -1302,7 +1314,7 @@ struct expression
    {
       return static_cast<T>(static_cast<result_type>(*this));
    }
-#if BOOST_CXX_VERSION >= 201703L
+#ifndef BOOST_MP_NO_ET_IMPLICIT_CONVERSIONS
    template <class T
 #ifndef __SUNPRO_CC
       ,

--- a/include/boost/multiprecision/detail/standalone_config.hpp
+++ b/include/boost/multiprecision/detail/standalone_config.hpp
@@ -107,6 +107,14 @@ namespace boost { namespace multiprecision {
 
 #endif
 
+#ifndef BOOST_CXX_VERSION
+#ifdef _MSVC_LANG
+#  define BOOST_CXX_VERSION _MSVC_LANG
+#else
+#  define BOOST_CXX_VERSION __cplusplus
+#endif
+#endif
+
 #endif // BOOST_MP_STANDALONE
 
 // Workarounds for numeric limits on old compilers

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -1231,6 +1231,7 @@ test-suite misc :
       [ run git_issue_509.cpp : : : [ requires cpp_lib_bit_cast ] ]
       [ run git_issue_526.cpp ]
       [ run git_issue_540.cpp ]
+      [ run git_issue_541.cpp ]
       [ compile git_issue_98.cpp : 
          [ check-target-builds ../config//has_float128 : <define>TEST_FLOAT128 <source>quadmath : ]
          [ check-target-builds ../config//has_gmp : <define>TEST_GMP <source>gmp : ]

--- a/test/git_issue_541.cpp
+++ b/test/git_issue_541.cpp
@@ -22,12 +22,15 @@ void f(F) {}
 
 int main()
 {
+#if BOOST_CXX_VERSION >= 201703L
    //
    // An expression template should be implicitly convertible to
-   // anything that the number type is:
+   // anything that the number type is, we only have a fix for this
+   // in C++17 and later which is super annoying, but the way that it is...
    //
    Float f1{2};
    f(f1 * 2);
    f(2 + f1);
    F ff = f1 * 2;
+#endif
 }

--- a/test/git_issue_541.cpp
+++ b/test/git_issue_541.cpp
@@ -22,7 +22,7 @@ void f(F) {}
 
 int main()
 {
-#if BOOST_CXX_VERSION >= 201703L
+#ifndef BOOST_MP_NO_ET_IMPLICIT_CONVERSIONS
    //
    // An expression template should be implicitly convertible to
    // anything that the number type is, we only have a fix for this

--- a/test/git_issue_541.cpp
+++ b/test/git_issue_541.cpp
@@ -1,0 +1,33 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright 2023 John Maddock. Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/multiprecision/cpp_dec_float.hpp>
+#include <iostream>
+
+using Float = boost::multiprecision::cpp_dec_float_50;
+
+struct F
+{
+   Float f;
+   F(const Float& f)
+       : f(f)
+   {}
+};
+
+void f(F) {}
+
+
+
+int main()
+{
+   //
+   // An expression template should be implicitly convertible to
+   // anything that the number type is:
+   //
+   Float f1{2};
+   f(f1 * 2);
+   f(2 + f1);
+   F ff = f1 * 2;
+}


### PR DESCRIPTION
to types that the number type will also convert to. Fixes: https://github.com/boostorg/multiprecision/issues/541.