### PR TITLE
Disable check for `__float128` on PGI compiler

### DIFF
--- a/include/boost/multiprecision/detail/number_base.hpp
+++ b/include/boost/multiprecision/detail/number_base.hpp
@@ -206,7 +206,7 @@ struct bits_of
                                               : sizeof(T) * CHAR_BIT - (boost::multiprecision::detail::is_signed<T>::value ? 1 : 0);
 };
 
-#if defined(_GLIBCXX_USE_FLOAT128) && defined(BOOST_GCC) && !defined(__STRICT_ANSI__)
+#if defined(_GLIBCXX_USE_FLOAT128) && defined(BOOST_GCC) && !defined(__STRICT_ANSI__) && !defined(__PGI)
 #define BOOST_MP_BITS_OF_FLOAT128_DEFINED
 template <>
 struct bits_of<float128_type>


### PR DESCRIPTION
Fixes #640 

Per config we should not have 128-bit float on this platform: https://github.com/boostorg/config/blob/19701e05d4832d1e97e06e791f2e4e1c7cba9b13/include/boost/config/compiler/pgi.hpp#L19.

Not sure if anything has happened in the 7 years since that commit was last updated...