### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/multiprecision.yml
+++ b/.github/workflows/multiprecision.yml
@@ -144,14 +144,14 @@ jobs:
         run: cat bin.v2/config.log
         working-directory: ../boost-root/
   ubuntu-focal:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     defaults:
       run:
         shell: bash
     strategy:
       fail-fast: false
       matrix:
-        compiler: [ g++-10, g++-11, clang++-10, clang++-11 ]
+        compiler: [ g++-13, g++-14, clang++-19, clang++-20 ]
         standard: [ c++14, c++17 ]
         suite: [ github_ci_block_1, github_ci_block_2 ]
     steps:
@@ -175,7 +175,7 @@ jobs:
         if: steps.retry1.outcome=='failure'
         run: sudo apt-add-repository -y "ppa:ubuntu-toolchain-r/test"
       - name: Install packages
-        run: sudo apt install g++-9 g++-10 g++-11 clang-10 clang-11 libgmp-dev libmpfr-dev libtommath-dev libeigen3-dev libmpfi-dev libmpc-dev
+        run: sudo apt install g++-13 g++-14 clang-19 clang-20 libgmp-dev libmpfr-dev libtommath-dev libeigen3-dev libmpfi-dev libmpc-dev
       - name: Checkout main boost
         run: git clone -b develop --depth 1 https://github.com/boostorg/boost.git ../boost-root
       - name: Update tools/boostdep
@@ -205,16 +205,16 @@ jobs:
       - name: b2 config
         run: cat bin.v2/config.log
         working-directory: ../boost-root/
-  ubuntu-focal-slow-tests:
-    runs-on: ubuntu-20.04
+  ubuntu-slow-tests:
+    runs-on: ubuntu-24.04
     defaults:
       run:
         shell: bash
     strategy:
       fail-fast: false
       matrix:
-        compiler: [ g++-10 ]
-        standard: [ c++17, c++2a ]
+        compiler: [ g++-13 ]
+        standard: [ c++17, c++20 ]
         suite: [ specfun_mpfr, specfun_gmp, specfun_cpp_dec_float, specfun_cpp_bin_float, specfun_float128 ]
     steps:
       - uses: actions/checkout@v4
@@ -267,16 +267,16 @@ jobs:
       - name: b2 config
         run: cat bin.v2/config.log
         working-directory: ../boost-root/
-  ubuntu-focal-standalone-tests:
-    runs-on: ubuntu-20.04
+  ubuntu-standalone-tests:
+    runs-on: ubuntu-24.04
     defaults:
       run:
         shell: bash
     strategy:
       fail-fast: false
       matrix:
-        compiler: [ g++-11 ]
-        standard: [ c++14, c++17, c++20 ]
+        compiler: [ g++-13 ]
+        standard: [ c++14, c++17, c++20, c++23 ]
         suite: [ standalone ]
     steps:
       - uses: actions/checkout@v4
@@ -329,16 +329,16 @@ jobs:
       - name: b2 config
         run: cat bin.v2/config.log
         working-directory: ../boost-root/
-  ubuntu-focal-ASAN:
-    runs-on: ubuntu-20.04
+  ubuntu-ASAN:
+    runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash
     strategy:
       fail-fast: false
       matrix:
-        compiler: [ g++-10 ]
-        standard: [ c++17 ]
+        compiler: [ g++13 ]
+        standard: [ c++20 ]
         suite: [ arithmetic_tests, functions_and_limits, conversions, cpp_int_tests, misc ]
     steps:
       - uses: actions/checkout@v4
@@ -391,16 +391,16 @@ jobs:
       - name: b2 config
         run: cat bin.v2/config.log
         working-directory: ../boost-root/
-  ubuntu-focal-UBSAN:
-    runs-on: ubuntu-20.04
+  ubuntu-UBSAN:
+    runs-on: ubuntu-24.04
     defaults:
       run:
         shell: bash
     strategy:
       fail-fast: false
       matrix:
-        compiler: [ g++-10 ]
-        standard: [ c++17 ]
+        compiler: [ g++-13 ]
+        standard: [ c++20 ]
         suite: [ arithmetic_tests, functions_and_limits, misc ]
     steps:
       - uses: actions/checkout@v4
@@ -507,6 +507,49 @@ jobs:
       fail-fast: false
       matrix:
         toolset: [ msvc-14.2 ]
+        standard: [ 14, 17, 20 ]
+        suite: [ github_ci_block_1, github_ci_block_2 ]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: '0'
+      - name: Checkout main boost
+        run: git clone -b develop --depth 1 https://github.com/boostorg/boost.git ../boost-root
+      - name: Update tools/boostdep
+        run: git submodule update --init tools/boostdep
+        working-directory: ../boost-root
+      - name: Copy files
+        run: xcopy /s /e /q %GITHUB_WORKSPACE% libs\multiprecision
+        working-directory: ../boost-root
+      - name: Install deps
+        run: python tools/boostdep/depinst/depinst.py multiprecision
+        working-directory: ../boost-root
+      - name: Bootstrap
+        run: bootstrap
+        working-directory: ../boost-root
+      - name: Generate headers
+        run: b2 headers
+        working-directory: ../boost-root
+      - name: Config Info
+        run: ..\..\..\b2 print_config_info print_math_info %ARGS%
+        working-directory: ../boost-root/libs/config/test
+      - name: Test
+        run: ..\..\..\b2 -j2 --hash %ARGS% define=CI_SUPPRESS_KNOWN_ISSUES ${{ matrix.suite }} define=BOOST_MP_SF_CONCEPT_TESTS
+        working-directory: ../boost-root/libs/multiprecision/test
+      - name: b2 config
+        run: cat bin.v2/config.log
+        working-directory: ../boost-root/
+  windows_msvc_14_3:
+    runs-on: windows-2022
+    defaults:
+      run:
+        shell: cmd
+    env:
+      ARGS: toolset=${{ matrix.toolset }} address-model=64 cxxstd=${{ matrix.standard }}
+    strategy:
+      fail-fast: false
+      matrix:
+        toolset: [ msvc-14.3 ]
         standard: [ 14, 17, 20 ]
         suite: [ github_ci_block_1, github_ci_block_2 ]
     steps:


### PR DESCRIPTION
We got hit with the brownout. I don't see a good way to go wholesale with boost.ci since we have so many test sets we need to cut down. I'll update drone next since the most recent clang on there is 10 and version 20 is on the streets.

CC: @ckormanyos 