### PR TITLE
Trivial syntax and MSVC 14_0 std latest in CI

### DIFF
--- a/.github/workflows/multiprecision.yml
+++ b/.github/workflows/multiprecision.yml
@@ -446,7 +446,7 @@ jobs:
       fail-fast: false
       matrix:
         toolset: [ msvc-14.0 ]
-        standard: [ 14, 17 ]
+        standard: [ 14, latest ]
         suite: [ github_ci_block_1, github_ci_block_2 ]
     steps:
       - uses: actions/checkout@v3

--- a/include/boost/multiprecision/cpp_int/bitwise.hpp
+++ b/include/boost/multiprecision/cpp_int/bitwise.hpp
@@ -436,12 +436,12 @@ inline BOOST_MP_CXX14_CONSTEXPR void left_shift_generic(Int& result, double_limb
          ++i;
       }
    }
-   for (; rs - i >= 2 + offset; ++i)
+   for (; rs - i >= static_cast<std::size_t>(static_cast<std::size_t>(2u) + offset); ++i)
    {
       pr[rs - 1 - i] = pr[rs - 1 - i - offset] << shift;
       pr[rs - 1 - i] |= pr[rs - 2 - i - offset] >> (Int::limb_bits - shift);
    }
-   if (rs - i >= 1 + offset)
+   if (rs - i >= static_cast<std::size_t>(static_cast<std::size_t>(1u) + offset))
    {
       pr[rs - 1 - i] = pr[rs - 1 - i - offset] << shift;
       ++i;

--- a/include/boost/multiprecision/cpp_int/divide.hpp
+++ b/include/boost/multiprecision/cpp_int/divide.hpp
@@ -552,8 +552,14 @@ eval_modulus(
     const limb_type                                                             mod)
 {
    const std::ptrdiff_t n = static_cast<std::ptrdiff_t>(a.size());
-   const double_limb_type two_n_mod = static_cast<limb_type>(1u) + (~static_cast<limb_type>(0u) - mod) % mod;
-   limb_type              res       = a.limbs()[n - 1] % mod;
+
+   const double_limb_type two_n_mod =
+      static_cast<double_limb_type>
+      (
+         static_cast<double_limb_type>(1u) + static_cast<limb_type>(static_cast<limb_type>(~static_cast<limb_type>(0u) - mod) % mod)
+      );
+
+   limb_type res = a.limbs()[n - 1] % mod;
 
    for (std::ptrdiff_t i = n - 2; i >= 0; --i)
       res = static_cast<limb_type>(static_cast<double_limb_type>(static_cast<double_limb_type>(res * two_n_mod) + a.limbs()[i]) % mod);


### PR DESCRIPTION
The purpose of this PR is to handle the trivial syntax issues mentioned in #563. It also tries to use the _latest_ standard on MSVC 14.0 in CI, expected to correspond to some kind of C++17 variant, as mentioned in #564.