### PR TITLE
Complex Overloads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,12 @@ else()
 
 endif()
 
+if(BUILD_TESTING AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/test/CMakeLists.txt")
+
+  add_subdirectory(test)
+
+endif()
+
 # Only enable tests when we're the root project
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
 

--- a/include/boost/multiprecision/complex.hpp
+++ b/include/boost/multiprecision/complex.hpp
@@ -8,13 +8,14 @@
 
 #include <boost/multiprecision/detail/assert.hpp>
 #include <boost/multiprecision/traits/is_backend.hpp>
+#include <boost/multiprecision/cpp_bin_float.hpp>
 #include <complex>
 #include <cmath>
 
 namespace boost {
 namespace multiprecision {
-
-template <typename T, std::enable_if_t<detail::is_backend<T>::value, bool> = true>
+/*
+template <typename T>
 class complex
 {
 private:
@@ -22,69 +23,71 @@ private:
     T imag_;
 
 public:
-    constexpr complex() noexcept = default;
-    explicit constexpr complex(T real) noexcept : real_ {real}, imag_ {T{0}} {}
-    constexpr complex(T real, T imag) noexcept : real_ {real}, imag_ {imag} {}
-    constexpr complex& operator=(const complex<T>& rhs) = default;
+    complex() noexcept = default;
+    complex(T real) noexcept : real_ {real}, imag_ {T{0}} {}
+    complex(T real, T imag) noexcept : real_ {real}, imag_ {imag} {}
+    complex& operator=(const complex<T>& rhs)
+    {
+        real_ = rhs.real_;
+        imag_ = rhs.imag_;
+    }
 
-    constexpr T real() noexcept { return real_; }
-    constexpr T imag() noexcept { return imag_; }
+    T real() noexcept { return real_; }
+    T imag() noexcept { return imag_; }
 
-    constexpr complex<T> operator+() { return *this; }
-    constexpr complex<T> operator-() { return {-real_, -imag_}; }
+    complex<T> operator+() { return *this; }
+    complex<T> operator-() { return {-real_, -imag_}; }
 
-    friend constexpr complex<T> operator+(const complex<T>& lhs, const complex<T>& rhs) noexcept;
-    friend constexpr complex<T> operator-(const complex<T>& lhs, const complex<T>& rhs) noexcept;
-    friend constexpr complex<T> operator*(const complex<T>& lhs, const complex<T>& rhs) noexcept;
-    friend constexpr complex<T> operator/(const complex<T>& lhs, const complex<T>& rhs) noexcept;
+    friend complex<T> operator+(const complex<T>& lhs, const complex<T>& rhs) noexcept;
+    friend complex<T> operator-(const complex<T>& lhs, const complex<T>& rhs) noexcept;
+    friend complex<T> operator*(const complex<T>& lhs, const complex<T>& rhs) noexcept;
+    friend complex<T> operator/(const complex<T>& lhs, const complex<T>& rhs) noexcept;
 
-    constexpr complex& operator+=(const complex<T>& rhs) noexcept
+    complex& operator+=(const complex<T>& rhs) noexcept
     {
         *this = *this + rhs;
         return *this;
     }
 
-    constexpr complex& operator-=(const complex<T>& rhs) noexcept
+    complex& operator-=(const complex<T>& rhs) noexcept
     {
         *this = *this - rhs;
         return *this;
     }
 
-    constexpr complex& operator*=(const complex<T>& rhs) noexcept
+    complex& operator*=(const complex<T>& rhs) noexcept
     {
         *this = *this * rhs;
         return *this;
     }
 
-    constexpr complex& operator/=(const complex<T>& rhs) noexcept
+    complex& operator/=(const complex<T>& rhs) noexcept
     {
         *this = *this / rhs;
         return *this;
     }
-
-    friend inline complex<T> polar(const T& rho, const T& theta) noexcept;
 };
 
 template <typename T>
-constexpr complex<T> operator+(const complex<T>& lhs, const complex<T>& rhs) noexcept
+complex<T> operator+(const complex<T>& lhs, const complex<T>& rhs) noexcept
 {
     return {lhs.real_ + rhs.real_, lhs.imag_ + rhs.imag_};
 }
 
 template <typename T>
-constexpr complex<T> operator-(const complex<T>& lhs, const complex<T>& rhs) noexcept
+complex<T> operator-(const complex<T>& lhs, const complex<T>& rhs) noexcept
 {
     return {lhs.real_ - rhs.real_, lhs.imag_ - rhs.imag_};
 }
 
 template <typename T>
-constexpr complex<T> operator*(const complex<T>& lhs, const complex<T>& rhs) noexcept
+complex<T> operator*(const complex<T>& lhs, const complex<T>& rhs) noexcept
 {
     return {lhs.real_ * rhs.real_ - lhs.imag_ * rhs.imag_, lhs.imag_ * rhs.real_ + lhs.real_ * rhs.imag_};
 }
 
 template <typename T>
-constexpr complex<T> operator/(const complex<T>& lhs, const complex<T>& rhs) noexcept
+complex<T> operator/(const complex<T>& lhs, const complex<T>& rhs) noexcept
 {
     const T divisor = rhs.real_ * rhs.real_ + rhs.imag_ * rhs.imag_;
     const T real_part = (lhs.real_ * rhs.real_ + lhs.imag_ * rhs.imag_) / divisor;
@@ -102,8 +105,91 @@ inline complex<T> polar(const T& rho, const T& theta) noexcept
 
     return {rho * cos(theta), rho * sin(theta)};
 }
-
+*/
 } // Namespace multiprecision
 } // Namespace boost
+
+namespace std {
+
+template <>
+class complex<boost::multiprecision::cpp_bin_float_50>
+{
+private:
+    using T = boost::multiprecision::cpp_bin_float_50;
+
+    T real_;
+    T imag_;
+
+public:
+    complex() noexcept = default;
+    complex(T real) noexcept : real_ {real}, imag_ {T{0}} {}
+    complex(T real, T imag) noexcept : real_ {real}, imag_ {imag} {}
+    complex& operator=(const complex<T>& rhs) = default;
+
+    T real() const noexcept { return real_; }
+    T imag() const noexcept { return imag_; }
+
+    complex<T> operator+() { return *this; }
+    complex<T> operator-() { return {-real_, -imag_}; }
+
+    complex<T> operator+(const complex<T>& rhs) noexcept
+    {
+        return {real_ + rhs.real_, imag_ + rhs.imag_};
+    }
+
+    complex<T> operator-(const complex<T>& rhs) noexcept
+    {
+        return {real_ - rhs.real_, imag_ - rhs.imag_};
+    }
+
+    complex<T> operator*(const complex<T>& rhs) noexcept
+    {
+        return {real_ * rhs.real_ - imag_ * rhs.imag_, imag_ * rhs.real_ + real_ * rhs.imag_};
+    }
+
+    complex<T> operator/(const complex<T>& rhs) noexcept
+    {
+        const T divisor = rhs.real_ * rhs.real_ + rhs.imag_ * rhs.imag_;
+        const T real_part = (real_ * rhs.real_ + imag_ * rhs.imag_) / divisor;
+        const T imag_part = (imag_ * rhs.real_ - real_ * rhs.imag_) / divisor;
+        return {real_part, imag_part};
+    }
+
+    complex& operator+=(const complex<T>& rhs) noexcept
+    {
+        *this = *this + rhs;
+        return *this;
+    }
+
+    complex& operator-=(const complex<T>& rhs) noexcept
+    {
+        *this = *this - rhs;
+        return *this;
+    }
+
+    complex& operator*=(const complex<T>& rhs) noexcept
+    {
+        *this = *this * rhs;
+        return *this;
+    }
+
+    complex& operator/=(const complex<T>& rhs) noexcept
+    {
+        *this = *this / rhs;
+        return *this;
+    }
+};
+
+inline complex<boost::multiprecision::cpp_bin_float_50> polar(const boost::multiprecision::cpp_bin_float_50& rho, const boost::multiprecision::cpp_bin_float_50& theta) noexcept
+{
+    using std::sin;
+    using std::cos;
+
+    BOOST_MP_ASSERT_MSG(rho >= boost::multiprecision::cpp_bin_float_50{0}, "Rho must be positive");
+
+    return {rho * cos(theta), rho * sin(theta)};
+}
+
+}
 
 #endif //BOOST_MP_COMPLEX_HPP

--- a/include/boost/multiprecision/complex.hpp
+++ b/include/boost/multiprecision/complex.hpp
@@ -30,6 +30,9 @@ public:
     constexpr T real() noexcept { return real_; }
     constexpr T imag() noexcept { return imag_; }
 
+    constexpr complex<T> operator+() { return *this; }
+    constexpr complex<T> operator-() { return {-real_, -imag_}; }
+
     friend constexpr complex<T> operator+(const complex<T>& lhs, const complex<T>& rhs) noexcept;
     friend constexpr complex<T> operator-(const complex<T>& lhs, const complex<T>& rhs) noexcept;
     friend constexpr complex<T> operator*(const complex<T>& lhs, const complex<T>& rhs) noexcept;

--- a/include/boost/multiprecision/complex.hpp
+++ b/include/boost/multiprecision/complex.hpp
@@ -1,0 +1,105 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright 2024 Matt Borland. Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef BOOST_MP_COMPLEX_HPP
+#define BOOST_MP_COMPLEX_HPP
+
+#include <boost/multiprecision/detail/assert.hpp>
+#include <complex>
+#include <cmath>
+
+namespace boost {
+namespace multiprecision {
+
+template <typename T>
+class complex
+{
+private:
+    T real_;
+    T imag_;
+
+public:
+    constexpr complex() noexcept = default;
+    explicit constexpr complex(T real) noexcept : real_ {real}, imag_ {T{0}} {}
+    constexpr complex(T real, T imag) noexcept : real_ {real}, imag_ {imag} {}
+    constexpr complex& operator=(const complex<T>& rhs) = default;
+
+    constexpr T real() noexcept { return real_; }
+    constexpr T imag() noexcept { return imag_; }
+
+    friend constexpr complex<T> operator+(const complex<T>& lhs, const complex<T>& rhs) noexcept;
+    friend constexpr complex<T> operator-(const complex<T>& lhs, const complex<T>& rhs) noexcept;
+    friend constexpr complex<T> operator*(const complex<T>& lhs, const complex<T>& rhs) noexcept;
+    friend constexpr complex<T> operator/(const complex<T>& lhs, const complex<T>& rhs) noexcept;
+
+    constexpr complex& operator+=(const complex<T>& rhs) noexcept
+    {
+        *this = *this + rhs;
+        return *this;
+    }
+
+    constexpr complex& operator-=(const complex<T>& rhs) noexcept
+    {
+        *this = *this - rhs;
+        return *this;
+    }
+
+    constexpr complex& operator*=(const complex<T>& rhs) noexcept
+    {
+        *this = *this * rhs;
+        return *this;
+    }
+
+    constexpr complex& operator/=(const complex<T>& rhs) noexcept
+    {
+        *this = *this / rhs;
+        return *this;
+    }
+
+    friend inline complex<T> polar(const T& rho, const T& theta) noexcept;
+};
+
+template <typename T>
+constexpr complex<T> operator+(const complex<T>& lhs, const complex<T>& rhs) noexcept
+{
+    return {lhs.real_ + rhs.real_, lhs.imag_ + rhs.imag_};
+}
+
+template <typename T>
+constexpr complex<T> operator-(const complex<T>& lhs, const complex<T>& rhs) noexcept
+{
+    return {lhs.real_ - rhs.real_, lhs.imag_ - rhs.imag_};
+}
+
+template <typename T>
+constexpr complex<T> operator*(const complex<T>& lhs, const complex<T>& rhs) noexcept
+{
+    return {lhs.real_ * rhs.real_ - lhs.imag_ * rhs.imag_, lhs.imag_ * rhs.real_ + lhs.real_ * rhs.imag_};
+}
+
+template <typename T>
+constexpr complex<T> operator/(const complex<T>& lhs, const complex<T>& rhs) noexcept
+{
+    const T divisor = rhs.real_ * rhs.real_ + rhs.imag_ * rhs.imag_;
+    const T real_part = (lhs.real_ * rhs.real_ + lhs.imag_ * rhs.imag_) / divisor;
+    const T imag_part = (lhs.imag_ * rhs.real_ - lhs.real_ * rhs.imag_) / divisor;
+    return {real_part, imag_part};
+}
+
+template <typename T>
+inline complex<T> polar(const T& rho, const T& theta) noexcept
+{
+    using std::sin;
+    using std::cos;
+
+    BOOST_MP_ASSERT_MSG(rho >= T{0}, "Rho must be positive");
+
+    return {rho * cos(theta), rho * sin(theta)};
+}
+
+} // Namespace multiprecision
+} // Namespace boost
+
+#endif //BOOST_MP_COMPLEX_HPP

--- a/include/boost/multiprecision/complex.hpp
+++ b/include/boost/multiprecision/complex.hpp
@@ -7,13 +7,14 @@
 #define BOOST_MP_COMPLEX_HPP
 
 #include <boost/multiprecision/detail/assert.hpp>
+#include <boost/multiprecision/traits/is_backend.hpp>
 #include <complex>
 #include <cmath>
 
 namespace boost {
 namespace multiprecision {
 
-template <typename T>
+template <typename T, std::enable_if_t<detail::is_backend<T>::value, bool> = true>
 class complex
 {
 private:
@@ -88,7 +89,7 @@ constexpr complex<T> operator/(const complex<T>& lhs, const complex<T>& rhs) noe
     return {real_part, imag_part};
 }
 
-template <typename T>
+template <typename T, std::enable_if_t<detail::is_backend<T>::value, bool> = true>
 inline complex<T> polar(const T& rho, const T& theta) noexcept
 {
     using std::sin;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,10 +3,7 @@
 # Distributed under the Boost Software License, Version 1.0.
 # See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
 
-include(BoostTestJamfile OPTIONAL RESULT_VARIABLE HAVE_BOOST_TEST)
-
-if(HAVE_BOOST_TEST)
-
-    boost_test_jamfile(FILE Jamfile.v2 LINK_LIBRARIES Boost::multiprecision Boost::assert Boost::config Boost::core Boost::integer Boost::lexical_cast Boost::math Boost::random)
-
-endif()
+file(GLOB SOURCES "*.cpp")
+add_library(boost_mp_tests STATIC ${SOURCES})
+target_compile_features(boost_mp_tests PRIVATE cxx_std_17)
+target_link_libraries(boost_mp_tests PUBLIC Boost::multiprecision Boost::assert Boost::config Boost::core Boost::integer Boost::lexical_cast Boost::math Boost::random)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Copyright 2018, 2019 Peter Dimov
+# Copyright 2024 Matt Borland
+# Distributed under the Boost Software License, Version 1.0.
+# See accompanying file LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt
+
+include(BoostTestJamfile OPTIONAL RESULT_VARIABLE HAVE_BOOST_TEST)
+
+if(HAVE_BOOST_TEST)
+
+    boost_test_jamfile(FILE Jamfile.v2 LINK_LIBRARIES Boost::multiprecision Boost::assert Boost::config Boost::core Boost::integer Boost::lexical_cast Boost::math Boost::random)
+
+endif()

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -223,6 +223,8 @@ test-suite arithmetic_tests :
    [ run test_complex_signed_zero.cpp : : : <define>TEST_CPP_BIN_FLOAT [ requires cxx17_if_constexpr ] : test_complex_signed_zero_cpp_bin_float ]
    [ run test_complex_signed_zero.cpp mpc mpfr gmp : : : <define>TEST_MPC [ requires cxx17_if_constexpr ] [ check-target-builds ../config//has_mpc : : <build>no ] : test_complex_signed_zero_mpc ]
 
+   [ run test_complex_class.cpp ]
+
    [ run test_preserve_source_precision.cpp gmp : : : [ requires cxx17_if_constexpr ] [ check-target-builds ../config//has_gmp : : <build>no ] <define>TEST_MPF : test_preserve_source_precision_gmp ]
    [ run test_preserve_source_precision.cpp gmp mpfr : : : [ requires cxx17_if_constexpr ] [ check-target-builds ../config//has_mpfr : : <build>no ] <define>TEST_MPFR  : test_preserve_source_precision_mpfr ]
    [ run test_preserve_source_precision.cpp gmp mpfr mpc : : : [ requires cxx17_if_constexpr ] [ check-target-builds ../config//has_mpc : : <build>no ] <define>TEST_MPC : test_preserve_source_precision_mpc ]

--- a/test/test_complex_class.cpp
+++ b/test/test_complex_class.cpp
@@ -1,0 +1,29 @@
+///////////////////////////////////////////////////////////////////////////////
+//  Copyright 2024 Matt Borland. Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include <boost/multiprecision/complex.hpp>
+#include <boost/multiprecision/cpp_bin_float.hpp>
+#include <boost/core/lightweight_test.hpp>
+#include <complex>
+#include <cmath>
+
+using namespace boost::multiprecision;
+
+template <typename T>
+void test_construction()
+{
+    using std::complex;
+    using std::polar;
+    using complex_scalar = decltype(polar(T(), T()));
+}
+
+int main()
+{
+    test_construction<float>();
+    test_construction<double>();
+    test_construction<cpp_bin_float_50>();
+
+    return boost::report_errors();
+}

--- a/test/test_complex_class.cpp
+++ b/test/test_complex_class.cpp
@@ -8,6 +8,7 @@
 #include <boost/multiprecision/cpp_dec_float.hpp>
 #include <boost/core/lightweight_test.hpp>
 #include <complex>
+#include <iostream>
 #include <cmath>
 
 using namespace boost::multiprecision;
@@ -18,6 +19,7 @@ void test_construction()
     using std::complex;
     using std::polar;
     using complex_scalar = decltype(polar(T(), T()));
+    std::cerr << typeid(complex_scalar).name() << std::endl;
 
     complex_scalar v {};
     BOOST_TEST_EQ(v.real(), T{0});
@@ -79,27 +81,47 @@ void test_subtraction()
     BOOST_TEST_EQ(res_1.real(), T{-1});
 }
 
+template <typename T>
+void test_multiplication()
+{
+    using std::complex;
+    using std::polar;
+    using complex_scalar = decltype(polar(T(), T()));
+
+    complex_scalar lhs_1 {T{-3}, T{3}};
+    complex_scalar rhs_1 {T{2}, T{2}};
+    complex_scalar res_1 = lhs_1 * rhs_1;
+
+    BOOST_TEST_EQ(res_1.real(), T{-12});
+    BOOST_TEST_EQ(res_1.imag(), T{0});
+}
+
 int main()
 {
     test_construction<float>();
     test_construction<double>();
     test_construction<cpp_bin_float_50>();
-    test_construction<cpp_dec_float_50>();
+    //test_construction<cpp_dec_float_50>();
 
     test_unary_operators<float>();
     test_unary_operators<double>();
     test_unary_operators<cpp_bin_float_50>();
-    test_unary_operators<cpp_dec_float_50>();
+    //test_unary_operators<cpp_dec_float_50>();
 
     test_addition<float>();
     test_addition<double>();
     test_addition<cpp_bin_float_50>();
-    test_addition<cpp_dec_float_50>();
+    //test_addition<cpp_dec_float_50>();
 
     test_subtraction<float>();
     test_subtraction<double>();
     test_subtraction<cpp_bin_float_50>();
-    test_subtraction<cpp_dec_float_50>();
+    //test_subtraction<cpp_dec_float_50>();
+
+    test_multiplication<float>();
+    test_multiplication<double>();
+    test_multiplication<cpp_bin_float_50>();
+    //test_multiplication<cpp_dec_float_50>();
 
     return boost::report_errors();
 }

--- a/test/test_complex_class.cpp
+++ b/test/test_complex_class.cpp
@@ -5,6 +5,7 @@
 
 #include <boost/multiprecision/complex.hpp>
 #include <boost/multiprecision/cpp_bin_float.hpp>
+#include <boost/multiprecision/cpp_dec_float.hpp>
 #include <boost/core/lightweight_test.hpp>
 #include <complex>
 #include <cmath>
@@ -31,11 +32,74 @@ void test_construction()
     BOOST_TEST_EQ(v2.imag(), T{2});
 }
 
+template <typename T>
+void test_unary_operators()
+{
+    using std::complex;
+    using std::polar;
+    using complex_scalar = decltype(polar(T(), T()));
+
+    const complex_scalar val {T{2}, T{-2}};
+    complex_scalar pos_val = +val;
+    BOOST_TEST_EQ(val.real(), pos_val.real());
+    BOOST_TEST_EQ(val.imag(), pos_val.imag());
+
+    complex_scalar neg_val = -val;
+    BOOST_TEST_EQ(neg_val.real(), T{-2});
+    BOOST_TEST_EQ(neg_val.imag(), T{2});
+}
+
+template <typename T>
+void test_addition()
+{
+    using std::complex;
+    using std::polar;
+    using complex_scalar = decltype(polar(T(), T()));
+
+    complex_scalar lhs_1 {T{1}, T{1}};
+    complex_scalar rhs_1 {T{2}, T{2}};
+    complex_scalar res_1 = lhs_1 + rhs_1;
+
+    BOOST_TEST_EQ(res_1.real(), T{3});
+    BOOST_TEST_EQ(res_1.real(), T{3});
+}
+
+template <typename T>
+void test_subtraction()
+{
+    using std::complex;
+    using std::polar;
+    using complex_scalar = decltype(polar(T(), T()));
+
+    complex_scalar lhs_1 {T{1}, T{1}};
+    complex_scalar rhs_1 {T{2}, T{2}};
+    complex_scalar res_1 = lhs_1 - rhs_1;
+
+    BOOST_TEST_EQ(res_1.real(), T{-1});
+    BOOST_TEST_EQ(res_1.real(), T{-1});
+}
+
 int main()
 {
     test_construction<float>();
     test_construction<double>();
     test_construction<cpp_bin_float_50>();
+    test_construction<cpp_dec_float_50>();
+
+    test_unary_operators<float>();
+    test_unary_operators<double>();
+    test_unary_operators<cpp_bin_float_50>();
+    test_unary_operators<cpp_dec_float_50>();
+
+    test_addition<float>();
+    test_addition<double>();
+    test_addition<cpp_bin_float_50>();
+    test_addition<cpp_dec_float_50>();
+
+    test_subtraction<float>();
+    test_subtraction<double>();
+    test_subtraction<cpp_bin_float_50>();
+    test_subtraction<cpp_dec_float_50>();
 
     return boost::report_errors();
 }

--- a/test/test_complex_class.cpp
+++ b/test/test_complex_class.cpp
@@ -17,6 +17,18 @@ void test_construction()
     using std::complex;
     using std::polar;
     using complex_scalar = decltype(polar(T(), T()));
+
+    complex_scalar v {};
+    BOOST_TEST_EQ(v.real(), T{0});
+    BOOST_TEST_EQ(v.imag(), T{0});
+
+    complex_scalar v1 {T{1}};
+    BOOST_TEST_EQ(v1.real(), T{1});
+    BOOST_TEST_EQ(v1.imag(), T{0});
+
+    complex_scalar v2 {T{2}, T{2}};
+    BOOST_TEST_EQ(v2.real(), T{2});
+    BOOST_TEST_EQ(v2.imag(), T{2});
 }
 
 int main()


### PR DESCRIPTION
@NAThompson I started poking around on this after you asked. I found the only real way to have viable overloads for multiprecision types is to inject them into `namespace std`. The STLs use unconstrained templates for their functions unlike `<cmath>` From libc++:

```
template<class _Tp>
inline _LIBCPP_INLINE_VISIBILITY
_Tp
abs(const complex<_Tp>& __c)
{
    return std::hypot(__c.real(), __c.imag());
}
```

I also tried using the derived class (the giant commented out class) like:

```
namespace std {

template <>
class complex<boost::multiprecision::cpp_bin_float_50> : public boost::multiprecision::complex<boost::multiprecision::cpp_bin_float_50> {};
```

I don't think this is explicit illegal since the standard only specifies `T - the type of the real and imaginary parts. The behavior is unspecified (and may fail to compile) if T is not a cv-unqualified standard(until C++23) floating-point type and undefined if T is not NumericType`

CC: @jzmaddock 