### PR TITLE
Suppress warnings caused by -Wimplicit-fallthrough

### DIFF
--- a/include/boost/multiprecision/cpp_bin_float.hpp
+++ b/include/boost/multiprecision/cpp_bin_float.hpp
@@ -1905,7 +1905,7 @@ inline void eval_sqrt(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE
    {
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_nan:
       errno = EDOM;
-      // fallthrough...
+      BOOST_FALLTHROUGH;
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero:
       res = arg;
       return;
@@ -1956,7 +1956,7 @@ inline void eval_floor(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, Min
    {
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_nan:
       errno = EDOM;
-      // fallthrough...
+      BOOST_FALLTHROUGH;
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero:
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_infinity:
       res = arg;
@@ -2006,7 +2006,7 @@ inline void eval_ceil(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE
    {
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_infinity:
       errno = EDOM;
-      // fallthrough...
+      BOOST_FALLTHROUGH;
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero:
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_nan:
       res = arg;

--- a/include/boost/multiprecision/cpp_bin_float.hpp
+++ b/include/boost/multiprecision/cpp_bin_float.hpp
@@ -1905,7 +1905,7 @@ inline void eval_sqrt(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE
    {
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_nan:
       errno = EDOM;
-      BOOST_FALLTHROUGH;
+      BOOST_MP_FALLTHROUGH;
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero:
       res = arg;
       return;
@@ -1956,7 +1956,7 @@ inline void eval_floor(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, Min
    {
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_nan:
       errno = EDOM;
-      BOOST_FALLTHROUGH;
+      BOOST_MP_FALLTHROUGH;
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero:
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_infinity:
       res = arg;
@@ -2006,7 +2006,7 @@ inline void eval_ceil(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE
    {
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_infinity:
       errno = EDOM;
-      BOOST_FALLTHROUGH;
+      BOOST_MP_FALLTHROUGH;
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero:
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_nan:
       res = arg;

--- a/include/boost/multiprecision/detail/standalone_config.hpp
+++ b/include/boost/multiprecision/detail/standalone_config.hpp
@@ -144,5 +144,18 @@ namespace boost { namespace multiprecision {
 #define BOOST_MP_NO_CONSTEXPR_DETECTION
 #endif
 
+#ifdef __has_attribute
+#  if __has_attribute(fallthrough)
+#    define BOOST_MP_FALLTHROUGH [[fallthrough]]
+#  endif
+#endif
+
+#ifndef BOOST_MP_FALLTHROUGH
+#  if __GNUC__ >= 7
+#    define BOOST_MP_FALLTHROUGH __attribute__((fallthrough))
+#  else
+#    define BOOST_MP_FALLTHROUGH ((void)0)
+#  endif
+#endif
 
 #endif // BOOST_MP_STANDALONE_CONFIG_HPP


### PR DESCRIPTION

Example of the warning:

```
restricted/boost/multiprecision/include/boost/multiprecision/cpp_bin_float.hpp:1920:4: error: unannotated fall-through between switch labels [-Werror,-Wimplicit-fallthrough]
 1920 |    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero:
      |    ^
restricted/boost/multiprecision/include/boost/multiprecision/detail/default_ops.hpp:3881:1: note: in instantiation of function template specialization 'boost::multiprecision::backends::eval_floor<64U, boost::multiprecision::backends::digit_base_2, void, short, (short)-16382, (short)16383>' requested here
 3881 | UNARY_OP_FUNCTOR(floor, number_kind_floating_point)
      | ^
restricted/boost/multiprecision/include/boost/multiprecision/detail/default_ops.hpp:3505:7: note: expanded from macro 'UNARY_OP_FUNCTOR'
 3505 |       BOOST_JOIN(eval_, func)(result.backend(), arg.backend());                                                                                                                                                                  \
      |       ^
restricted/boost/config/include/boost/config/helper_macros.hpp:33:26: note: expanded from macro 'BOOST_JOIN'
   33 | #define BOOST_JOIN(X, Y) BOOST_DO_JOIN(X, Y)
      |                          ^
restricted/boost/config/include/boost/config/helper_macros.hpp:34:29: note: expanded from macro 'BOOST_DO_JOIN'
   34 | #define BOOST_DO_JOIN(X, Y) BOOST_DO_JOIN2(X,Y)
      |                             ^
restricted/boost/config/include/boost/config/helper_macros.hpp:35:30: note: expanded from macro 'BOOST_DO_JOIN2'
   35 | #define BOOST_DO_JOIN2(X, Y) X##Y
      |                              ^
<scratch space>:104:1: note: expanded from here
  104 | eval_floor
      | ^
clickhouse/base/base/wide_integer_impl.h:1063:16: note: in instantiation of member function 'wide::integer<128, unsigned int>::_impl::wide_integer_from_builtin' requested here
 1063 |         _impl::wide_integer_from_builtin(*this, rhs);
      |                ^
clickhouse/src/Formats/JSONExtractTree.h:162:59: note: in instantiation of function template specialization 'accurate::convertNumeric<double, wide::integer<128, unsigned int>, false>' requested here
  162 |             else if (!allow_type_conversion || !accurate::convertNumeric<Float64, NumberType, false>(element.getDouble(), value))
      |                                                           ^
clickhouse/src/Formats/JSONExtractTree.h:287:14: note: in instantiation of function template specialization 'DB::tryGetNumericValueFromJSONElement<NYT::NClickHouseServer::TYsonParserAdapter, wide::integer<128, unsigned int>>' requested here
  287 |         if (!tryGetNumericValueFromJSONElement<JSONParser, NumberType>(value, element, insert_settings.convert_bool_to_integer || is_bool_type, insert_settings.allow_type_conversion, error))
      |              ^
clickhouse/src/Formats/JSONExtractTree.h:254:7: note: in instantiation of member function 'DB::NumericNode<NYT::NClickHouseServer::TYsonParserAdapter, wide::integer<128, unsigned int>>::insertResultToColumn' requested here
  254 | class NumericNode : public JSONExtractTreeNode<JSONParser>
      |       ^
/home/khlebnikov/src/ytsaurus/yt/yt/library/clickhouse_functions/ypath.cpp:570:28: note: in instantiation of function template specialization 'DB::buildJSONExtractTree<NYT::NClickHouseServer::TYsonParserAdapter>' requested here
  570 |         auto extractTree = buildJSONExtractTree<TYsonParserAdapter>(returnType, nullptr /*source_for_exception_message*/);
      |                            ^
/home/khlebnikov/src/ytsaurus/yt/yt/library/clickhouse_functions/ypath.cpp:492:7: note: in instantiation of member function 'NYT::NClickHouseServer::TFunctionYPathExtractImpl<true, NYT::NClickHouseServer::TNameYPathExtractStrict>::executeImpl' requested here
  492 | class TFunctionYPathExtractImpl : public IFunction
      |       ^
/home/khlebnikov/src/ytsaurus/yt/yt/library/clickhouse_functions/ypath.cpp:665:13: note: in instantiation of function template specialization 'DB::FunctionFactory::registerFunction<NYT::NClickHouseServer::TFunctionYPathExtractImpl<true, NYT::NClickHouseServer::TNameYPathExtractStrict>>' requested here
  665 |     factory.registerFunction<TFunctionYPathExtractStrict>();
      |             ^
restricted/boost/multiprecision/include/boost/multiprecision/cpp_bin_float.hpp:1920:4: note: insert 'BOOST_FALLTHROUGH;' to silence this warning
 1920 |    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero:
      |    ^
      |    BOOST_FALLTHROUGH; 
restricted/boost/multiprecision/include/boost/multiprecision/cpp_bin_float.hpp:1920:4: note: insert 'break;' to avoid fall-through
 1920 |    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero:
      |    ^
      |    break; 
1 error generated.
Failed

```