### PR TITLE
Add CodeCov badge for develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,20 @@
 Boost Multiprecision Library
 ============================
 
->ANNOUNCEMENT: This library now requires a compliant C++14 compiler.
+>ANNOUNCEMENT: This library requires a compliant C++14 compiler.
 
 |                  |  Master  |   Develop   |
 |------------------|----------|-------------|
 | Drone            | [![Build Status](https://drone.cpp.al/api/badges/boostorg/multiprecision/status.svg?ref=refs/heads/master)](https://drone.cpp.al/boostorg/multiprecision)          | [![Build Status](https://drone.cpp.al/api/badges/boostorg/multiprecision/status.svg)](https://drone.cpp.al/boostorg/multiprecision) |
 | Github Actions   | [![Build Status](https://github.com/boostorg/multiprecision/workflows/multiprecision/badge.svg?branch=master)](https://github.com/boostorg/multiprecision/actions) | [![Build Status](https://github.com/boostorg/multiprecision/workflows/multiprecision/badge.svg?branch=develop)](https://github.com/boostorg/multiprecision/actions) |
-| Codecov          | [![codecov](https://codecov.io/gh/boostorg/multiprecision/branch/master/graph/badge.svg)](https://codecov.io/gh/boostorg/multiprecision/branch/master)             | [![codecov](https://codecov.io/gh/boostorg/multiprecision/branch/develop/graph/badge.svg)]
+| Codecov          | [![codecov](https://codecov.io/gh/boostorg/multiprecision/branch/master/graph/badge.svg)](https://codecov.io/gh/boostorg/multiprecision/branch/master)             | [![codecov](https://codecov.io/gh/boostorg/multiprecision/branch/develop/graph/badge.svg)](https://codecov.io/gh/boostorg/multiprecision/branch/develop) |
 
- The Multiprecision Library provides integer, rational, floating-point, complex and interval number types in C++ that have more range and 
- precision than C++'s ordinary built-in types. The big number types in Multiprecision can be used with a wide selection of basic 
- mathematical operations, elementary transcendental functions as well as the functions in Boost.Math. The Multiprecision types can 
- also interoperate with the built-in types in C++ using clearly defined conversion rules. This allows Boost.Multiprecision to be 
- used for all kinds of mathematical calculations involving integer, rational and floating-point types requiring extended range and precision.
+
+The Multiprecision Library provides integer, rational, floating-point, complex and interval number types in C++ that have more range and 
+precision than C++'s ordinary built-in types. The big number types in Multiprecision can be used with a wide selection of basic 
+mathematical operations, elementary transcendental functions as well as the functions in Boost.Math. The Multiprecision types can 
+also interoperate with the built-in types in C++ using clearly defined conversion rules. This allows Boost.Multiprecision to be 
+used for all kinds of mathematical calculations involving integer, rational and floating-point types requiring extended range and precision.
 
 Multiprecision consists of a generic interface to the mathematics of large numbers as well as a selection of big number back ends, with 
 support for integer, rational and floating-point types. Boost.Multiprecision provides a selection of back ends provided off-the-rack in 
@@ -25,6 +26,43 @@ Depending upon the number type, precision may be arbitrarily large (limited only
 for better performance than naive user-defined types. 
 
 The full documentation is available on [boost.org](http://www.boost.org/doc/libs/release/libs/multiprecision/index.html).
+
+## Using Multiprecision ##
+
+<p align="center">
+  <a href="https://godbolt.org/z/546vnEjvh" alt="godbolt">
+    <img src="https://img.shields.io/badge/try%20it%20on-godbolt-green" /></a>
+</p>
+
+In the following example, we use Multiprecision's Boost-licensed binary
+floating-point backend type `cpp_bin_float` to compute ${\sim}100$ decimal digits of
+
+$$ sqrt{\pi} = {\Gamma}{\left(}{\frac{1}{2}}{\right)} {\approx} 1.772453850905516027298{\ldots}~, $$
+
+where we also observe that Multiprecision can seemlesly interoperate with
+[Boost.Math](https://github.com/boostorg/math).
+
+```
+#include <iomanip>
+#include <iostream>
+
+#include <boost/multiprecision/cpp_bin_float.hpp>
+#include <boost/math/special_functions/gamma.hpp>
+
+auto main() -> int
+{
+  using big_float_type = boost::multiprecision::cpp_bin_float_100;
+
+  const big_float_type sqrt_pi { sqrt(boost::math::constants::pi<big_float_type>()) };
+
+  const big_float_type one_half { big_float_type(1) / 2 };
+
+  const big_float_type gamma_half { boost::math::tgamma(one_half) }; 
+
+  std::cout << std::setprecision(std::numeric_limits<big_float_type>::digits10) << "sqrt_pi   : " << sqrt_pi    << std::endl;
+  std::cout << std::setprecision(std::numeric_limits<big_float_type>::digits10) << "gamma_half: " << gamma_half << std::endl;
+}
+```
 
 ## Standalone ##
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Boost Multiprecision Library
 |------------------|----------|-------------|
 | Drone            | [![Build Status](https://drone.cpp.al/api/badges/boostorg/multiprecision/status.svg?ref=refs/heads/master)](https://drone.cpp.al/boostorg/multiprecision)          | [![Build Status](https://drone.cpp.al/api/badges/boostorg/multiprecision/status.svg)](https://drone.cpp.al/boostorg/multiprecision) |
 | Github Actions   | [![Build Status](https://github.com/boostorg/multiprecision/workflows/multiprecision/badge.svg?branch=master)](https://github.com/boostorg/multiprecision/actions) | [![Build Status](https://github.com/boostorg/multiprecision/workflows/multiprecision/badge.svg?branch=develop)](https://github.com/boostorg/multiprecision/actions) |
-| Code Coverage    |          | [![codecov](https://codecov.io/gh/boostorg/multiprecision/graph/badge.svg?token=SDDBym7Pc9)](https://codecov.io/gh/boostorg/multiprecision) |
+| Codecov          | [![codecov](https://codecov.io/gh/boostorg/multiprecision/branch/master/graph/badge.svg)](https://codecov.io/gh/boostorg/multiprecision/branch/master)             | [![codecov](https://codecov.io/gh/boostorg/multiprecision/branch/develop/graph/badge.svg)]
 
  The Multiprecision Library provides integer, rational, floating-point, complex and interval number types in C++ that have more range and 
  precision than C++'s ordinary built-in types. The big number types in Multiprecision can be used with a wide selection of basic 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The full documentation is available on [boost.org](http://www.boost.org/doc/libs
 In the following example, we use Multiprecision's Boost-licensed binary
 floating-point backend type `cpp_bin_float` to compute ${\sim}100$ decimal digits of
 
-$$sqrt{\pi} = \Gamma \left( \frac{1}{2} \right) {\approx}1.772453850905516027298{\ldots}\text{,}$$
+$$\sqrt{\pi} = \Gamma \left( \frac{1}{2} \right)~{\approx}~1.772453850905516027298{\ldots}\text{,}$$
 
 where we also observe that Multiprecision can seemlesly interoperate with
 [Boost.Math](https://github.com/boostorg/math).

--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@ Boost Multiprecision Library
 
 |                  |  Master  |   Develop   |
 |------------------|----------|-------------|
-| Drone            |  [![Build Status](https://drone.cpp.al/api/badges/boostorg/multiprecision/status.svg?ref=refs/heads/master)](https://drone.cpp.al/boostorg/multiprecision) | [![Build Status](https://drone.cpp.al/api/badges/boostorg/multiprecision/status.svg)](https://drone.cpp.al/boostorg/multiprecision) |
-| Github Actions | [![Build Status](https://github.com/boostorg/multiprecision/workflows/multiprecision/badge.svg?branch=master)](https://github.com/boostorg/multiprecision/actions) | [![Build Status](https://github.com/boostorg/multiprecision/workflows/multiprecision/badge.svg?branch=develop)](https://github.com/boostorg/multiprecision/actions) |
+| Drone            | [![Build Status](https://drone.cpp.al/api/badges/boostorg/multiprecision/status.svg?ref=refs/heads/master)](https://drone.cpp.al/boostorg/multiprecision)          | [![Build Status](https://drone.cpp.al/api/badges/boostorg/multiprecision/status.svg)](https://drone.cpp.al/boostorg/multiprecision) |
+| Github Actions   | [![Build Status](https://github.com/boostorg/multiprecision/workflows/multiprecision/badge.svg?branch=master)](https://github.com/boostorg/multiprecision/actions) | [![Build Status](https://github.com/boostorg/multiprecision/workflows/multiprecision/badge.svg?branch=develop)](https://github.com/boostorg/multiprecision/actions) |
+| Code Coverage    |          | [![codecov](https://codecov.io/gh/boostorg/multiprecision/graph/badge.svg?token=SDDBym7Pc9)](https://codecov.io/gh/boostorg/multiprecision) |
 
  The Multiprecision Library provides integer, rational, floating-point, complex and interval number types in C++ that have more range and 
  precision than C++'s ordinary built-in types. The big number types in Multiprecision can be used with a wide selection of basic 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The full documentation is available on [boost.org](http://www.boost.org/doc/libs
 In the following example, we use Multiprecision's Boost-licensed binary
 floating-point backend type `cpp_bin_float` to compute ${\sim}100$ decimal digits of
 
-$$ sqrt{\pi} = {\Gamma}{\left(}{\frac{1}{2}}{\right)} {\approx} 1.772453850905516027298{\ldots}~, $$
+$$sqrt{\pi} = \Gamma \left( \frac{1}{2} \right) {\approx}1.772453850905516027298{\ldots}\text{,}$$
 
 where we also observe that Multiprecision can seemlesly interoperate with
 [Boost.Math](https://github.com/boostorg/math).


### PR DESCRIPTION
Hi @jzmaddock and @mborland I hope you like this as much as I do. I would like quick access and clear visibility for the CodeCov achievements on the front cover ReadMe.

Can we do this? Do we really need table entries for develop/master? Or should i make a separate viewing area for a single CodeCov badge?