### PR TITLE
Fix issue with temporaries when compiling constexpr expression templates with clang

### DIFF
--- a/include/boost/multiprecision/detail/number_base.hpp
+++ b/include/boost/multiprecision/detail/number_base.hpp
@@ -457,7 +457,7 @@ struct expression_storage_base<T, true>
 };
 
 template <class T>
-struct expression_storage : public expression_storage_base<T, boost::multiprecision::detail::is_arithmetic<T>::value>
+struct expression_storage : public expression_storage_base<T, boost::multiprecision::detail::is_arithmetic<T>::value || std::is_empty<T>::value>
 {};
 
 template <class T>

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -1062,6 +1062,7 @@ test-suite misc :
       [ run constexpr_test_cpp_int_5.cpp : : : [ requires cxx14_constexpr cxx17_if_constexpr ] [ check-target-builds ../config//has_is_constant_evaluated : : <build>no ] ]
       [ run constexpr_test_cpp_int_6.cpp : : : [ requires cxx14_constexpr cxx17_if_constexpr ] [ check-target-builds ../config//has_is_constant_evaluated : "<toolset>msvc:<cxxflags>-constexpr:steps10000000" <toolset>clang:<cxxflags>-fconstexpr-steps=268435456 : <build>no ] [ check-target-builds ../config//has_constexpr_limits : <cxxflags>-fconstexpr-ops-limit=268435456 ] ]
       [ run constexpr_test_cpp_int_7.cpp : : : [ requires cxx14_constexpr cxx17_if_constexpr ] [ check-target-builds ../config//has_is_constant_evaluated : "<toolset>msvc:<cxxflags>-constexpr:steps10000000" <toolset>clang:<cxxflags>-fconstexpr-steps=268435456 : <build>no ] ]
+      [ run constexpr_test_cpp_int_8.cpp : : : [ requires cxx14_constexpr cxx17_if_constexpr ] [ check-target-builds ../config//has_is_constant_evaluated : : <build>no ] ]
 
       [ compile test_nothrow_cpp_int.cpp ]
       [ compile test_nothrow_cpp_rational.cpp ]

--- a/test/constexpr_test_cpp_int_8.cpp
+++ b/test/constexpr_test_cpp_int_8.cpp
@@ -11,7 +11,6 @@
 
 int main()
 {
-   // ensure that 
    namespace mp = boost::multiprecision;
 
    using int512_et_off = mp::number<mp::cpp_int_backend<

--- a/test/constexpr_test_cpp_int_8.cpp
+++ b/test/constexpr_test_cpp_int_8.cpp
@@ -1,0 +1,38 @@
+//  (C) Copyright Marco Ribeiro 2026.
+//  Use, modification and distribution are subject to the
+//  Boost Software License, Version 1.0. (See accompanying file
+//  LICENSE_1_0.txt or copy at http://www.boost.org/LICENSE_1_0.txt)
+
+#include "constexpr_arithmetric_test.hpp"
+#include "boost/multiprecision/cpp_int.hpp"
+#include "test.hpp"
+
+#if !defined(BOOST_MP_NO_CONSTEXPR_DETECTION) && !defined(DISABLE_TESTS)
+
+int main()
+{
+   // ensure that 
+   namespace mp = boost::multiprecision;
+
+   using int512_et_off = mp::number<mp::cpp_int_backend<
+      512, 512, mp::signed_magnitude, mp::unchecked, void
+   >, mp::et_off>;
+
+   using int512_et_on = mp::number<mp::cpp_int_backend<
+      512, 512, mp::signed_magnitude, mp::unchecked, void
+   >, mp::et_on>;
+
+   static_assert(mp::abs(int512_et_off(-12345)) == 12345);
+   static_assert(mp::conj(int512_et_off(100)) == 100);
+   static_assert(mp::proj(int512_et_off(100)) == 100);
+   static_assert(mp::powm(int512_et_off(-5), 2, 7) == 4);
+
+   static_assert(mp::abs(int512_et_on(-12345)) == 12345);
+   static_assert(mp::conj(int512_et_on(100)) == 100);
+   static_assert(mp::proj(int512_et_on(100)) == 100);
+   static_assert(mp::powm(int512_et_on(-5), 2, 7) == 4);
+}
+#else
+int main() {}
+#endif
+


### PR DESCRIPTION
Fixed the issue discussed [here](https://github.com/boostorg/multiprecision/pull/654#discussion_r3062377794). Currently, clang is unable to compile constexpr `cpp_int`s with expression templates enabled due to the tags being stored as reference inside the expressions. This PR adds a simple fix that prefer copying values to the expression when their type is an empty struct, which is the case for all functions used on expressions.

Error reproduction on compiler explorer: https://godbolt.org/z/fn69aGsWs