### PR TITLE
Suppress spurious array bound warning from gcc.

### DIFF
--- a/include/boost/multiprecision/cpp_int/bitwise.hpp
+++ b/include/boost/multiprecision/cpp_int/bitwise.hpp
@@ -563,7 +563,11 @@ inline BOOST_MP_CXX14_CONSTEXPR void right_shift_limb(Int& result, double_limb_t
       pr[i] = pr[i + offset];
    result.resize(rs, rs);
 }
-
+// see discussion at https://github.com/boostorg/multiprecision/issues/686 for logic in disabling this.
+#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ >= 12)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
 template <class Int>
 inline BOOST_MP_CXX14_CONSTEXPR void right_shift_generic(Int& result, double_limb_type s)
 {
@@ -598,6 +602,9 @@ inline BOOST_MP_CXX14_CONSTEXPR void right_shift_generic(Int& result, double_lim
    pr[i] = pr[i + offset] >> shift;
    result.resize(rs, rs);
 }
+#if defined(__GNUC__) && !defined(__clang__) && (__GNUC__ >= 12)
+#pragma GCC diagnostic pop
+#endif
 
 template <std::size_t MinBits1, std::size_t MaxBits1, cpp_int_check_type Checked1, class Allocator1>
 inline BOOST_MP_CXX14_CONSTEXPR typename std::enable_if<!is_trivial_cpp_int<cpp_int_backend<MinBits1, MaxBits1, unsigned_magnitude, Checked1, Allocator1> >::value>::type


### PR DESCRIPTION
Fixes: https://github.com/boostorg/multiprecision/issues/686