### PR TITLE
Uniform logic has or not-has GCD/LCM

### DIFF
--- a/include/boost/multiprecision/cpp_int/misc.hpp
+++ b/include/boost/multiprecision/cpp_int/misc.hpp
@@ -11,15 +11,19 @@
 #ifndef BOOST_MP_CPP_INT_MISC_HPP
 #define BOOST_MP_CPP_INT_MISC_HPP
 
-#include <boost/multiprecision/detail/standalone_config.hpp>
-#include <boost/multiprecision/detail/number_base.hpp>
 #include <boost/multiprecision/cpp_int/cpp_int_config.hpp>
-#include <boost/multiprecision/detail/float128_functions.hpp>
 #include <boost/multiprecision/detail/assert.hpp>
-#include <boost/multiprecision/detail/constexpr.hpp>
 #include <boost/multiprecision/detail/bitscan.hpp> // lsb etc
+#include <boost/multiprecision/detail/constexpr.hpp>
+#include <boost/multiprecision/detail/float128_functions.hpp>
 #include <boost/multiprecision/detail/hash.hpp>
 #include <boost/multiprecision/detail/no_exceptions_support.hpp>
+#include <boost/multiprecision/detail/number_base.hpp>
+#include <boost/multiprecision/detail/standalone_config.hpp>
+
+#ifndef BOOST_MP_STANDALONE
+#include <boost/integer/common_factor_rt.hpp>
+#endif
 
 #ifdef BOOST_MP_MATH_AVAILABLE
 #include <boost/math/special_functions/next.hpp>
@@ -31,6 +35,7 @@
 
 #include <cmath>
 #include <numeric>
+#include <stdexcept>
 #include <type_traits>
 
 #ifdef BOOST_MSVC

--- a/include/boost/multiprecision/cpp_int/misc.hpp
+++ b/include/boost/multiprecision/cpp_int/misc.hpp
@@ -30,9 +30,7 @@
 #endif
 
 #include <cmath>
-#if defined(BOOST_MP_LIB_GCD_LCM_AVAILABLE)
 #include <numeric>
-#endif
 #include <type_traits>
 
 #ifdef BOOST_MSVC

--- a/include/boost/multiprecision/cpp_int/misc.hpp
+++ b/include/boost/multiprecision/cpp_int/misc.hpp
@@ -20,17 +20,19 @@
 #include <boost/multiprecision/detail/bitscan.hpp> // lsb etc
 #include <boost/multiprecision/detail/hash.hpp>
 #include <boost/multiprecision/detail/no_exceptions_support.hpp>
-#include <numeric> // std::gcd
+
+#ifdef BOOST_MP_MATH_AVAILABLE
+#include <boost/math/special_functions/next.hpp>
+#endif
+
 #include <type_traits>
 #include <stdexcept>
 #include <cmath>
 
-#ifndef BOOST_MP_STANDALONE
-#include <boost/integer/common_factor_rt.hpp>
-#endif
+#if (defined(__cpp_lib_gcd_lcm) && (__cpp_lib_gcd_lcm >= 201606L)) && (!defined(BOOST_HAS_INT128) || !defined(__STRICT_ANSI__))
+#include <numeric> // std::gcd
 
-#ifdef BOOST_MP_MATH_AVAILABLE
-#include <boost/math/special_functions/next.hpp>
+#define BOOST_MP_STD_GCD_AVAILABLE
 #endif
 
 #ifdef BOOST_MSVC
