### PR TITLE
Ensure checked integers are in a sane state after a throw.

### DIFF
--- a/doc/html/boost_multiprecision/indexes/s01.html
+++ b/doc/html/boost_multiprecision/indexes/s01.html
@@ -25,7 +25,7 @@
 </div>
 <div class="section">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="id1243940"></a>Function Index</h3></div></div></div>
+<a name="id1248604"></a>Function Index</h3></div></div></div>
 <p><a class="link" href="s01.html#idx_id_0">A</a> <a class="link" href="s01.html#idx_id_1">B</a> <a class="link" href="s01.html#idx_id_2">C</a> <a class="link" href="s01.html#idx_id_3">D</a> <a class="link" href="s01.html#idx_id_4">E</a> <a class="link" href="s01.html#idx_id_5">F</a> <a class="link" href="s01.html#idx_id_6">G</a> <a class="link" href="s01.html#idx_id_7">H</a> <a class="link" href="s01.html#idx_id_8">I</a> <a class="link" href="s01.html#idx_id_9">L</a> <a class="link" href="s01.html#idx_id_10">M</a> <a class="link" href="s01.html#idx_id_11">N</a> <a class="link" href="s01.html#idx_id_12">O</a> <a class="link" href="s01.html#idx_id_13">P</a> <a class="link" href="s01.html#idx_id_14">R</a> <a class="link" href="s01.html#idx_id_15">S</a> <a class="link" href="s01.html#idx_id_16">T</a> <a class="link" href="s01.html#idx_id_17">V</a> <a class="link" href="s01.html#idx_id_18">X</a> <a class="link" href="s01.html#idx_id_19">Z</a></p>
 <div class="variablelist"><dl class="variablelist">
 <dt>

--- a/doc/html/boost_multiprecision/indexes/s02.html
+++ b/doc/html/boost_multiprecision/indexes/s02.html
@@ -25,7 +25,7 @@
 </div>
 <div class="section">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="id1251007"></a>Class Index</h3></div></div></div>
+<a name="id1255921"></a>Class Index</h3></div></div></div>
 <p><a class="link" href="s02.html#idx_id_22">C</a> <a class="link" href="s02.html#idx_id_23">D</a> <a class="link" href="s02.html#idx_id_24">E</a> <a class="link" href="s02.html#idx_id_25">F</a> <a class="link" href="s02.html#idx_id_26">G</a> <a class="link" href="s02.html#idx_id_28">I</a> <a class="link" href="s02.html#idx_id_29">L</a> <a class="link" href="s02.html#idx_id_30">M</a> <a class="link" href="s02.html#idx_id_31">N</a> <a class="link" href="s02.html#idx_id_34">R</a> <a class="link" href="s02.html#idx_id_36">T</a></p>
 <div class="variablelist"><dl class="variablelist">
 <dt>

--- a/doc/html/boost_multiprecision/indexes/s03.html
+++ b/doc/html/boost_multiprecision/indexes/s03.html
@@ -25,7 +25,7 @@
 </div>
 <div class="section">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="id1251871"></a>Typedef Index</h3></div></div></div>
+<a name="id1259199"></a>Typedef Index</h3></div></div></div>
 <p></p>
 <div class="variablelist"><dl class="variablelist"></dl></div>
 </div>

--- a/doc/html/boost_multiprecision/indexes/s04.html
+++ b/doc/html/boost_multiprecision/indexes/s04.html
@@ -24,7 +24,7 @@
 </div>
 <div class="section">
 <div class="titlepage"><div><div><h3 class="title">
-<a name="id1251888"></a>Index</h3></div></div></div>
+<a name="id1259200"></a>Index</h3></div></div></div>
 <p><a class="link" href="s04.html#idx_id_60">A</a> <a class="link" href="s04.html#idx_id_61">B</a> <a class="link" href="s04.html#idx_id_62">C</a> <a class="link" href="s04.html#idx_id_63">D</a> <a class="link" href="s04.html#idx_id_64">E</a> <a class="link" href="s04.html#idx_id_65">F</a> <a class="link" href="s04.html#idx_id_66">G</a> <a class="link" href="s04.html#idx_id_67">H</a> <a class="link" href="s04.html#idx_id_68">I</a> <a class="link" href="s04.html#idx_id_69">L</a> <a class="link" href="s04.html#idx_id_70">M</a> <a class="link" href="s04.html#idx_id_71">N</a> <a class="link" href="s04.html#idx_id_72">O</a> <a class="link" href="s04.html#idx_id_73">P</a> <a class="link" href="s04.html#idx_id_74">R</a> <a class="link" href="s04.html#idx_id_75">S</a> <a class="link" href="s04.html#idx_id_76">T</a> <a class="link" href="s04.html#idx_id_77">V</a> <a class="link" href="s04.html#idx_id_78">X</a> <a class="link" href="s04.html#idx_id_79">Z</a></p>
 <div class="variablelist"><dl class="variablelist">
 <dt>

