### PR TITLE
Handle issue652 with upper-bound check

### DIFF
--- a/include/boost/multiprecision/cpp_bin_float.hpp
+++ b/include/boost/multiprecision/cpp_bin_float.hpp
@@ -1631,13 +1631,9 @@ inline void convert_to_unsigned_int(I* res, const cpp_bin_float<Digits, DigitBas
 
    if (arg.sign())
    {
-      #ifdef BOOST_HAS_INT128
-      using local_signed_type = std::conditional_t<std::is_same<I, unsigned __int128>::value, signed __int128, std::make_signed_t<I>>;
-      #else
-      using local_signed_type = std::make_signed_t<I>;
-      #endif
+      using si_type = typename boost::multiprecision::detail::make_signed<I>::type;
 
-      local_signed_type val;
+      si_type val;
 
       convert_to_signed_int(&val, arg);
 

--- a/include/boost/multiprecision/cpp_bin_float.hpp
+++ b/include/boost/multiprecision/cpp_bin_float.hpp
@@ -1631,7 +1631,11 @@ inline void convert_to_unsigned_int(I* res, const cpp_bin_float<Digits, DigitBas
 
    if (arg.sign())
    {
+      #ifdef BOOST_HAS_INT128
+      using local_signed_type = std::conditional_t<std::is_same<I, unsigned __int128>::value, signed __int128, std::make_signed_t<I>>;
+      #else
       using local_signed_type = std::make_signed_t<I>;
+      #endif
 
       local_signed_type val;
 

--- a/include/boost/multiprecision/cpp_bin_float.hpp
+++ b/include/boost/multiprecision/cpp_bin_float.hpp
@@ -1629,7 +1629,19 @@ inline void convert_to_unsigned_int(I* res, const cpp_bin_float<Digits, DigitBas
 
    const shift_type shift = (shift_type)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - 1 - arg.exponent();
 
-   if (shift > (shift_type)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - 1)
+   if (arg.sign())
+   {
+      using local_signed_type = std::make_signed_t<I>;
+
+      local_signed_type val;
+
+      convert_to_signed_int(&val, arg);
+
+      *res = static_cast<I>(val);
+
+      return;
+   }
+   else if (shift > (shift_type)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - 1)
    {
       *res = 0;
       return;

--- a/include/boost/multiprecision/cpp_bin_float.hpp
+++ b/include/boost/multiprecision/cpp_bin_float.hpp
@@ -1626,10 +1626,17 @@ inline void convert_to_unsigned_int(I* res, const cpp_bin_float<Digits, DigitBas
    }
    typename cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::rep_type                                                                                                                                                              man(arg.bits());
    using shift_type = typename std::conditional<sizeof(typename cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_type) < sizeof(int), int, typename cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::exponent_type>::type;
-   shift_type                                                                                                                                                                                                                                        shift = (shift_type)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - 1 - arg.exponent();
+
+   const shift_type shift = (shift_type)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - 1 - arg.exponent();
+
    if (shift > (shift_type)cpp_bin_float<Digits, DigitBase, Allocator, Exponent, MinE, MaxE>::bit_count - 1)
    {
       *res = 0;
+      return;
+   }
+   else if (arg.compare(max_val) >= 0)
+   {
+      *res = max_val;
       return;
    }
    else if (shift < 0)

--- a/include/boost/multiprecision/cpp_bin_float.hpp
+++ b/include/boost/multiprecision/cpp_bin_float.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////
-//  Copyright 2013 - 2022 John Maddock.
-//  Copyright 2022 Christopher Kormanyos.
+//  Copyright 2013 - 2025 John Maddock.
+//  Copyright 2022 - 2025 Christopher Kormanyos.
 //  Distributed under the Boost Software License,
 //  Version 1.0. (See accompanying file LICENSE_1_0.txt
 //  or copy at https://www.boost.org/LICENSE_1_0.txt)

--- a/include/boost/multiprecision/cpp_dec_float.hpp
+++ b/include/boost/multiprecision/cpp_dec_float.hpp
@@ -1713,7 +1713,7 @@ long long cpp_dec_float<Digits10, ExponentType, Allocator>::extract_signed_long_
       // See https://svn.boost.org/trac/boost/ticket/9740.
       //
       long long sval = static_cast<long long>(val - 1);
-      sval                       = -sval;
+      sval           = -sval;
       --sval;
       return sval;
    }

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -1244,7 +1244,8 @@ test-suite misc :
       [ run git_issue_624.cpp ]
       [ run git_issue_626.cpp ]
       [ run git_issue_636.cpp : : : [ check-target-builds ../config//has_float128 : <source>quadmath : <build>no ] ]
-      [ compile git_issue_98.cpp : 
+      [ run git_issue_652.cpp ]
+      [ compile git_issue_98.cpp :
          [ check-target-builds ../config//has_float128 : <define>TEST_FLOAT128 <source>quadmath : ]
          [ check-target-builds ../config//has_gmp : <define>TEST_GMP <source>gmp : ]
          [ check-target-builds ../config//has_mpfr : <define>TEST_MPFR <source>gmp <source>mpfr : ]

--- a/test/git_issue_652.cpp
+++ b/test/git_issue_652.cpp
@@ -58,10 +58,10 @@ auto test_max_convert() -> void
 
 namespace detail {
 
-template<typename FloatType>
-auto test_convert_negs_to_ull_impl(std::vector<unsigned long long>& ull_ctrls) -> void
+template<typename FloatType, typename LongIshType>
+auto test_convert_neg_to_ll_types_impl(std::vector<LongIshType>& ll_ctrls) -> void
 {
-  ull_ctrls.clear();
+  ll_ctrls.clear();
 
   using float_type = FloatType;
 
@@ -72,51 +72,139 @@ auto test_convert_negs_to_ull_impl(std::vector<unsigned long long>& ull_ctrls) -
   const float_array_type factors =
   {
     float_type { -ldexp(float_type { 1 }, -28) },
-    float_type { -1.0E-9 },
-    float_type { -0.999 },
+    float_type { "-1.0E-9" },
+    float_type { "-0.999" },
     float_type { -1 },
-    float_type { -1.011 },
-    float_type { -2.022 },
-    float_type { -3.033 },
-    float_type { -4.044 },
-    float_type { -5.055 }
+    float_type { "-1.011" },
+    float_type { "-2.022" },
+    float_type { "-3.033" },
+    float_type { "-4.044" },
+    float_type { "-5.055" }
   };
-
-  using ull_array_type = std::array<unsigned long long, std::tuple_size<float_array_type>::value>;
 
   for(std::size_t i = std::size_t { UINT8_C(0) }; i < factors.size(); ++i)
   {
     static_cast<void>(i);
 
     using float_type = FloatType;
+    using long_type = LongIshType;
 
     const float_type
       flt_val
       {
-        static_cast<float_type>((std::numeric_limits<unsigned long long>::max)()) * factors[i]
+        static_cast<float_type>((std::numeric_limits<long_type>::max)()) * factors[i]
       };
 
-    const unsigned long long conversion_result { static_cast<unsigned long long>(flt_val) };
+    const long_type conversion_result { static_cast<long_type>(flt_val) };
 
-    ull_ctrls.push_back(conversion_result);
+    ll_ctrls.push_back(conversion_result);
+  }
+}
+
+template<typename FloatType, typename LongIshType>
+auto test_convert_pos_to_ll_types_impl(std::vector<LongIshType>& ll_ctrls) -> void
+{
+  ll_ctrls.clear();
+
+  using float_type = FloatType;
+
+  using std::ldexp;
+
+  using float_array_type = std::array<float_type, std::size_t { UINT8_C(9) }>;
+
+  const float_array_type factors =
+  {
+    float_type { +ldexp(float_type { 1 }, -28) },
+    float_type { "+1.0E-9" },
+    float_type { "+0.999" },
+    float_type { -1 },
+    float_type { "+1.011" },
+    float_type { "+2.022" },
+    float_type { "+3.033" },
+    float_type { "+4.044" },
+    float_type { "+5.055" }
+  };
+
+  for(std::size_t i = std::size_t { UINT8_C(0) }; i < factors.size(); ++i)
+  {
+    static_cast<void>(i);
+
+    using float_type = FloatType;
+    using long_type = LongIshType;
+
+    const float_type
+      flt_val
+      {
+        static_cast<float_type>((std::numeric_limits<long_type>::max)()) * factors[i]
+      };
+
+    const long_type conversion_result { static_cast<long_type>(flt_val) };
+
+    ll_ctrls.push_back(conversion_result);
   }
 }
 
 } // namespace detail
 
-auto test_convert_negs_to_ull() -> void
+auto test_convert_pos_to_ll_types() -> void
 {
   std::vector<unsigned long long> ull_ctrls_dec;
   std::vector<unsigned long long> ull_ctrls_bin;
 
-  detail::test_convert_negs_to_ull_impl<::boost::multiprecision::cpp_dec_float_50>(ull_ctrls_dec);
-  detail::test_convert_negs_to_ull_impl<::boost::multiprecision::cpp_bin_float_50>(ull_ctrls_bin);
+  std::vector<signed long long> sll_ctrls_dec;
+  std::vector<signed long long> sll_ctrls_bin;
+
+  detail::test_convert_pos_to_ll_types_impl<::boost::multiprecision::cpp_dec_float_50, unsigned long long>(ull_ctrls_dec);
+  detail::test_convert_pos_to_ll_types_impl<::boost::multiprecision::cpp_bin_float_50, unsigned long long>(ull_ctrls_bin);
+
+  detail::test_convert_pos_to_ll_types_impl<::boost::multiprecision::cpp_dec_float_50, signed long long>(sll_ctrls_dec);
+  detail::test_convert_pos_to_ll_types_impl<::boost::multiprecision::cpp_bin_float_50, signed long long>(sll_ctrls_bin);
 
   BOOST_TEST(ull_ctrls_dec.size() == ull_ctrls_bin.size());
+  BOOST_TEST(!ull_ctrls_dec.empty());
 
   for(std::size_t i { std::size_t { UINT8_C(0) } }; i < ull_ctrls_dec.size(); ++i)
   {
     BOOST_TEST(ull_ctrls_dec[i] == ull_ctrls_bin[i]);
+  }
+
+  BOOST_TEST(sll_ctrls_dec.size() == sll_ctrls_bin.size());
+  BOOST_TEST(!sll_ctrls_dec.empty());
+
+  for(std::size_t i { std::size_t { UINT8_C(0) } }; i < sll_ctrls_dec.size(); ++i)
+  {
+    BOOST_TEST(sll_ctrls_dec[i] == sll_ctrls_bin[i]);
+  }
+}
+
+auto test_convert_neg_to_ll_types() -> void
+{
+  std::vector<unsigned long long> ull_ctrls_dec;
+  std::vector<unsigned long long> ull_ctrls_bin;
+
+  std::vector<signed long long> sll_ctrls_dec;
+  std::vector<signed long long> sll_ctrls_bin;
+
+  detail::test_convert_neg_to_ll_types_impl<::boost::multiprecision::cpp_dec_float_50, unsigned long long>(ull_ctrls_dec);
+  detail::test_convert_neg_to_ll_types_impl<::boost::multiprecision::cpp_bin_float_50, unsigned long long>(ull_ctrls_bin);
+
+  detail::test_convert_neg_to_ll_types_impl<::boost::multiprecision::cpp_dec_float_50, signed long long>(sll_ctrls_dec);
+  detail::test_convert_neg_to_ll_types_impl<::boost::multiprecision::cpp_bin_float_50, signed long long>(sll_ctrls_bin);
+
+  BOOST_TEST(ull_ctrls_dec.size() == ull_ctrls_bin.size());
+  BOOST_TEST(!ull_ctrls_dec.empty());
+
+  for(std::size_t i { std::size_t { UINT8_C(0) } }; i < ull_ctrls_dec.size(); ++i)
+  {
+    BOOST_TEST(ull_ctrls_dec[i] == ull_ctrls_bin[i]);
+  }
+
+  BOOST_TEST(sll_ctrls_dec.size() == sll_ctrls_bin.size());
+  BOOST_TEST(!sll_ctrls_dec.empty());
+
+  for(std::size_t i { std::size_t { UINT8_C(0) } }; i < sll_ctrls_dec.size(); ++i)
+  {
+    BOOST_TEST(sll_ctrls_dec[i] == sll_ctrls_bin[i]);
   }
 }
 
@@ -128,7 +216,12 @@ auto main() -> int
 
   local::test_max_convert<::boost::multiprecision::cpp_bin_float_50, unsigned long long>();
 
-  local::test_convert_negs_to_ull();
+  local::test_max_convert<::boost::multiprecision::cpp_dec_float_50, signed long long>();
+
+  local::test_max_convert<::boost::multiprecision::cpp_bin_float_50, signed long long>();
+
+  local::test_convert_neg_to_ll_types();
+  local::test_convert_pos_to_ll_types();
 
   return boost::report_errors();
 }

--- a/test/git_issue_652.cpp
+++ b/test/git_issue_652.cpp
@@ -1,0 +1,67 @@
+// Copyright 2025 Christopher Kormanyos
+// Distributed under the Boost Software License, Version 1.0.
+// https://www.boost.org/LICENSE_1_0.txt
+
+#include <boost/core/lightweight_test.hpp>
+#include <boost/multiprecision/cpp_bin_float.hpp>
+#include <boost/multiprecision/cpp_dec_float.hpp>
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+namespace local {
+
+template<typename FloatType, typename LongIshType>
+auto test_max_convert() -> void
+{
+  using float_type = FloatType;
+
+  using float_array_type = std::array<float_type, std::size_t { UINT8_C(6) }>;
+
+  const float_array_type factors =
+  {
+    float_type { "0.999" },
+    float_type { "1.011" },
+    float_type { "2.022" },
+    float_type { "3.033" },
+    float_type { "4.044" },
+    float_type { "5.055" }
+  };
+
+  for(std::size_t i = std::size_t { UINT8_C(0) }; i < std::tuple_size<float_array_type>::value; ++i)
+  {
+    static_cast<void>(i);
+
+    using long_type = LongIshType;
+
+    const float_type
+      flt_more_than_max_of_built_in_integral
+      {
+        float_type { (std::numeric_limits<long_type>::max)() } * factors[i]
+      };
+
+    const long_type conversion_result { static_cast<long_type>(flt_more_than_max_of_built_in_integral) };
+
+    if(i == std::size_t { UINT8_C(0) })
+    {
+      BOOST_TEST(conversion_result < (std::numeric_limits<long_type>::max)());
+    }
+    else
+    {
+      BOOST_TEST(conversion_result == (std::numeric_limits<long_type>::max)());
+    }
+  }
+}
+
+} // namespace local
+
+auto main() -> int
+{
+  local::test_max_convert<::boost::multiprecision::cpp_dec_float_50, unsigned long long>();
+
+  local::test_max_convert<::boost::multiprecision::cpp_bin_float_50, unsigned long long>();
+
+  return boost::report_errors();
+}

--- a/test/git_issue_652.cpp
+++ b/test/git_issue_652.cpp
@@ -18,11 +18,12 @@ auto test_max_convert() -> void
 {
   using float_type = FloatType;
 
-  using float_array_type = std::array<float_type, std::size_t { UINT8_C(6) }>;
+  using float_array_type = std::array<float_type, std::size_t { UINT8_C(7) }>;
 
   const float_array_type factors =
   {
     float_type { "0.999" },
+    float_type { 1 },
     float_type { "1.011" },
     float_type { "2.022" },
     float_type { "3.033" },
@@ -37,12 +38,12 @@ auto test_max_convert() -> void
     using long_type = LongIshType;
 
     const float_type
-      flt_more_than_max_of_built_in_integral
+      flt_val
       {
         float_type { (std::numeric_limits<long_type>::max)() } * factors[i]
       };
 
-    const long_type conversion_result { static_cast<long_type>(flt_more_than_max_of_built_in_integral) };
+    const long_type conversion_result { static_cast<long_type>(flt_val) };
 
     if(i == std::size_t { UINT8_C(0) })
     {
@@ -55,6 +56,70 @@ auto test_max_convert() -> void
   }
 }
 
+namespace detail {
+
+template<typename FloatType>
+auto test_convert_negs_to_ull_impl(std::vector<unsigned long long>& ull_ctrls) -> void
+{
+  ull_ctrls.clear();
+
+  using float_type = FloatType;
+
+  using std::ldexp;
+
+  using float_array_type = std::array<float_type, std::size_t { UINT8_C(9) }>;
+
+  const float_array_type factors =
+  {
+    float_type { -ldexp(float_type { 1 }, -28) },
+    float_type { -1.0E-9 },
+    float_type { -0.999 },
+    float_type { -1 },
+    float_type { -1.011 },
+    float_type { -2.022 },
+    float_type { -3.033 },
+    float_type { -4.044 },
+    float_type { -5.055 }
+  };
+
+  using ull_array_type = std::array<unsigned long long, std::tuple_size<float_array_type>::value>;
+
+  for(std::size_t i = std::size_t { UINT8_C(0) }; i < factors.size(); ++i)
+  {
+    static_cast<void>(i);
+
+    using float_type = FloatType;
+
+    const float_type
+      flt_val
+      {
+        static_cast<float_type>((std::numeric_limits<unsigned long long>::max)()) * factors[i]
+      };
+
+    const unsigned long long conversion_result { static_cast<unsigned long long>(flt_val) };
+
+    ull_ctrls.push_back(conversion_result);
+  }
+}
+
+} // namespace detail
+
+auto test_convert_negs_to_ull() -> void
+{
+  std::vector<unsigned long long> ull_ctrls_dec;
+  std::vector<unsigned long long> ull_ctrls_bin;
+
+  detail::test_convert_negs_to_ull_impl<::boost::multiprecision::cpp_dec_float_50>(ull_ctrls_dec);
+  detail::test_convert_negs_to_ull_impl<::boost::multiprecision::cpp_bin_float_50>(ull_ctrls_bin);
+
+  BOOST_TEST(ull_ctrls_dec.size() == ull_ctrls_bin.size());
+
+  for(std::size_t i { std::size_t { UINT8_C(0) } }; i < ull_ctrls_dec.size(); ++i)
+  {
+    BOOST_TEST(ull_ctrls_dec[i] == ull_ctrls_bin[i]);
+  }
+}
+
 } // namespace local
 
 auto main() -> int
@@ -62,6 +127,8 @@ auto main() -> int
   local::test_max_convert<::boost::multiprecision::cpp_dec_float_50, unsigned long long>();
 
   local::test_max_convert<::boost::multiprecision::cpp_bin_float_50, unsigned long long>();
+
+  local::test_convert_negs_to_ull();
 
   return boost::report_errors();
 }


### PR DESCRIPTION
This is intended to repair #652, which I believe is an actual bug. The upper-bound check was missing on the unsigned version of the conversion routine (it was already present for the signed case).
