### PR TITLE
Make float128 a trivially copyable type

### DIFF
--- a/include/boost/multiprecision/float128.hpp
+++ b/include/boost/multiprecision/float128.hpp
@@ -176,12 +176,9 @@ struct float128_backend
 
  public:
    constexpr   float128_backend() noexcept : m_value(0) {}
-   constexpr   float128_backend(const float128_backend& o) noexcept : m_value(o.m_value) {}
-   BOOST_MP_CXX14_CONSTEXPR float128_backend& operator=(const float128_backend& o) noexcept
-   {
-      m_value = o.m_value;
-      return *this;
-   }
+   constexpr   float128_backend(const float128_backend& o) noexcept = default;
+   BOOST_MP_CXX14_CONSTEXPR float128_backend& operator=(const float128_backend& o) noexcept = default;
+
    template <class T>
    constexpr float128_backend(const T& i, const typename std::enable_if<std::is_convertible<T, float128_type>::value>::type* = nullptr) noexcept(noexcept(std::declval<float128_type&>() = std::declval<const T&>()))
        : m_value(i) {}

--- a/include/boost/multiprecision/number.hpp
+++ b/include/boost/multiprecision/number.hpp
@@ -51,7 +51,7 @@ class number
    static constexpr expression_template_option et = ExpressionTemplates;
 
    BOOST_MP_FORCEINLINE constexpr number() noexcept(noexcept(Backend())) {}
-   BOOST_MP_FORCEINLINE constexpr number(const number& e) noexcept(noexcept(Backend(std::declval<Backend const&>()))) : m_backend(e.m_backend) {}
+   BOOST_MP_FORCEINLINE constexpr number(const number& e) noexcept(noexcept(Backend(std::declval<Backend const&>()))) = default;
    template <class V>
    BOOST_MP_FORCEINLINE BOOST_MP_CXX14_CONSTEXPR number(const V& v, 
       typename std::enable_if<
@@ -372,11 +372,7 @@ class number
    }
 
    BOOST_MP_FORCEINLINE BOOST_MP_CXX14_CONSTEXPR number& operator=(const number& e)
-       noexcept(noexcept(std::declval<Backend&>() = std::declval<Backend const&>()))
-   {
-      m_backend = e.m_backend;
-      return *this;
-   }
+       noexcept(noexcept(std::declval<Backend&>() = std::declval<Backend const&>())) = default;
 
    template <class V>
    BOOST_MP_FORCEINLINE BOOST_MP_CXX14_CONSTEXPR typename std::enable_if<std::is_convertible<V, self_type>::value, number<Backend, ExpressionTemplates>&>::type
@@ -451,14 +447,9 @@ class number
 
    // rvalues:
    BOOST_MP_FORCEINLINE constexpr number(number&& r)
-       noexcept(noexcept(Backend(std::declval<Backend>())))
-       : m_backend(static_cast<Backend&&>(r.m_backend))
-   {}
-   BOOST_MP_FORCEINLINE BOOST_MP_CXX14_CONSTEXPR number& operator=(number&& r) noexcept(noexcept(std::declval<Backend&>() = std::declval<Backend>()))
-   {
-      m_backend = static_cast<Backend&&>(r.m_backend);
-      return *this;
-   }
+       noexcept(noexcept(Backend(std::declval<Backend>()))) = default;
+   BOOST_MP_FORCEINLINE BOOST_MP_CXX14_CONSTEXPR number& operator=(number&& r) noexcept(noexcept(std::declval<Backend&>() = std::declval<Backend>())) = default;
+
    template <class Other, expression_template_option ET>
    BOOST_MP_FORCEINLINE BOOST_MP_CXX14_CONSTEXPR number(number<Other, ET>&& val,
                                                         typename std::enable_if<(std::is_convertible<Other, Backend>::value && !detail::is_restricted_conversion<Other, Backend>::value)>::type* = nullptr)


### PR DESCRIPTION
Closes #635.

Opted to go for trivially copyable and not fully trivial as otherwise we'd have to make the `constexpr float128_backend() noexcept` constructor trivial but I expect we'd like to keep zero initialisation for the data member `m_value` we're wrapping even when using default initialisation. In any case, I never needed the type to be trivial, only trivially copyable, so I'm happy if you are?

Code snippet to print type traits and limits: https://godbolt.org/z/ddsj16M7W. I'm not sure we need everything in there, I just copied the original snippet and added a trivially copyable check, but feel free to edit it to your liking and we can then amend the website. :)