### PR TITLE
A few header-only warns and warns in CI

### DIFF
--- a/include/boost/multiprecision/cpp_bin_float.hpp
+++ b/include/boost/multiprecision/cpp_bin_float.hpp
@@ -1634,7 +1634,7 @@ inline void convert_to_unsigned_int(I* res, const cpp_bin_float<Digits, DigitBas
    }
    else if (shift < 0)
    {
-      if (cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - shift <= digits)
+      if ((shift_type)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - shift <= (shift_type)digits)
       {
          // We have more bits in ulong_long_type than the float, so it's OK to left shift:
          eval_convert_to(res, man);
@@ -1644,7 +1644,7 @@ inline void convert_to_unsigned_int(I* res, const cpp_bin_float<Digits, DigitBas
       *res = max_val;
       return;
    }
-   eval_right_shift(man, shift);
+   eval_right_shift(man, static_cast<unsigned>(shift));
    eval_convert_to(res, man);
 }
 
@@ -2035,18 +2035,18 @@ inline void eval_ceil(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE
    }
    bool fractional = (shift_type)eval_lsb(arg.bits()) < shift;
    res             = arg;
-   eval_right_shift(res.bits(), shift);
+   eval_right_shift(res.bits(), static_cast<unsigned>(shift));
    if (fractional && !res.sign())
    {
       eval_increment(res.bits());
-      if ((std::ptrdiff_t)eval_msb(res.bits()) != cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - 1 - shift)
+      if ((std::ptrdiff_t)eval_msb(res.bits()) != (std::ptrdiff_t)(static_cast<shift_type>(cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count) - 1 - shift))
       {
          // Must have extended result by one bit in the increment:
          --shift;
          ++res.exponent();
       }
    }
-   eval_left_shift(res.bits(), shift);
+   eval_left_shift(res.bits(), static_cast<unsigned>(shift));
 }
 
 template <unsigned D1, backends::digit_base_type B1, class A1, class E1, E1 M1, E1 M2>

--- a/include/boost/multiprecision/cpp_dec_float.hpp
+++ b/include/boost/multiprecision/cpp_dec_float.hpp
@@ -1749,14 +1749,14 @@ unsigned long long cpp_dec_float<Digits10, ExponentType, Allocator>::extract_uns
    else
    {
       // Extract the data into an unsigned long long value.
-      val = static_cast<unsigned long long>(xn.data[0]);
+      val = static_cast<unsigned long long>(xn.data[std::size_t { 0U }]);
 
       const std::int32_t imax = (std::min)(static_cast<std::int32_t>(static_cast<std::int32_t>(xn.exp) / cpp_dec_float_elem_digits10), static_cast<std::int32_t>(cpp_dec_float_elem_number - static_cast<std::int32_t>(1)));
 
       for (std::int32_t i = static_cast<std::int32_t>(1); i <= imax; i++)
       {
          val *= static_cast<unsigned long long>(cpp_dec_float_elem_mask);
-         val += static_cast<unsigned long long>(xn.data[i]);
+         val += static_cast<unsigned long long>(xn.data[static_cast<std::size_t>(i)]);
       }
    }
 

--- a/include/boost/multiprecision/cpp_int/bitwise.hpp
+++ b/include/boost/multiprecision/cpp_int/bitwise.hpp
@@ -700,7 +700,7 @@ BOOST_MP_FORCEINLINE BOOST_MP_CXX14_CONSTEXPR typename std::enable_if<is_trivial
 eval_left_shift(cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>& result, T s) noexcept((is_non_throwing_cpp_int<cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1> >::value))
 {
    is_valid_bitwise_op(result, typename cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::checked_type());
-   *result.limbs() = detail::checked_left_shift(*result.limbs(), s, typename cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::checked_type());
+   *result.limbs() = detail::checked_left_shift(*result.limbs(), static_cast<unsigned long long>(s), typename cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::checked_type());
    result.normalize();
 }
 
@@ -710,7 +710,7 @@ eval_right_shift(cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Alloca
 {
    // Nothing to check here... just make sure we don't invoke undefined behavior:
    is_valid_bitwise_op(result, typename cpp_int_backend<MinBits1, MaxBits1, SignType1, Checked1, Allocator1>::checked_type());
-   *result.limbs() = (static_cast<unsigned>(s) >= sizeof(*result.limbs()) * CHAR_BIT) ? 0 : (result.sign() ? ((--*result.limbs()) >> s) + 1 : *result.limbs() >> s);
+   *result.limbs() = (static_cast<std::size_t>(s) >= static_cast<std::size_t>(sizeof(*result.limbs()) * CHAR_BIT)) ? 0 : (result.sign() ? ((--*result.limbs()) >> s) + 1 : *result.limbs() >> s);
    if (result.sign() && (*result.limbs() == 0))
       result = static_cast<signed_limb_type>(-1);
 }

--- a/test/math/high_prec/test_gamma.hpp
+++ b/test/math/high_prec/test_gamma.hpp
@@ -26,8 +26,7 @@
 template <class Real, class T>
 void do_test_gamma(const T& data, const char* type_name, const char* test_name)
 {
-   typedef typename T::value_type row_type;
-   typedef Real                   value_type;
+   typedef Real value_type;
 
    typedef value_type (*pg)(value_type);
 #if defined(BOOST_MATH_NO_DEDUCED_FUNCTION_POINTERS)

--- a/test/math/setup.hpp
+++ b/test/math/setup.hpp
@@ -142,7 +142,7 @@ typedef boost::multiprecision::float128 test_type_1;
 #ifndef BOOST_MATH_TEST_TYPE
 #define BOOST_TEST_MAIN
 #include <boost/test/unit_test.hpp>
-#include <boost/test/floating_point_comparison.hpp>
+#include <boost/test/tools/floating_point_comparison.hpp>
 #endif
 
 #define ALL_TESTS      \


### PR DESCRIPTION
In this PR, we have found a few remaining warnings `-Wconversion` and `-Wsign-conversion` in the code and cleaned these up.

There was also a deprecated test header being used in the setup of the specfun tests. This has been corrected and the output logs of the specfun tests are expected to be much cleaner.
