### PR TITLE
Bug Fix for 1.88

### DIFF
--- a/include/boost/multiprecision/cpp_bin_float.hpp
+++ b/include/boost/multiprecision/cpp_bin_float.hpp
@@ -1905,7 +1905,7 @@ inline void eval_sqrt(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE
    {
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_nan:
       errno = EDOM;
-      // fallthrough...
+      BOOST_MP_FALLTHROUGH;
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero:
       res = arg;
       return;
@@ -1956,7 +1956,7 @@ inline void eval_floor(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, Min
    {
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_nan:
       errno = EDOM;
-      // fallthrough...
+      BOOST_MP_FALLTHROUGH;
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero:
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_infinity:
       res = arg;
@@ -2006,7 +2006,7 @@ inline void eval_ceil(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE
    {
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_infinity:
       errno = EDOM;
-      // fallthrough...
+      BOOST_MP_FALLTHROUGH;
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_zero:
    case cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_nan:
       res = arg;

--- a/include/boost/multiprecision/detail/standalone_config.hpp
+++ b/include/boost/multiprecision/detail/standalone_config.hpp
@@ -144,5 +144,18 @@ namespace boost { namespace multiprecision {
 #define BOOST_MP_NO_CONSTEXPR_DETECTION
 #endif
 
+#ifdef __has_attribute
+#  if __has_attribute(fallthrough)
+#    define BOOST_MP_FALLTHROUGH [[fallthrough]]
+#  endif
+#endif
+
+#ifndef BOOST_MP_FALLTHROUGH
+#  if __GNUC__ >= 7
+#    define BOOST_MP_FALLTHROUGH __attribute__((fallthrough))
+#  else
+#    define BOOST_MP_FALLTHROUGH ((void)0)
+#  endif
+#endif
 
 #endif // BOOST_MP_STANDALONE_CONFIG_HPP


### PR DESCRIPTION
* Suppress warnings caused by -Wimplicit-fallthrough

* Add and replace definition of BOOST_FALLTHROUGH with MP version

---------