### PR TITLE
Prelim fix issue586 (if none better found)

### DIFF
--- a/include/boost/multiprecision/detail/functions/trunc.hpp
+++ b/include/boost/multiprecision/detail/functions/trunc.hpp
@@ -23,23 +23,16 @@ namespace impl {
 template <typename T>
 inline T trunc BOOST_PREVENT_MACRO_SUBSTITUTION (const T arg)
 {
-    using std::floor;
+    if (arg > 0)
+    {
+       using std::floor;
+
+       return floor(arg);
+    }
+
     using std::ceil;
 
-    T t { };
-
-    if (arg > T(0))
-    {
-        t = floor(arg);
-    }
-    else
-    {
-        t = ceil(arg);
-    }
-
-    return t;
-}
-
+    return ceil(arg);}
 } // namespace impl
 
 #ifdef BOOST_MP_MATH_AVAILABLE

--- a/include/boost/multiprecision/detail/functions/trunc.hpp
+++ b/include/boost/multiprecision/detail/functions/trunc.hpp
@@ -26,7 +26,18 @@ inline T trunc BOOST_PREVENT_MACRO_SUBSTITUTION (const T arg)
     using std::floor;
     using std::ceil;
 
-    return (arg > 0) ? floor(arg) : ceil(arg);
+    T t { };
+
+    if (arg > T(0))
+    {
+        t = floor(arg);
+    }
+    else
+    {
+        t = ceil(arg);
+    }
+
+    return t;
 }
 
 } // namespace impl


### PR DESCRIPTION
The purpose of this PR is to provide a minimalistic fix to #586.

In that issue, we see a phenomenon that may require conversion to number-wrap or non-wrapped type detected in overloads of `trunc` and `lltrunc`.

If no better fix is found in this releasce cycle, then this _does the trick_.

Cc: @jzmaddock John take a look if you find better...

Cc: @mborland Standalone with/without the presence of `Math`.

Cc: @radj307