### PR TITLE
Trivial doc spell correction of word fulfills

### DIFF
--- a/doc/reference_cpp_bin_float.qbk
+++ b/doc/reference_cpp_bin_float.qbk
@@ -32,7 +32,7 @@
 
    }} // namespaces
 
-Class template `cpp_bin_float` fulfils all of the requirements for a [link boost_multiprecision.ref.backendconc Backend] type.
+Class template `cpp_bin_float` fulfills all of the requirements for a [link boost_multiprecision.ref.backendconc Backend] type.
 Its members and non-member functions are deliberately not documented: these are considered implementation details that are subject
 to change.
 

--- a/doc/reference_cpp_dec_float.qbk
+++ b/doc/reference_cpp_dec_float.qbk
@@ -20,7 +20,7 @@
 
    }} // namespaces
 
-Class template `cpp_dec_float` fulfils all of the requirements for a [link boost_multiprecision.ref.backendconc Backend] type.
+Class template `cpp_dec_float` fulfills all of the requirements for a [link boost_multiprecision.ref.backendconc Backend] type.
 Its members and non-member functions are deliberately not documented: these are considered implementation details that are subject
 to change.
 

--- a/doc/reference_cpp_int.qbk
+++ b/doc/reference_cpp_int.qbk
@@ -65,7 +65,7 @@
 
    }} // namespaces
 
-Class template `cpp_int_backend` fulfils all of the requirements for a [link boost_multiprecision.ref.backendconc Backend] type.
+Class template `cpp_int_backend` fulfills all of the requirements for a [link boost_multiprecision.ref.backendconc Backend] type.
 Its members and non-member functions are deliberately not documented: these are considered implementation details that are subject
 to change.
 

--- a/doc/reference_gmp_float.qbk
+++ b/doc/reference_gmp_float.qbk
@@ -23,7 +23,7 @@
 
    }} // namespaces
 
-Class template `gmp_float` fulfils all of the requirements for a [link boost_multiprecision.ref.backendconc Backend] type.
+Class template `gmp_float` fulfills all of the requirements for a [link boost_multiprecision.ref.backendconc Backend] type.
 Its members and non-member functions are deliberately not documented: these are considered implementation details that are subject
 to change.
 

--- a/doc/reference_gmp_int.qbk
+++ b/doc/reference_gmp_int.qbk
@@ -18,7 +18,7 @@
 
    }} // namespaces
 
-Class template `gmp_int` fulfils all of the requirements for a [link boost_multiprecision.ref.backendconc Backend] type.
+Class template `gmp_int` fulfills all of the requirements for a [link boost_multiprecision.ref.backendconc Backend] type.
 Its members and non-member functions are deliberately not documented: these are considered implementation details that are subject
 to change.
 

--- a/doc/reference_mpfr_float.qbk
+++ b/doc/reference_mpfr_float.qbk
@@ -23,7 +23,7 @@
 
    }} // namespaces
 
-Class template `mpfr_float_backend` fulfils all of the requirements for a [link boost_multiprecision.ref.backendconc Backend] type.
+Class template `mpfr_float_backend` fulfills all of the requirements for a [link boost_multiprecision.ref.backendconc Backend] type.
 Its members and non-member functions are deliberately not documented: these are considered implementation details that are subject
 to change.
 

--- a/doc/reference_tom_int.qbk
+++ b/doc/reference_tom_int.qbk
@@ -18,7 +18,7 @@
 
    }} // namespaces
 
-Class template `tommath_int` fulfils all of the requirements for a [link boost_multiprecision.ref.backendconc Backend] type.
+Class template `tommath_int` fulfills all of the requirements for a [link boost_multiprecision.ref.backendconc Backend] type.
 Its members and non-member functions are deliberately not documented: these are considered implementation details that are subject
 to change.
 


### PR DESCRIPTION
This PR is a trivial spelling correction of the work _fulfills_ in parts of the documentation.