--- a/doc/html/boost_multiprecision/tut/ints/cpp_int.html
+++ b/doc/html/boost_multiprecision/tut/ints/cpp_int.html
@@ -242,6 +242,16 @@
 </tr>
 </tbody>
 </table></div>
+<div class="note"><table border="0" summary="Note">
+<tr>
+<td rowspan="2" align="center" valign="top" width="25"><img alt="[Note]" src="../../../../../../../doc/src/images/note.png"></td>
+<th align="left">Note</th>
+</tr>
+<tr><td align="left" valign="top"><p>
+            When an exception is thrown as a result of using a checked type, then
+            the value of the target operand after the exception is caught is unspecified.
+          </p></td></tr>
+</table></div>
 <p>
           Things you should know when using this type:
         </p>

--- a/doc/tutorial_cpp_int.qbk
+++ b/doc/tutorial_cpp_int.qbk
@@ -107,6 +107,8 @@ result from treating the unsigned type as a 2's complement signed type.]]
 that would result from performing the operation on a 2's complement integer type.]]
 ]
 
+[note When an exception is thrown as a result of using a checked type, then the value of the target operand after the exception is caught is unspecified.]
+
 Things you should know when using this type:
 
 * Default constructed `cpp_int_backend`s have the value zero.

--- a/include/boost/multiprecision/cpp_int.hpp
+++ b/include/boost/multiprecision/cpp_int.hpp
@@ -844,10 +844,17 @@ struct cpp_int_base<MinBits, MinBits, unsigned_magnitude, Checked, void, false>
    BOOST_MP_FORCEINLINE BOOST_MP_CXX14_CONSTEXPR void normalize() noexcept((Checked == unchecked))
    {
       limb_pointer p = limbs();
-      detail::verify_limb_mask(m_limbs == internal_limb_count, p[internal_limb_count - 1], upper_limb_mask, checked_type());
+
+      limb_type c = p[internal_limb_count - 1];
+      bool full_limbs = m_limbs == internal_limb_count;
+
       p[internal_limb_count - 1] &= upper_limb_mask;
       while ((m_limbs - 1) && !p[m_limbs - 1])
          --m_limbs;
+      //
+      // Verification at the end, so that we're in a valid state if we throw:
+      //
+      detail::verify_limb_mask(full_limbs, c, upper_limb_mask, checked_type());
    }
 
    BOOST_MP_FORCEINLINE constexpr cpp_int_base() noexcept
@@ -1264,8 +1271,13 @@ struct cpp_int_base<MinBits, MinBits, unsigned_magnitude, Checked, void, true>
    }
    BOOST_MP_FORCEINLINE BOOST_MP_CXX14_CONSTEXPR void normalize() noexcept((Checked == unchecked))
    {
-      detail::verify_limb_mask(true, m_data, limb_mask, checked_type());
+      local_limb_type c = m_data;
       m_data &= limb_mask;
+      //
+      // Verification has to come afterwards, otherwise we can leave 
+      // ourselves in an invalid state:
+      //
+      detail::verify_limb_mask(true, c, limb_mask, checked_type());
    }
 
    BOOST_MP_FORCEINLINE constexpr cpp_int_base() noexcept : m_data(0) {}

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -1242,6 +1242,7 @@ test-suite misc :
                                     <define>TEST_CPP_BIN_FLOAT ]
       [ compile git_issue_608.cpp ]
       [ run git_issue_624.cpp ]