@@ -517,7 +519,7 @@ BOOST_MP_FORCEINLINE BOOST_MP_CXX14_CONSTEXPR limb_type eval_gcd(limb_type u, li
    // boundary cases
    if (!u || !v)
       return u | v;
-#if (defined(__cpp_lib_gcd_lcm) && (__cpp_lib_gcd_lcm >= 201606L))
+#if defined(BOOST_MP_STD_GCD_AVAILABLE)
    return std::gcd(u, v);
 #else
    std::size_t shift = boost::multiprecision::detail::find_lsb(u | v);
@@ -535,7 +537,7 @@ BOOST_MP_FORCEINLINE BOOST_MP_CXX14_CONSTEXPR limb_type eval_gcd(limb_type u, li
 
 inline BOOST_MP_CXX14_CONSTEXPR double_limb_type eval_gcd(double_limb_type u, double_limb_type v)
 {
-#if (defined(__cpp_lib_gcd_lcm) && (__cpp_lib_gcd_lcm >= 201606L)) && (!defined(BOOST_HAS_INT128) || !defined(__STRICT_ANSI__))
+#if defined(BOOST_MP_STD_GCD_AVAILABLE)
    return std::gcd(u, v);
 #else
    if (u == 0)
@@ -1420,21 +1422,6 @@ inline BOOST_MP_CXX14_CONSTEXPR std::size_t hash_value(const cpp_int_backend<Min
 
 namespace detail {
 
-#ifndef BOOST_MP_STANDALONE
-template <typename T>
-inline BOOST_CXX14_CONSTEXPR T constexpr_gcd(T a, T b) noexcept
-{
-   return boost::integer::gcd(a, b);
-}
-
-template <typename T>
-inline BOOST_CXX14_CONSTEXPR T constexpr_lcm(T a, T b) noexcept
-{
-   return boost::integer::lcm(a, b);
-}
-
-#else
-
 template <typename T>
 inline BOOST_CXX14_CONSTEXPR T constexpr_gcd(T a, T b) noexcept
 {
@@ -1447,8 +1434,6 @@ inline BOOST_CXX14_CONSTEXPR T constexpr_lcm(T a, T b) noexcept
    const T ab_gcd = boost::multiprecision::detail::constexpr_gcd(a, b);
    return (a * b) / ab_gcd;
 }
-
-#endif // BOOST_MP_STANDALONE
 
 }
 

--- a/include/boost/multiprecision/cpp_int/misc.hpp
+++ b/include/boost/multiprecision/cpp_int/misc.hpp
@@ -11,31 +11,28 @@
 #ifndef BOOST_MP_CPP_INT_MISC_HPP
 #define BOOST_MP_CPP_INT_MISC_HPP
 
+#include <boost/multiprecision/detail/standalone_config.hpp>
+#include <boost/multiprecision/detail/number_base.hpp>
 #include <boost/multiprecision/cpp_int/cpp_int_config.hpp>
-#include <boost/multiprecision/detail/assert.hpp>
-#include <boost/multiprecision/detail/bitscan.hpp> // lsb etc
-#include <boost/multiprecision/detail/constexpr.hpp>
 #include <boost/multiprecision/detail/float128_functions.hpp>
+#include <boost/multiprecision/detail/assert.hpp>
+#include <boost/multiprecision/detail/constexpr.hpp>
+#include <boost/multiprecision/detail/bitscan.hpp> // lsb etc
 #include <boost/multiprecision/detail/hash.hpp>
 #include <boost/multiprecision/detail/no_exceptions_support.hpp>
-#include <boost/multiprecision/detail/number_base.hpp>
-#include <boost/multiprecision/detail/standalone_config.hpp>
-
-#ifndef BOOST_MP_STANDALONE
-#include <boost/integer/common_factor_rt.hpp>
-#endif
 
 #ifdef BOOST_MP_MATH_AVAILABLE
 #include <boost/math/special_functions/next.hpp>
 #endif
 
-#if (defined(__cpp_lib_gcd_lcm) && (__cpp_lib_gcd_lcm >= 201606L)) && (!defined(BOOST_HAS_INT128) || !defined(__STRICT_ANSI__))
+#if ((defined(__cpp_lib_gcd_lcm) && (__cpp_lib_gcd_lcm >= 201606L)) && (!defined(BOOST_HAS_INT128) || !defined(__STRICT_ANSI__)))
 #define BOOST_MP_LIB_GCD_LCM_AVAILABLE
 #endif
 
 #include <cmath>
+#if defined(BOOST_MP_LIB_GCD_LCM_AVAILABLE)
 #include <numeric>
-#include <stdexcept>
+#endif
 #include <type_traits>
 
 #ifdef BOOST_MSVC

--- a/include/boost/multiprecision/cpp_int/misc.hpp
+++ b/include/boost/multiprecision/cpp_int/misc.hpp
@@ -514,7 +514,10 @@ eval_integer_modulus(const cpp_int_backend<MinBits1, MaxBits1, SignType1, Checke
    return eval_integer_modulus(x, boost::multiprecision::detail::unsigned_abs(val));
 }
 
-BOOST_MP_FORCEINLINE BOOST_MP_CXX14_CONSTEXPR limb_type eval_gcd(limb_type u, limb_type v)
+namespace detail {
+
+template <class AnyIntegralType>
+inline BOOST_MP_CXX14_CONSTEXPR AnyIntegralType eval_gcd_impl(AnyIntegralType u, AnyIntegralType v)
 {
    // boundary cases
    if (!u || !v)
@@ -535,25 +538,17 @@ BOOST_MP_FORCEINLINE BOOST_MP_CXX14_CONSTEXPR limb_type eval_gcd(limb_type u, li
 #endif
 }
 
-inline BOOST_MP_CXX14_CONSTEXPR double_limb_type eval_gcd(double_limb_type u, double_limb_type v)
-{
-#if defined(BOOST_MP_STD_GCD_AVAILABLE)
-   return std::gcd(u, v);
-#else
-   if (u == 0)
-      return v;
+}
 
-   std::size_t shift = boost::multiprecision::detail::find_lsb(u | v);
-   u >>= boost::multiprecision::detail::find_lsb(u);
-   do
-   {
-      v >>= boost::multiprecision::detail::find_lsb(v);
-      if (u > v)
-         std_constexpr::swap(u, v);
-      v -= u;
-   } while (v);
-   return u << shift;
-#endif
+template <class IntegralType>
+BOOST_MP_FORCEINLINE BOOST_MP_CXX14_CONSTEXPR typename std::enable_if<std::is_integral<IntegralType>::value && !std::is_same<IntegralType, double_limb_type>::value, IntegralType>::type eval_gcd(IntegralType u, IntegralType v)
+{
+   return detail::eval_gcd_impl(u, v);
+}
+
+BOOST_MP_FORCEINLINE BOOST_MP_CXX14_CONSTEXPR double_limb_type eval_gcd(double_limb_type u, double_limb_type v)
+{
+   return detail::eval_gcd_impl(u, v);
 }
 
 template <std::size_t MinBits1, std::size_t MaxBits1, cpp_integer_type SignType1, cpp_int_check_type Checked1, class Allocator1>


### PR DESCRIPTION
In [cpp_int/misc.hpp](https://github.com/boostorg/multiprecision/blob/ce635570f667266864c0f18d1d9accd7b591486a/include/boost/multiprecision/cpp_int/misc.hpp#L29), there is a dependency on `Boost.Integer`.

But if and only if it is not standalone. Yet the standalone version does not need integer. I was wondering if it is possible to remove this dependency in the non-standalone mode? Thereby the behavior would be the same for `constexpr_gcd` in standalone as well as non-standalone mode.

Why? I got some pesky warnings coming in from `Boost.Integer`.

The header has also been refactored to treat having/not-having `std::gcd` in a uniform fashion with respect to compiler switches. The compiler switches were not the same in the two places earlier.

Cc: @jzmaddock and @mborland