### PR TITLE
Correct divide-by-zero in cpp_int modulus operations.

### DIFF
--- a/include/boost/multiprecision/cpp_int/divide.hpp
+++ b/include/boost/multiprecision/cpp_int/divide.hpp
@@ -551,6 +551,10 @@ eval_modulus(
     const cpp_int_backend<MinBits2, MaxBits2, SignType2, Checked2, Allocator2>& a,
     const limb_type                                                             mod)
 {
+
+   if(mod == 0)
+     BOOST_MP_THROW_EXCEPTION(std::overflow_error("Division by zero."));
+
    const std::ptrdiff_t n = static_cast<std::ptrdiff_t>(a.size());
 
    const double_limb_type two_n_mod =
@@ -654,6 +658,42 @@ eval_modulus(
       BOOST_MP_THROW_EXCEPTION(std::overflow_error("Division by zero."));
    *result.limbs() %= *o.limbs();
    result.sign(result.sign());
+}
+
+template <std::size_t MinBits1, std::size_t MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1, class V>
+BOOST_MP_FORCEINLINE BOOST_MP_CXX14_CONSTEXPR typename std::enable_if<
+    is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && std::is_unsigned<V>::value>::type
+eval_modulus(
+    cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result,
+    const cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& a,
+    V o)
+{
+   using local_limb_type = cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::local_limb_type;
+
+   BOOST_IF_CONSTEXPR(std::numeric_limits<V>::digits > MaxBits1)
+   {
+      if (o > (static_cast<V>(1u) << std::numeric_limits<local_limb_type>::digits))
+      {
+         result = a;
+         return;
+      }
+   }
+   if (!o)
+      BOOST_MP_THROW_EXCEPTION(std::overflow_error("Division by zero."));
+   *result.limbs() = *a.limbs() % static_cast<local_limb_type>(o);
+   result.sign(a.sign());
+}
+
+template <std::size_t MinBits1, std::size_t MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1, class V>
+BOOST_MP_FORCEINLINE BOOST_MP_CXX14_CONSTEXPR typename std::enable_if<
+    is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value && std::is_signed<V>::value>::type
+eval_modulus(
+    cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result,
+    const cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& a,
+    V o)
+{
+   using unsigned_type = typename std::make_unsigned<V>::type;
+   eval_modulus(result, a, static_cast<unsigned_type>(std::abs(o)));
 }
 
 }}} // namespace boost::multiprecision::backends

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -1241,6 +1241,7 @@ test-suite misc :
                                     <define>TEST_CPP_DEC_FLOAT 
                                     <define>TEST_CPP_BIN_FLOAT ]
       [ compile git_issue_608.cpp ]
+      [ run git_issue_624.cpp ]
       [ compile git_issue_98.cpp : 
          [ check-target-builds ../config//has_float128 : <define>TEST_FLOAT128 <source>quadmath : ]
          [ check-target-builds ../config//has_gmp : <define>TEST_GMP <source>gmp : ]

--- a/test/git_issue_624.cpp
+++ b/test/git_issue_624.cpp
@@ -1,0 +1,32 @@
+
+#include <iostream>
+#include <boost/multiprecision/cpp_int.hpp>
+#include "test.hpp"
+
+template <class T>
+void test_divide_by_zero()
+{
+    T val = 42;
+
+    BOOST_CHECK_THROW(val % 0, std::overflow_error);
+    BOOST_CHECK_THROW(val % static_cast<T>(0), std::overflow_error);
+    BOOST_CHECK_THROW(val % static_cast<std::uintmax_t>(0), std::overflow_error);
+    BOOST_CHECK_THROW(val % static_cast<std::intmax_t>(0), std::overflow_error);
+
+    val = -val;
+    BOOST_CHECK_THROW(val % 0, std::overflow_error);
+    BOOST_CHECK_THROW(val % static_cast<T>(0), std::overflow_error);
+    BOOST_CHECK_THROW(val % static_cast<std::uintmax_t>(0), std::overflow_error);
+    BOOST_CHECK_THROW(val % static_cast<std::intmax_t>(0), std::overflow_error);
+}
+
+int main()
+{
+    using int64_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<64, 64, boost::multiprecision::signed_magnitude>>;
+
+    test_divide_by_zero<int64_t>();
+    test_divide_by_zero<boost::multiprecision::int128_t>();
+    test_divide_by_zero<boost::multiprecision::int256_t>();
+    test_divide_by_zero<boost::multiprecision::int1024_t>();
+}
+


### PR DESCRIPTION
Also added some more efficient operator overloads for the trivial case. Fixes https://github.com/boostorg/multiprecision/issues/624