+      [ run git_issue_626.cpp ]
       [ compile git_issue_98.cpp : 
          [ check-target-builds ../config//has_float128 : <define>TEST_FLOAT128 <source>quadmath : ]
          [ check-target-builds ../config//has_gmp : <define>TEST_GMP <source>gmp : ]

--- a/test/git_issue_624.cpp
+++ b/test/git_issue_624.cpp
@@ -8,29 +8,75 @@
 #include "test.hpp"
 
 template <class T>
+void test_neg_divide_by_zero(std::true_type const&)
+{
+    T val = -42;
+    BOOST_CHECK_THROW(static_cast<T>(val % 0), std::overflow_error);
+    BOOST_CHECK_THROW(static_cast<T>(val % static_cast<T>(0)), std::overflow_error);
+    BOOST_CHECK_THROW(static_cast<T>(val % static_cast<std::uintmax_t>(0)), std::overflow_error);
+    BOOST_CHECK_THROW(static_cast<T>(val % static_cast<std::intmax_t>(0)), std::overflow_error);
+}
+template <class T>
+void test_neg_divide_by_zero(std::false_type const&)
+{
+}
+
+template <class T>
 void test_divide_by_zero()
 {
     T val = 42;
 
-    BOOST_CHECK_THROW(val % 0, std::overflow_error);
-    BOOST_CHECK_THROW(val % static_cast<T>(0), std::overflow_error);
-    BOOST_CHECK_THROW(val % static_cast<std::uintmax_t>(0), std::overflow_error);
-    BOOST_CHECK_THROW(val % static_cast<std::intmax_t>(0), std::overflow_error);
+    BOOST_CHECK_THROW(static_cast<T>(val % 0), std::overflow_error);
+    BOOST_CHECK_THROW(static_cast<T>(val % static_cast<T>(0)), std::overflow_error);
+    BOOST_CHECK_THROW(static_cast<T>(val % static_cast<std::uintmax_t>(0)), std::overflow_error);
+    BOOST_CHECK_THROW(static_cast<T>(val % static_cast<std::intmax_t>(0)), std::overflow_error);
 
-    val = -val;
-    BOOST_CHECK_THROW(val % 0, std::overflow_error);
-    BOOST_CHECK_THROW(val % static_cast<T>(0), std::overflow_error);
-    BOOST_CHECK_THROW(val % static_cast<std::uintmax_t>(0), std::overflow_error);
-    BOOST_CHECK_THROW(val % static_cast<std::intmax_t>(0), std::overflow_error);
+    BOOST_IF_CONSTEXPR((std::numeric_limits<T>::digits < 500) && std::numeric_limits<T>::digits)
+    {
+       val <<= std::numeric_limits<T>::digits - 10;
+    }
+    else
+       val <<= 500;
+
+    BOOST_CHECK_THROW(static_cast<T>(val % 0), std::overflow_error);
+    BOOST_CHECK_THROW(static_cast<T>(val % static_cast<T>(0)), std::overflow_error);
+    BOOST_CHECK_THROW(static_cast<T>(val % static_cast<std::uintmax_t>(0)), std::overflow_error);
+    BOOST_CHECK_THROW(static_cast<T>(val % static_cast<std::intmax_t>(0)), std::overflow_error);
+
+    using tag_type = std::integral_constant<bool, std::numeric_limits<T>::is_signed>;
+
+    test_neg_divide_by_zero<T>(tag_type());
 }
 
 int main()
 {
     using int64_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<64, 64, boost::multiprecision::signed_magnitude>>;
+    using uint64_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<64, 64, boost::multiprecision::unsigned_magnitude>>;
+    using checked_int64_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<64, 64, boost::multiprecision::signed_magnitude, boost::multiprecision::checked>>;
+    using checked_uint64_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<64, 64, boost::multiprecision::unsigned_magnitude, boost::multiprecision::checked>>;
 
     test_divide_by_zero<int64_t>();
     test_divide_by_zero<boost::multiprecision::int128_t>();
     test_divide_by_zero<boost::multiprecision::int256_t>();
     test_divide_by_zero<boost::multiprecision::int1024_t>();
+
+    test_divide_by_zero<uint64_t>();
+    test_divide_by_zero<boost::multiprecision::uint128_t>();
+    test_divide_by_zero<boost::multiprecision::uint256_t>();
+    test_divide_by_zero<boost::multiprecision::uint1024_t>();
+
+    test_divide_by_zero<checked_int64_t>();
+    test_divide_by_zero<boost::multiprecision::checked_int128_t>();
+    test_divide_by_zero<boost::multiprecision::checked_int256_t>();
+    test_divide_by_zero<boost::multiprecision::checked_int1024_t>();
+
+    test_divide_by_zero<uint64_t>();
+    test_divide_by_zero<boost::multiprecision::checked_uint128_t>();
+    test_divide_by_zero<boost::multiprecision::checked_uint256_t>();
+    test_divide_by_zero<boost::multiprecision::checked_uint1024_t>();
+
+    test_divide_by_zero<boost::multiprecision::cpp_int>();
+
+    return boost::report_errors();
 }
 

--- a/test/git_issue_626.cpp
+++ b/test/git_issue_626.cpp
@@ -35,13 +35,13 @@ template <unsigned int N>
 void test_overflow() {
    using uint_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<N, N, boost::multiprecision::unsigned_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
 
-   uint_t value = std::numeric_limits<uint_t>::max();
+   uint_t value = (std::numeric_limits<uint_t>::max)();
    BOOST_CHECK_THROW(value += 1, std::overflow_error);
    //
    // We don't care what the value is, but it must be sane and normalized
    // to be within the range of the type under test:
    //
-   BOOST_CHECK(value <= std::numeric_limits<uint_t>::max());
+   BOOST_CHECK(value <= (std::numeric_limits<uint_t>::max)());
 }
 
 template <unsigned int N>

--- a/test/git_issue_626.cpp
+++ b/test/git_issue_626.cpp
@@ -1,0 +1,75 @@
+///////////////////////////////////////////////////////////////
+//  Copyright 2024 John Maddock. Distributed under the Boost
+//  Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at https://www.boost.org/LICENSE_1_0.txt
+
+#include <iostream>
+#include <boost/multiprecision/cpp_int.hpp>
+#include "test.hpp"
+
+template <class T>
+void test_subtract_underflow()
+{
+    T val = 42;
+
+    int sub = 43;
+
+    BOOST_CHECK_THROW(static_cast<T>(val - sub), std::range_error);
+    BOOST_CHECK_THROW(static_cast<T>(val - static_cast<T>(sub)), std::range_error);
+    BOOST_CHECK_THROW(static_cast<T>(val - static_cast<std::uintmax_t>(sub)), std::range_error);
+    BOOST_CHECK_THROW(static_cast<T>(val - static_cast<std::intmax_t>(sub)), std::range_error);
+
+    BOOST_IF_CONSTEXPR((std::numeric_limits<T>::digits < 500) && std::numeric_limits<T>::digits)
+    {
+       val <<= std::numeric_limits<T>::digits - 10;
+    }
+    else
+       val <<= 500;
+
+    T sub2 = val + 1;
+
+    BOOST_CHECK_THROW(static_cast<T>(val - sub2), std::range_error);
+}
+
+template <unsigned int N>
+void test_overflow() {
+   using uint_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<N, N, boost::multiprecision::unsigned_magnitude, boost::multiprecision::cpp_int_check_type::checked, void>>;
+
+   uint_t value = std::numeric_limits<uint_t>::max();
+   BOOST_CHECK_THROW(value += 1, std::overflow_error);
+   //
+   // We don't care what the value is, but it must be sane and normalized
+   // to be within the range of the type under test:
+   //
+   BOOST_CHECK(value <= std::numeric_limits<uint_t>::max());
+}
+
+template <unsigned int N>
+struct TestOverflow {
+   static void run() {
+      test_overflow<N>();
+      TestOverflow<N + 8>::run();
+   }
+};
+
+template <>
+struct TestOverflow<1032> {
+   static void run() {}
+};
+
+
+
+int main()
+{
+    using checked_uint64_t = boost::multiprecision::number<boost::multiprecision::cpp_int_backend<64, 64, boost::multiprecision::unsigned_magnitude, boost::multiprecision::checked>>;
+
+    test_subtract_underflow<checked_uint64_t>();
+    test_subtract_underflow<boost::multiprecision::checked_uint128_t>();
+    test_subtract_underflow<boost::multiprecision::checked_uint256_t>();
+    test_subtract_underflow<boost::multiprecision::checked_uint1024_t>();
+
+   TestOverflow<8>::run();
+
+    return boost::report_errors();
+}
+


### PR DESCRIPTION
Document that the value of the target operand is unspecified after a throw. Improve testing.
Fixes https://github.com/boostorg/multiprecision/issues/626